### PR TITLE
Don't send Content-Type on bodyless GET requests

### DIFF
--- a/src/__tests__/client.test.ts
+++ b/src/__tests__/client.test.ts
@@ -82,4 +82,22 @@ describe("SubstackClient requests", () => {
     const opts = fetchMock.mock.calls[0][1] as { headers: Record<string, string> };
     expect(opts.headers["User-Agent"]).toBe("MyUA/1.0");
   });
+
+  it("omits Content-Type on a bodyless GET", async () => {
+    const fetchMock = stubFetch({ posts: [] });
+    const client = new SubstackClient("https://example.substack.com", "tok", "1");
+    await client.getDrafts();
+
+    const opts = fetchMock.mock.calls[0][1] as { headers: Record<string, string> };
+    expect(opts.headers["Content-Type"]).toBeUndefined();
+  });
+
+  it("sends Content-Type on a request with a body", async () => {
+    const fetchMock = stubFetch({ id: 1, draft_title: "hi" });
+    const client = new SubstackClient("https://example.substack.com", "tok", "1");
+    await client.createDraft("hi");
+
+    const opts = fetchMock.mock.calls[0][1] as { headers: Record<string, string> };
+    expect(opts.headers["Content-Type"]).toBe("application/json");
+  });
 });

--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -48,7 +48,6 @@ export class SubstackClient {
   ): Promise<T> {
     const headers: Record<string, string> = {
       Cookie: this.cookie,
-      "Content-Type": "application/json",
       "User-Agent": this.userAgent,
       Accept: "application/json, text/plain, */*",
       // Without a Referer, Substack 301-redirects canonical *.substack.com API
@@ -58,6 +57,13 @@ export class SubstackClient {
       Referer: `${this.publicationUrl}/publish/home`,
       ...(options.headers as Record<string, string> || {}),
     };
+
+    // Only send Content-Type when there's a body. A bodyless GET carrying
+    // Content-Type is a non-browser signature — the same class of tell the
+    // browser UA/Referer above exist to avoid. Respect a caller override.
+    if (options.body && !("Content-Type" in headers)) {
+      headers["Content-Type"] = "application/json";
+    }
 
     const response = await fetch(url, {
       ...options,


### PR DESCRIPTION
## What

`request()` set `Content-Type: application/json` on every request, including GETs that carry no body. This follows up on #8: a bodyless GET with a `Content-Type` header is a non-browser signature — the same class of tell the browser `User-Agent` and `Referer` headers added in #8 exist to avoid on Cloudflare-fronted publications. Real browsers don't send `Content-Type` on a bodyless `fetch`.

## Change

- Set `Content-Type: application/json` only when the request has a body, and only if a caller hasn't already provided one.
- All write methods (`createDraft`, `updateDraft`, `uploadImage`, `createNote`, `createNoteAttachment`) pass a JSON body, so they keep the header. GETs drop it.

## Notes

Cloudflare wasn't blocking on this today — #8's live tests passed — so this is a small consistency fix, not a bug fix. It just removes one avoidable non-browser tell.

## Verification

- `npm run build` clean
- `npm test` → 100 passing (2 new: GET omits `Content-Type`, body request keeps it)

🤖 Generated with [Claude Code](https://claude.com/claude-code)