### PR TITLE
Add lint script and CLAUDE.md for autonomous workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,5 +19,6 @@ jobs:
           node-version: ${{ matrix.node-version }}
           cache: npm
       - run: npm ci
+      - run: npm run lint
       - run: npm run build
       - run: npm test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,5 @@ jobs:
           node-version: ${{ matrix.node-version }}
           cache: npm
       - run: npm ci
-      - run: npm run lint
       - run: npm run build
       - run: npm test

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,6 +33,6 @@ npm test        # vitest run
 
 ## Agent workflow
 - Always work on a branch. Never push directly to main.
-- Create PRs targeting main. CI must pass (lint + build + test on Node 20 and 22).
+- Create PRs targeting main. CI must pass (build + test on Node 20 and 22). `npm run build` runs `tsc` and fails on type errors.
 - Keep changes focused — one feature or fix per PR.
-- Run `npm test` locally before pushing.
+- Run `npm run lint` (fast no-emit type-check) and `npm test` locally before pushing.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 # substack-mcp
 
-MCP server for Substack — read posts, manage drafts, create notes. No publish or delete by design.
+MCP server for Substack — read posts, manage drafts, create notes. Cannot publish or delete posts by design; notes (short-form) publish immediately since Substack has no note-draft state.
 
 ## Architecture
 - `src/index.ts` — MCP server bootstrap and entry point
@@ -12,8 +12,9 @@ MCP server for Substack — read posts, manage drafts, create notes. No publish 
 - `src/__tests__/` — Vitest tests for client, errors, and markdown conversion
 
 ## Key constraints
-- Read and draft operations only — no publish or delete capabilities by design
-- Uses `connect.sid` session cookie for auth (not `substack.sid` on custom domains)
+- Posts are read/draft only — no publish or delete capabilities by design
+- Notes publish immediately via `create_note` / `create_note_with_link` — Substack has no note-draft state, so there is no preview step
+- Auth sends both `connect.sid` and `substack.sid` cookies set to the same session token (custom domains use `connect.sid`, substack.com uses `substack.sid`)
 - Markdown must be converted to ProseMirror format for Substack's editor
 
 ## Development

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,37 @@
+# substack-mcp
+
+MCP server for Substack — read posts, manage drafts, create notes. No publish or delete by design.
+
+## Architecture
+- `src/index.ts` — MCP server bootstrap and entry point
+- `src/server.ts` — Tool registration, request handlers, Zod schema generation
+- `src/api/client.ts` — HTTP client for Substack API (session cookie auth)
+- `src/api/types.ts` — TypeScript interfaces for API responses
+- `src/utils/errors.ts` — Error handling utilities
+- `src/utils/markdown-to-prosemirror.ts` — Markdown to ProseMirror AST converter (Substack editor format)
+- `src/__tests__/` — Vitest tests for client, errors, and markdown conversion
+
+## Key constraints
+- Read and draft operations only — no publish or delete capabilities by design
+- Uses `connect.sid` session cookie for auth (not `substack.sid` on custom domains)
+- Markdown must be converted to ProseMirror format for Substack's editor
+
+## Development
+```bash
+npm ci
+npm run lint    # tsc --noEmit (type-check)
+npm run build   # tsc (outputs to dist/)
+npm test        # vitest run
+```
+
+## Testing
+3 test suites:
+- `client.test.ts` — API client auth validation
+- `errors.test.ts` — Error handling and wrapping
+- `markdown-to-prosemirror.test.ts` — Markdown to ProseMirror AST conversion
+
+## Agent workflow
+- Always work on a branch. Never push directly to main.
+- Create PRs targeting main. CI must pass (lint + build + test on Node 20 and 22).
+- Keep changes focused — one feature or fix per PR.
+- Run `npm test` locally before pushing.

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   },
   "scripts": {
     "build": "tsc",
+    "lint": "tsc --noEmit",
     "test": "vitest run",
     "start": "node dist/index.js",
     "dev": "tsx src/index.ts"


### PR DESCRIPTION
## Summary
- Adds `lint` script (`tsc --noEmit`) for fast local type-checking (CI's `build` step already runs `tsc` with emit, so no separate lint step is needed in CI)
- Creates CLAUDE.md with architecture docs and agent contribution rules

Part of autonomous repo setup.

## Test plan
- [ ] CI passes (build + test) on Node 20 and 22
- [ ] `npm run lint` succeeds locally
- [ ] CLAUDE.md renders correctly