### PR TITLE
ci: switch npm publish to trusted publishing (OIDC)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -19,7 +19,7 @@ jobs:
 
       - uses: actions/setup-node@v6
         with:
-          node-version: 20
+          node-version: 22
           registry-url: https://registry.npmjs.org
 
       - name: Check if package.json version is already published
@@ -50,11 +50,13 @@ jobs:
         if: steps.version.outputs.changed == 'true'
         run: npm test --if-present
 
+      - name: Update npm for trusted publishing
+        if: steps.version.outputs.changed == 'true'
+        run: npm install -g npm@latest
+
       - name: Publish to npm
         if: steps.version.outputs.changed == 'true'
         run: npm publish --provenance --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Create GitHub release
         if: steps.version.outputs.changed == 'true'


### PR DESCRIPTION
## Summary
- Switches `.github/workflows/publish.yml` from `NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}` to npm trusted publishing (OIDC) — no long-lived npm token, publish auth is scoped to this workflow via GitHub Actions OIDC.
- Bumps the publish job to Node 22 and adds `npm install -g npm@latest` before the publish step (npm trusted publishing requires npm CLI >= 11.5.1 and Node >= 22.14, per https://docs.npmjs.com/trusted-publishers; the Node 20 runner ships an older npm/Node).
- Keeps `--provenance` (and `--access public` where present) and `id-token: write` / `contents: write` permissions.

## Requires
This workflow is inert until a trusted publisher is configured for the package on npmjs.com:
- Publisher: GitHub Actions
- Owner: conorbronsdon
- Repo: substack-mcp
- Workflow: publish.yml
- Environment: (none)

Until that config exists, `npm publish` in this workflow will fail with no auth — expected, since there is no `NPM_TOKEN` fallback anymore.

## Test plan
- [ ] YAML validated with `python -c "import yaml; yaml.safe_load(open(...))"`
- [ ] Configure trusted publisher on npmjs.com for this package
- [ ] Merge and verify next `package.json` version bump publishes successfully via OIDC
