### PR TITLE
Add MCP tool annotations; make the safety banner honest about Notes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,6 +5,7 @@ MCP server for Substack — read posts, manage drafts, create notes. Cannot publ
 ## Architecture
 - `src/index.ts` — MCP server bootstrap and entry point
 - `src/server.ts` — Tool registration, request handlers, Zod schema generation
+- `src/annotations.ts` — Tool side-effect classification (read / additive-write / publish) → MCP annotations
 - `src/api/client.ts` — HTTP client for Substack API (session cookie auth)
 - `src/api/types.ts` — TypeScript interfaces for API responses
 - `src/utils/errors.ts` — Error handling utilities
@@ -26,10 +27,11 @@ npm test        # vitest run
 ```
 
 ## Testing
-3 test suites:
+4 test suites:
 - `client.test.ts` — API client auth validation
 - `errors.test.ts` — Error handling and wrapping
 - `markdown-to-prosemirror.test.ts` — Markdown to ProseMirror AST conversion
+- `annotations.test.ts` — Annotation mapping + completeness (every registered tool classified)
 
 ## Agent workflow
 - Always work on a branch. Never push directly to main.

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # substack-mcp
 
-An MCP server for Substack. Read your publication data and manage drafts from your AI agent. No publish or delete by design.
+An MCP server for Substack. Read your publication data and manage drafts from your AI agent. Long-form posts are draft-only by design — no publish, no delete. Short-form Notes publish immediately.
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg?style=flat-square)](LICENSE)
 [![Language: TypeScript](https://img.shields.io/badge/TypeScript-3178c6?style=flat-square&logo=typescript&logoColor=white)](https://www.typescriptlang.org/)
@@ -19,7 +19,7 @@ An MCP server for Substack. Read your publication data and manage drafts from yo
 
 An MCP server for Substack that lets AI assistants read your publication data and manage drafts. The draft list shown in the demo above is sample data, not real account values.
 
-**Safe by design:** This server can create and edit drafts but cannot publish or delete posts. You always review and publish manually through Substack's editor.
+**Safe by design — with one loud exception:** This server cannot publish or delete long-form posts. Post tools create and edit drafts only; you review and publish manually through Substack's editor. The exception is Substack **Notes**: `create_note` and `create_note_with_link` publish short-form Notes immediately, because Notes have no draft state on Substack. Treat the Note tools as public-publish actions — there is no preview step and no undo from this server.
 
 <a href="https://glama.ai/mcp/servers/conorbronsdon/substack-mcp">
   <img width="380" height="200" src="https://glama.ai/mcp/servers/conorbronsdon/substack-mcp/badge" alt="substack-mcp MCP server" />
@@ -35,6 +35,8 @@ Built and maintained by [Conor Bronsdon](https://github.com/conorbronsdon) for t
 
 ## Tools
 
+Every tool declares MCP [tool annotations](https://modelcontextprotocol.io/docs/concepts/tools#tool-annotations): reads carry `readOnlyHint: true`, draft/upload writes carry `readOnlyHint: false`, and the Note tools additionally carry `openWorldHint: true` so clients don't treat an immediate public publish as a low-stakes write.
+
 ### Read
 
 | Tool | Description |
@@ -46,19 +48,26 @@ Built and maintained by [Conor Bronsdon](https://github.com/conorbronsdon) for t
 | `get_draft` | Get full content of a draft by ID |
 | `get_post_comments` | Get comments on a published post |
 
-### Write
+### Write (drafts and uploads — nothing goes public)
 
 | Tool | Description |
 |------|-------------|
 | `create_draft` | Create a new draft from markdown |
 | `update_draft` | Update an existing draft (unpublished only) |
 | `upload_image` | Upload an image to Substack's CDN |
-| `create_note` | Publish a Substack Note (short-form, publishes immediately) |
-| `create_note_with_link` | Publish a Note with a link card attachment |
+
+### Publish (Notes — public immediately)
+
+| Tool | Description |
+|------|-------------|
+| `create_note` | Publish a Substack Note (short-form, **publishes immediately**) |
+| `create_note_with_link` | Publish a Note with a link card attachment (**publishes immediately**) |
+
+Notes have no draft state on Substack, so there is no draft-first option for these two tools.
 
 ### Intentionally excluded
 
-- **Publish posts** — Publishing long-form posts should be a deliberate human action
+- **Publish posts** — Publishing long-form posts should be a deliberate human action (Notes are the documented exception above)
 - **Delete** — Too destructive for an AI tool
 - **Schedule** — Use Substack's editor for scheduling
 
@@ -160,7 +169,7 @@ npm start
 
 ## Contributing
 
-Issues and pull requests are welcome. Because this server uses Substack's unofficial API, the most useful contributions are fixes when an endpoint changes. If a tool stops working, open an issue with the tool name and the error. The safe-by-design boundary stays: no publish, no delete, no schedule.
+Issues and pull requests are welcome. Because this server uses Substack's unofficial API, the most useful contributions are fixes when an endpoint changes. If a tool stops working, open an issue with the tool name and the error. The safe-by-design boundary stays: no publish, no delete, no schedule for long-form posts. Notes publish immediately by design and must keep saying so loudly in their descriptions.
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@conorbronsdon/substack-mcp",
-  "version": "0.2.2",
-  "description": "MCP server for Substack — read posts, manage drafts. No publish or delete by design.",
+  "version": "0.3.0",
+  "description": "MCP server for Substack — read posts, manage drafts, publish Notes. Long-form posts are draft-only by design (no publish, no delete); Notes publish immediately.",
   "type": "module",
   "bin": {
     "substack-mcp": "./dist/index.js"

--- a/server.json
+++ b/server.json
@@ -2,17 +2,17 @@
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.conorbronsdon/substack-mcp",
   "title": "Substack MCP Server",
-  "description": "MCP server for Substack — read posts, manage drafts, upload images. Safe by design: cannot publish or delete. Uses unofficial Substack API.",
+  "description": "MCP server for Substack — read posts, manage drafts, upload images, publish Notes. Long-form posts are draft-only (no publish or delete); Notes publish immediately. Uses unofficial Substack API.",
   "repository": {
     "url": "https://github.com/conorbronsdon/substack-mcp",
     "source": "github"
   },
-  "version": "0.2.2",
+  "version": "0.3.0",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "@conorbronsdon/substack-mcp",
-      "version": "0.2.2",
+      "version": "0.3.0",
       "runtimeHint": "npx",
       "transport": {
         "type": "stdio"

--- a/src/__tests__/annotations.test.ts
+++ b/src/__tests__/annotations.test.ts
@@ -1,0 +1,116 @@
+import { describe, it, expect } from "vitest";
+import { buildAnnotations, TOOL_KINDS, type ToolName } from "../annotations.js";
+import { createServer } from "../server.js";
+import type { SubstackClient } from "../api/client.js";
+
+// The server only touches the client inside tool handlers, which these tests
+// never invoke — a bare object is enough to register everything.
+const server = createServer({} as SubstackClient);
+
+interface RegisteredToolShape {
+  description?: string;
+  annotations?: Record<string, unknown>;
+}
+
+// SDK-private registry; the McpServer API has no public tool introspection.
+const registered = (
+  server as unknown as { _registeredTools: Record<string, RegisteredToolShape> }
+)._registeredTools;
+
+const READ_TOOLS: ToolName[] = [
+  "get_subscriber_count",
+  "list_published_posts",
+  "list_drafts",
+  "get_post",
+  "get_draft",
+  "get_post_comments",
+];
+
+const ADDITIVE_WRITE_TOOLS: ToolName[] = [
+  "create_draft",
+  "update_draft",
+  "upload_image",
+];
+
+const PUBLISH_TOOLS: ToolName[] = ["create_note", "create_note_with_link"];
+
+describe("buildAnnotations mapping", () => {
+  it("read -> { readOnlyHint: true } and nothing else", () => {
+    const a = buildAnnotations("get_post");
+    expect(a).toEqual({ readOnlyHint: true });
+  });
+
+  it("additive write -> { readOnlyHint: false } with no destructive or open-world hint", () => {
+    const a = buildAnnotations("create_draft");
+    expect(a).toEqual({ readOnlyHint: false });
+    expect(a.destructiveHint).toBeUndefined();
+    expect(a.openWorldHint).toBeUndefined();
+  });
+
+  it("publish (Notes) -> { readOnlyHint: false, openWorldHint: true }", () => {
+    const a = buildAnnotations("create_note");
+    expect(a).toEqual({ readOnlyHint: false, openWorldHint: true });
+  });
+});
+
+describe("tool annotation classifications", () => {
+  it("completeness: registered tools and the classification registry match exactly", () => {
+    // Every registered tool must be classified, and every classified tool
+    // must exist — new tools cannot slip through unannotated, and stale
+    // registry entries cannot linger.
+    expect(Object.keys(registered).sort()).toEqual(
+      Object.keys(TOOL_KINDS).sort(),
+    );
+  });
+
+  it("every registered tool carries the annotations its classification dictates", () => {
+    for (const name of Object.keys(TOOL_KINDS) as ToolName[]) {
+      expect(
+        registered[name].annotations,
+        `${name} annotations should match buildAnnotations`,
+      ).toEqual(buildAnnotations(name));
+    }
+  });
+
+  it("read tools are readOnlyHint:true", () => {
+    for (const name of READ_TOOLS) {
+      expect(buildAnnotations(name).readOnlyHint, name).toBe(true);
+    }
+  });
+
+  it("additive writes are readOnlyHint:false with no destructive or open-world hint", () => {
+    for (const name of ADDITIVE_WRITE_TOOLS) {
+      const a = buildAnnotations(name);
+      expect(a.readOnlyHint, name).toBe(false);
+      expect(a.destructiveHint, name).toBeUndefined();
+      expect(a.openWorldHint, name).toBeUndefined();
+    }
+  });
+
+  it("Note tools (immediate public publish) carry openWorldHint:true", () => {
+    for (const name of PUBLISH_TOOLS) {
+      const a = buildAnnotations(name);
+      expect(a.readOnlyHint, name).toBe(false);
+      expect(a.openWorldHint, name).toBe(true);
+    }
+  });
+
+  it("no tool is destructive (this server has no deletes by design)", () => {
+    for (const name of Object.keys(TOOL_KINDS) as ToolName[]) {
+      expect(buildAnnotations(name).destructiveHint, name).toBeUndefined();
+    }
+  });
+
+  it("Note tool descriptions say loudly that they publish immediately", () => {
+    for (const name of PUBLISH_TOOLS) {
+      expect(registered[name].description, name).toMatch(
+        /publishes immediately/i,
+      );
+    }
+  });
+
+  it("the classification groups above cover the whole registry", () => {
+    const grouped = [...READ_TOOLS, ...ADDITIVE_WRITE_TOOLS, ...PUBLISH_TOOLS];
+    expect(grouped.sort()).toEqual(Object.keys(TOOL_KINDS).sort());
+  });
+});

--- a/src/annotations.ts
+++ b/src/annotations.ts
@@ -1,0 +1,81 @@
+/**
+ * Tool side-effect classification → MCP tool annotations.
+ *
+ * Mirrors the gws-mcp-server pattern: every tool declares exactly one
+ * side-effect class in an exhaustive registry, and `buildAnnotations` maps
+ * that class to MCP annotation hints so clients can reason about side
+ * effects and render accurate consent UI. A completeness test asserts the
+ * registry matches the set of tools actually registered on the server, so
+ * new tools cannot ship unclassified.
+ */
+
+/** Side-effect classes for substack-mcp tools. */
+export type ToolKind =
+  /** Pure read: no side effects on the user's Substack data. */
+  | "read"
+  /**
+   * Additive write to PRIVATE state (drafts, CDN image uploads). Reversible
+   * in Substack's editor; nothing becomes public from these tools.
+   */
+  | "additive-write"
+  /**
+   * Write with IMMEDIATE PUBLIC effect: Substack Notes publish the moment
+   * the tool runs. Notes have no draft state on Substack, and this server
+   * has no delete tools, so there is no undo from here.
+   */
+  | "publish";
+
+/**
+ * Exhaustive tool-name → kind registry.
+ *
+ * This server has NO destructive tools (no deletes) by design. If one is
+ * ever added, introduce a "destructive" kind mapping to
+ * `{ readOnlyHint: false, destructiveHint: true }` per the MCP spec.
+ */
+export const TOOL_KINDS = {
+  // Reads
+  get_subscriber_count: "read",
+  list_published_posts: "read",
+  list_drafts: "read",
+  get_post: "read",
+  get_draft: "read",
+  get_post_comments: "read",
+  // Additive writes (private: drafts and uploads — nothing goes public)
+  create_draft: "additive-write",
+  update_draft: "additive-write",
+  upload_image: "additive-write",
+  // Immediate public publishes (Substack Notes)
+  create_note: "publish",
+  create_note_with_link: "publish",
+} as const satisfies Record<string, ToolKind>;
+
+export type ToolName = keyof typeof TOOL_KINDS;
+
+/** MCP tool annotations derived from a tool's side-effect class. */
+export interface ToolAnnotationHints {
+  readOnlyHint: boolean;
+  destructiveHint?: boolean;
+  openWorldHint?: boolean;
+}
+
+/**
+ * Map a tool's declared kind into MCP `annotations`.
+ *
+ * Every tool gets an explicit `readOnlyHint` (true for reads, false for any
+ * write) so clients always know the side-effect class. Additive writes carry
+ * `readOnlyHint: false` and no destructive hint (matching gws-mcp-server:
+ * they create or update reversible private state, never remove data). The
+ * Note tools additionally carry `openWorldHint: true` because they publish
+ * public content immediately — clients should not treat them as low-stakes
+ * writes.
+ */
+export function buildAnnotations(name: ToolName): ToolAnnotationHints {
+  switch (TOOL_KINDS[name]) {
+    case "read":
+      return { readOnlyHint: true };
+    case "additive-write":
+      return { readOnlyHint: false };
+    case "publish":
+      return { readOnlyHint: false, openWorldHint: true };
+  }
+}

--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -35,7 +35,7 @@ export class SubstackClient {
     const headers: Record<string, string> = {
       Cookie: this.cookie,
       "Content-Type": "application/json",
-      "User-Agent": "substack-mcp/0.2.2",
+      "User-Agent": "substack-mcp/0.3.0",
       ...(options.headers as Record<string, string> || {}),
     };
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,20 +1,29 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
 import { SubstackClient } from "./api/client.js";
+import { buildAnnotations } from "./annotations.js";
 import { markdownToProseMirror, markdownToProseMirrorContent } from "./utils/markdown-to-prosemirror.js";
 
 export function createServer(client: SubstackClient): McpServer {
   const server = new McpServer({
     name: "substack-mcp",
-    version: "0.2.2",
+    version: "0.3.0",
   });
+
+  // Every tool is registered with MCP annotations derived from its declared
+  // side-effect class (see annotations.ts) so clients can render accurate
+  // consent UI. Reads are readOnlyHint:true; draft/upload writes are
+  // additive; the Note tools publish public content immediately.
 
   // --- Read tools ---
 
-  server.tool(
+  server.registerTool(
     "get_subscriber_count",
-    "Get the current subscriber count for your Substack publication",
-    {},
+    {
+      description: "Get the current subscriber count for your Substack publication",
+      inputSchema: {},
+      annotations: buildAnnotations("get_subscriber_count"),
+    },
     async () => {
       const result = await client.getSubscriberCount();
       return {
@@ -25,12 +34,15 @@ export function createServer(client: SubstackClient): McpServer {
     },
   );
 
-  server.tool(
+  server.registerTool(
     "list_published_posts",
-    "List published posts with pagination. Returns title, date, slug, and URL for each post.",
     {
-      offset: z.number().optional().default(0).describe("Number of posts to skip"),
-      limit: z.number().optional().default(25).describe("Max posts to return (1-100)"),
+      description: "List published posts with pagination. Returns title, date, slug, and URL for each post.",
+      inputSchema: {
+        offset: z.number().optional().default(0).describe("Number of posts to skip"),
+        limit: z.number().optional().default(25).describe("Max posts to return (1-100)"),
+      },
+      annotations: buildAnnotations("list_published_posts"),
     },
     async ({ offset, limit }) => {
       const { posts, total } = await client.getPublishedPosts(offset, Math.min(limit, 100));
@@ -50,12 +62,15 @@ export function createServer(client: SubstackClient): McpServer {
     },
   );
 
-  server.tool(
+  server.registerTool(
     "list_drafts",
-    "List draft posts. Returns title, creation date, and audience for each draft.",
     {
-      offset: z.number().optional().default(0).describe("Number of drafts to skip"),
-      limit: z.number().optional().default(25).describe("Max drafts to return (1-100)"),
+      description: "List draft posts. Returns title, creation date, and audience for each draft.",
+      inputSchema: {
+        offset: z.number().optional().default(0).describe("Number of drafts to skip"),
+        limit: z.number().optional().default(25).describe("Max drafts to return (1-100)"),
+      },
+      annotations: buildAnnotations("list_drafts"),
     },
     async ({ offset, limit }) => {
       const drafts = await client.getDrafts(offset, Math.min(limit, 100));
@@ -74,11 +89,14 @@ export function createServer(client: SubstackClient): McpServer {
     },
   );
 
-  server.tool(
+  server.registerTool(
     "get_post",
-    "Get the full content of a published post by ID. Returns title, body HTML, metadata.",
     {
-      post_id: z.number().describe("The post ID to retrieve"),
+      description: "Get the full content of a published post by ID. Returns title, body HTML, metadata.",
+      inputSchema: {
+        post_id: z.number().describe("The post ID to retrieve"),
+      },
+      annotations: buildAnnotations("get_post"),
     },
     async ({ post_id }) => {
       const post = await client.getPost(post_id);
@@ -107,11 +125,14 @@ export function createServer(client: SubstackClient): McpServer {
     },
   );
 
-  server.tool(
+  server.registerTool(
     "get_draft",
-    "Get the full content of a draft post by ID. Returns title, body, metadata.",
     {
-      draft_id: z.number().describe("The draft ID to retrieve"),
+      description: "Get the full content of a draft post by ID. Returns title, body, metadata.",
+      inputSchema: {
+        draft_id: z.number().describe("The draft ID to retrieve"),
+      },
+      annotations: buildAnnotations("get_draft"),
     },
     async ({ draft_id }) => {
       const draft = await client.getDraft(draft_id);
@@ -139,12 +160,15 @@ export function createServer(client: SubstackClient): McpServer {
     },
   );
 
-  server.tool(
+  server.registerTool(
     "get_post_comments",
-    "Get comments on a published post. Returns commenter name, comment body, date, and reaction counts.",
     {
-      post_id: z.number().describe("The post ID to get comments for"),
-      limit: z.number().optional().default(20).describe("Max comments to return (default 20)"),
+      description: "Get comments on a published post. Returns commenter name, comment body, date, and reaction counts.",
+      inputSchema: {
+        post_id: z.number().describe("The post ID to get comments for"),
+        limit: z.number().optional().default(20).describe("Max comments to return (default 20)"),
+      },
+      annotations: buildAnnotations("get_post_comments"),
     },
     async ({ post_id, limit }) => {
       const comments = await client.getPostComments(post_id, limit);
@@ -162,20 +186,23 @@ export function createServer(client: SubstackClient): McpServer {
     },
   );
 
-  // --- Write tools ---
+  // --- Write tools (additive: drafts and uploads — nothing goes public) ---
 
-  server.tool(
+  server.registerTool(
     "create_draft",
-    "Create a new draft post. Accepts markdown body which is converted to Substack's format. Does NOT publish — creates a draft only.",
     {
-      title: z.string().describe("Post title"),
-      body: z.string().optional().describe("Post body in markdown format"),
-      subtitle: z.string().optional().describe("Post subtitle"),
-      audience: z
-        .enum(["everyone", "only_paid", "founding", "only_free"])
-        .optional()
-        .default("everyone")
-        .describe("Who can see this post"),
+      description: "Create a new draft post. Accepts markdown body which is converted to Substack's format. Does NOT publish — creates a draft only.",
+      inputSchema: {
+        title: z.string().describe("Post title"),
+        body: z.string().optional().describe("Post body in markdown format"),
+        subtitle: z.string().optional().describe("Post subtitle"),
+        audience: z
+          .enum(["everyone", "only_paid", "founding", "only_free"])
+          .optional()
+          .default("everyone")
+          .describe("Who can see this post"),
+      },
+      annotations: buildAnnotations("create_draft"),
     },
     async ({ title, body, subtitle, audience }) => {
       const prosemirrorBody = body ? markdownToProseMirror(body) : undefined;
@@ -204,18 +231,21 @@ export function createServer(client: SubstackClient): McpServer {
     },
   );
 
-  server.tool(
+  server.registerTool(
     "update_draft",
-    "Update an existing draft post. Only works on unpublished drafts. Accepts markdown body.",
     {
-      draft_id: z.number().describe("The draft ID to update"),
-      title: z.string().optional().describe("New title"),
-      subtitle: z.string().optional().describe("New subtitle"),
-      body: z.string().optional().describe("New body in markdown format"),
-      audience: z
-        .enum(["everyone", "only_paid", "founding", "only_free"])
-        .optional()
-        .describe("Who can see this post"),
+      description: "Update an existing draft post. Only works on unpublished drafts. Accepts markdown body.",
+      inputSchema: {
+        draft_id: z.number().describe("The draft ID to update"),
+        title: z.string().optional().describe("New title"),
+        subtitle: z.string().optional().describe("New subtitle"),
+        body: z.string().optional().describe("New body in markdown format"),
+        audience: z
+          .enum(["everyone", "only_paid", "founding", "only_free"])
+          .optional()
+          .describe("Who can see this post"),
+      },
+      annotations: buildAnnotations("update_draft"),
     },
     async ({ draft_id, title, subtitle, body, audience }) => {
       const updates: Record<string, unknown> = {};
@@ -244,15 +274,18 @@ export function createServer(client: SubstackClient): McpServer {
     },
   );
 
-  server.tool(
+  server.registerTool(
     "upload_image",
-    "Upload a base64-encoded image to Substack's CDN. Returns the hosted image URL.",
     {
-      image_base64: z
-        .string()
-        .describe(
-          'Base64-encoded image with data URI prefix (e.g., "data:image/png;base64,...")',
-        ),
+      description: "Upload a base64-encoded image to Substack's CDN. Returns the hosted image URL.",
+      inputSchema: {
+        image_base64: z
+          .string()
+          .describe(
+            'Base64-encoded image with data URI prefix (e.g., "data:image/png;base64,...")',
+          ),
+      },
+      annotations: buildAnnotations("upload_image"),
     },
     async ({ image_base64 }) => {
       const result = await client.uploadImage(image_base64);
@@ -264,11 +297,16 @@ export function createServer(client: SubstackClient): McpServer {
     },
   );
 
-  server.tool(
+  // --- Note tools (PUBLISH IMMEDIATELY — public the moment they run) ---
+
+  server.registerTool(
     "create_note",
-    "Create a Substack Note (short-form content). Accepts markdown text. Publishes immediately — there is no draft state for notes.",
     {
-      body: z.string().describe("Note content in markdown format"),
+      description: "Create a Substack Note (short-form content). Accepts markdown text. PUBLISHES IMMEDIATELY to your public Notes feed — Notes have no draft state on Substack, and this server has no delete tools, so there is no undo from here.",
+      inputSchema: {
+        body: z.string().describe("Note content in markdown format"),
+      },
+      annotations: buildAnnotations("create_note"),
     },
     async ({ body }) => {
       const bodyJson = {
@@ -297,12 +335,15 @@ export function createServer(client: SubstackClient): McpServer {
     },
   );
 
-  server.tool(
+  server.registerTool(
     "create_note_with_link",
-    "Create a Substack Note with a link attachment. The link is displayed as a rich card below the note text. Publishes immediately.",
     {
-      body: z.string().describe("Note content in markdown format"),
-      url: z.string().url().describe("URL to attach as a link card"),
+      description: "Create a Substack Note with a link attachment, displayed as a rich card below the note text. PUBLISHES IMMEDIATELY to your public Notes feed — same caveats as create_note: no draft state, no undo from this server.",
+      inputSchema: {
+        body: z.string().describe("Note content in markdown format"),
+        url: z.string().url().describe("URL to attach as a link card"),
+      },
+      annotations: buildAnnotations("create_note_with_link"),
     },
     async ({ body, url }) => {
       const attachment = await client.createNoteAttachment(url);


### PR DESCRIPTION
## Summary
- **Issue #4 — annotations.** Every tool now declares MCP annotations via a new `src/annotations.ts` registry mirroring the gws-mcp-server v0.2.0 pattern: 6 reads (`readOnlyHint: true`), 3 additive writes (`readOnlyHint: false`), and the two Note tools (`readOnlyHint: false, openWorldHint: true` — they publish public content immediately). No destructive tools exist (verified: no delete endpoints in the client). `server.ts` migrated from deprecated `server.tool` to `registerTool` with annotations attached.
- **Issue #3 — honest README.** The "cannot publish" banner now scopes the guarantee to long-form posts and calls out the Notes exception loudly. Write table split into additive writes vs immediate publishes. `package.json`/`server.json` descriptions fixed too. Note tool descriptions now say "PUBLISHES IMMEDIATELY" with the no-draft-state, no-undo caveat.
- **Tests.** New `annotations.test.ts`: mapping unit tests, completeness test (registered tool set must equal classification registry), no-destructive guard, and a description regex guard on the Note tools. 90 tests green; lint and build clean.
- **Version.** 0.2.2 → 0.3.0 (minor), synced across package.json, server.json (both version fields), the `McpServer` version string, and the client User-Agent.

Verified over the wire: server boots on stdio and `tools/list` returns the expected annotations for all 11 tools.

Closes #4
Closes #3

🤖 Generated with [Claude Code](https://claude.com/claude-code)