### PR TITLE
Set tool annotation hints explicitly; fix inverted MCP defaults

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,7 +5,7 @@ MCP server for Substack — read posts, manage drafts, create notes. Cannot publ
 ## Architecture
 - `src/index.ts` — MCP server bootstrap and entry point
 - `src/server.ts` — Tool registration, request handlers, Zod schema generation
-- `src/annotations.ts` — Tool side-effect classification (read / additive-write / publish) → MCP annotations
+- `src/annotations.ts` — Tool side-effect classification (read / draft-write / public-upload / publish) → MCP annotations (hints set explicitly; MCP defaults omitted hints to the unsafe direction)
 - `src/api/client.ts` — HTTP client for Substack API (session cookie auth)
 - `src/api/types.ts` — TypeScript interfaces for API responses
 - `src/utils/errors.ts` — Error handling utilities

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Built and maintained by [Conor Bronsdon](https://github.com/conorbronsdon) for t
 
 ## Tools
 
-Every tool declares MCP [tool annotations](https://modelcontextprotocol.io/docs/concepts/tools#tool-annotations): reads carry `readOnlyHint: true`, draft/upload writes carry `readOnlyHint: false`, and the Note tools additionally carry `openWorldHint: true` so clients don't treat an immediate public publish as a low-stakes write.
+Every tool declares MCP [tool annotations](https://modelcontextprotocol.io/docs/concepts/tools#tool-annotations), set **explicitly** rather than left to MCP's defaults (an omitted `destructiveHint` or `openWorldHint` defaults to `true`). Reads carry `readOnlyHint: true`. Every write is additive, so all writes carry `destructiveHint: false`. Draft writes are private (`openWorldHint: false`); `upload_image` carries `openWorldHint: true` because it returns a publicly-fetchable CDN URL; and the Note tools carry `openWorldHint: true` for immediate public publish. Annotations are untrusted hints, so the authoritative wording lives in each tool's description.
 
 ### Read
 
@@ -48,13 +48,13 @@ Every tool declares MCP [tool annotations](https://modelcontextprotocol.io/docs/
 | `get_draft` | Get full content of a draft by ID |
 | `get_post_comments` | Get comments on a published post |
 
-### Write (drafts and uploads — nothing goes public)
+### Write (private drafts; image upload returns a public URL)
 
 | Tool | Description |
 |------|-------------|
-| `create_draft` | Create a new draft from markdown |
-| `update_draft` | Update an existing draft (unpublished only) |
-| `upload_image` | Upload an image to Substack's CDN |
+| `create_draft` | Create a new draft from markdown (private) |
+| `update_draft` | Update an existing draft (unpublished only; private) |
+| `upload_image` | Upload an image to Substack's CDN — returns a publicly-fetchable (unlisted) URL |
 
 ### Publish (Notes — public immediately)
 

--- a/src/__tests__/annotations.test.ts
+++ b/src/__tests__/annotations.test.ts
@@ -26,11 +26,9 @@ const READ_TOOLS: ToolName[] = [
   "get_post_comments",
 ];
 
-const ADDITIVE_WRITE_TOOLS: ToolName[] = [
-  "create_draft",
-  "update_draft",
-  "upload_image",
-];
+const DRAFT_WRITE_TOOLS: ToolName[] = ["create_draft", "update_draft"];
+
+const PUBLIC_UPLOAD_TOOLS: ToolName[] = ["upload_image"];
 
 const PUBLISH_TOOLS: ToolName[] = ["create_note", "create_note_with_link"];
 
@@ -40,16 +38,31 @@ describe("buildAnnotations mapping", () => {
     expect(a).toEqual({ readOnlyHint: true });
   });
 
-  it("additive write -> { readOnlyHint: false } with no destructive or open-world hint", () => {
+  it("draft write -> readOnlyHint:false, explicitly non-destructive and closed-world", () => {
     const a = buildAnnotations("create_draft");
-    expect(a).toEqual({ readOnlyHint: false });
-    expect(a.destructiveHint).toBeUndefined();
-    expect(a.openWorldHint).toBeUndefined();
+    expect(a).toEqual({
+      readOnlyHint: false,
+      destructiveHint: false,
+      openWorldHint: false,
+    });
   });
 
-  it("publish (Notes) -> { readOnlyHint: false, openWorldHint: true }", () => {
+  it("public upload -> openWorldHint:true (returns a publicly-fetchable URL), non-destructive", () => {
+    const a = buildAnnotations("upload_image");
+    expect(a).toEqual({
+      readOnlyHint: false,
+      destructiveHint: false,
+      openWorldHint: true,
+    });
+  });
+
+  it("publish (Notes) -> readOnlyHint:false, openWorldHint:true, non-destructive", () => {
     const a = buildAnnotations("create_note");
-    expect(a).toEqual({ readOnlyHint: false, openWorldHint: true });
+    expect(a).toEqual({
+      readOnlyHint: false,
+      destructiveHint: false,
+      openWorldHint: true,
+    });
   });
 });
 
@@ -78,12 +91,21 @@ describe("tool annotation classifications", () => {
     }
   });
 
-  it("additive writes are readOnlyHint:false with no destructive or open-world hint", () => {
-    for (const name of ADDITIVE_WRITE_TOOLS) {
+  it("draft writes are readOnlyHint:false, explicitly non-destructive and closed-world", () => {
+    for (const name of DRAFT_WRITE_TOOLS) {
       const a = buildAnnotations(name);
       expect(a.readOnlyHint, name).toBe(false);
-      expect(a.destructiveHint, name).toBeUndefined();
-      expect(a.openWorldHint, name).toBeUndefined();
+      expect(a.destructiveHint, name).toBe(false);
+      expect(a.openWorldHint, name).toBe(false);
+    }
+  });
+
+  it("public uploads carry openWorldHint:true (publicly-fetchable URL), non-destructive", () => {
+    for (const name of PUBLIC_UPLOAD_TOOLS) {
+      const a = buildAnnotations(name);
+      expect(a.readOnlyHint, name).toBe(false);
+      expect(a.destructiveHint, name).toBe(false);
+      expect(a.openWorldHint, name).toBe(true);
     }
   });
 
@@ -95,9 +117,15 @@ describe("tool annotation classifications", () => {
     }
   });
 
-  it("no tool is destructive (this server has no deletes by design)", () => {
-    for (const name of Object.keys(TOOL_KINDS) as ToolName[]) {
-      expect(buildAnnotations(name).destructiveHint, name).toBeUndefined();
+  it("no write tool is destructive (this server has no deletes by design)", () => {
+    // Writes set destructiveHint explicitly to false — never left to MCP's
+    // unsafe default of true. Reads omit it (not meaningful for a read).
+    for (const name of [
+      ...DRAFT_WRITE_TOOLS,
+      ...PUBLIC_UPLOAD_TOOLS,
+      ...PUBLISH_TOOLS,
+    ]) {
+      expect(buildAnnotations(name).destructiveHint, name).toBe(false);
     }
   });
 
@@ -110,7 +138,12 @@ describe("tool annotation classifications", () => {
   });
 
   it("the classification groups above cover the whole registry", () => {
-    const grouped = [...READ_TOOLS, ...ADDITIVE_WRITE_TOOLS, ...PUBLISH_TOOLS];
+    const grouped = [
+      ...READ_TOOLS,
+      ...DRAFT_WRITE_TOOLS,
+      ...PUBLIC_UPLOAD_TOOLS,
+      ...PUBLISH_TOOLS,
+    ];
     expect(grouped.sort()).toEqual(Object.keys(TOOL_KINDS).sort());
   });
 });

--- a/src/annotations.ts
+++ b/src/annotations.ts
@@ -7,6 +7,20 @@
  * effects and render accurate consent UI. A completeness test asserts the
  * registry matches the set of tools actually registered on the server, so
  * new tools cannot ship unclassified.
+ *
+ * IMPORTANT — MCP hints default to the UNSAFE direction. Per the spec
+ * (schema 2025-06-18), an omitted `destructiveHint` defaults to `true` and an
+ * omitted `openWorldHint` defaults to `true`. So we set EVERY relevant hint
+ * explicitly on writes; leaving one off would make a reversible private draft
+ * edit read to a conformant client as destructive and open-world. Annotations
+ * are also untrusted hints — the authoritative consent surface is the tool
+ * description, so descriptions carry the load-bearing wording (e.g. that
+ * `upload_image` returns a publicly-fetchable URL).
+ *
+ * `openWorldHint` convention used here: `true` means the tool's output enters
+ * an open world of external entities — a public Substack Note, or a
+ * publicly-fetchable CDN image URL. Private draft writes stay in your account
+ * and are `false`.
  */
 
 /** Side-effect classes for substack-mcp tools. */
@@ -14,10 +28,16 @@ export type ToolKind =
   /** Pure read: no side effects on the user's Substack data. */
   | "read"
   /**
-   * Additive write to PRIVATE state (drafts, CDN image uploads). Reversible
-   * in Substack's editor; nothing becomes public from these tools.
+   * Additive write to PRIVATE draft state. Reversible in Substack's editor;
+   * nothing becomes reachable outside your account.
    */
-  | "additive-write"
+  | "draft-write"
+  /**
+   * Additive write that returns a PUBLICLY FETCHABLE (but unlisted) CDN URL.
+   * The image bytes are served without authentication to anyone holding the
+   * URL, though the asset is not attributed or added to your feed.
+   */
+  | "public-upload"
   /**
    * Write with IMMEDIATE PUBLIC effect: Substack Notes publish the moment
    * the tool runs. Notes have no draft state on Substack, and this server
@@ -28,9 +48,10 @@ export type ToolKind =
 /**
  * Exhaustive tool-name → kind registry.
  *
- * This server has NO destructive tools (no deletes) by design. If one is
- * ever added, introduce a "destructive" kind mapping to
- * `{ readOnlyHint: false, destructiveHint: true }` per the MCP spec.
+ * This server has NO destructive tools (no deletes) by design — every write
+ * is additive, so all writes set `destructiveHint: false` explicitly. If a
+ * destructive tool is ever added, set `destructiveHint: true` for it per the
+ * MCP spec.
  */
 export const TOOL_KINDS = {
   // Reads
@@ -40,10 +61,11 @@ export const TOOL_KINDS = {
   get_post: "read",
   get_draft: "read",
   get_post_comments: "read",
-  // Additive writes (private: drafts and uploads — nothing goes public)
-  create_draft: "additive-write",
-  update_draft: "additive-write",
-  upload_image: "additive-write",
+  // Additive writes to private draft state (nothing reachable outside account)
+  create_draft: "draft-write",
+  update_draft: "draft-write",
+  // Additive write returning a publicly-fetchable CDN URL
+  upload_image: "public-upload",
   // Immediate public publishes (Substack Notes)
   create_note: "publish",
   create_note_with_link: "publish",
@@ -59,23 +81,37 @@ export interface ToolAnnotationHints {
 }
 
 /**
- * Map a tool's declared kind into MCP `annotations`.
+ * Map a tool's declared kind into MCP `annotations`, setting every relevant
+ * hint EXPLICITLY (never relying on MCP's unsafe-by-default omission).
  *
- * Every tool gets an explicit `readOnlyHint` (true for reads, false for any
- * write) so clients always know the side-effect class. Additive writes carry
- * `readOnlyHint: false` and no destructive hint (matching gws-mcp-server:
- * they create or update reversible private state, never remove data). The
- * Note tools additionally carry `openWorldHint: true` because they publish
- * public content immediately — clients should not treat them as low-stakes
- * writes.
+ * - Reads: `readOnlyHint: true` (destructive/open-world hints are not
+ *   meaningful for a read).
+ * - Every write is additive, so `destructiveHint: false`.
+ * - `openWorldHint` is `true` only when the tool's output becomes reachable
+ *   by outside parties: a public Note, or a publicly-fetchable CDN image URL.
+ *   Private draft writes are `false`.
  */
 export function buildAnnotations(name: ToolName): ToolAnnotationHints {
   switch (TOOL_KINDS[name]) {
     case "read":
       return { readOnlyHint: true };
-    case "additive-write":
-      return { readOnlyHint: false };
+    case "draft-write":
+      return {
+        readOnlyHint: false,
+        destructiveHint: false,
+        openWorldHint: false,
+      };
+    case "public-upload":
+      return {
+        readOnlyHint: false,
+        destructiveHint: false,
+        openWorldHint: true,
+      };
     case "publish":
-      return { readOnlyHint: false, openWorldHint: true };
+      return {
+        readOnlyHint: false,
+        destructiveHint: false,
+        openWorldHint: true,
+      };
   }
 }

--- a/src/server.ts
+++ b/src/server.ts
@@ -186,7 +186,7 @@ export function createServer(client: SubstackClient): McpServer {
     },
   );
 
-  // --- Write tools (additive: drafts and uploads — nothing goes public) ---
+  // --- Write tools (additive: private drafts + a public-URL image upload) ---
 
   server.registerTool(
     "create_draft",
@@ -277,7 +277,8 @@ export function createServer(client: SubstackClient): McpServer {
   server.registerTool(
     "upload_image",
     {
-      description: "Upload a base64-encoded image to Substack's CDN. Returns the hosted image URL.",
+      description:
+        "Upload a base64-encoded image to Substack's CDN. Returns a hosted image URL that is publicly fetchable by anyone with the link (an unlisted asset — not attributed to you or added to your feed).",
       inputSchema: {
         image_base64: z
           .string()


### PR DESCRIPTION
## Problem

MCP annotation hints default to the **unsafe** direction: an omitted `destructiveHint` or `openWorldHint` defaults to `true` (schema 2025-06-18). The additive write tools emitted only `{ readOnlyHint: false }` and relied on omission to mean "safe" — so a spec-conformant client read reversible private draft edits as **destructive + open-world**, the opposite of this server's "safe by design" intent. The explicit `openWorldHint: true` on the Note tools was also redundant with the default.

Surfaced by @MaazAhmed47 in #9, whose question about `upload_image`'s CDN URL exposed the broader scheme.

## Changes

- **Emit every relevant hint explicitly.** All writes now carry `destructiveHint: false` (every write is additive; no deletes) and an explicit `openWorldHint`.
- **Split `upload_image` into its own `public-upload` class.** It returns a publicly-fetchable (unlisted) CDN URL → `openWorldHint: true`. Private draft writes stay `openWorldHint: false`.
- **Fix the consent surface.** `upload_image`'s description now states the returned URL is publicly fetchable by anyone with the link; README no longer claims "nothing goes public" for uploads.
- **Tests** updated to the explicit-hints scheme.

## Verification

- `tsc` clean
- `94/94` tests pass (13 in the annotations suite)

🤖 Generated with [Claude Code](https://claude.com/claude-code)