### PR TITLE
Extend typed error hierarchy: RateLimitError, ValidationError, NotFoundError, ServerError

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,21 @@ Substack publications served on a custom domain (e.g. `blog.example.com`) sit be
 }
 ```
 
+## Typed errors
+
+API failures are mapped to a typed error hierarchy (`SubstackAPIError` base, with `AuthenticationError`, `RateLimitError`, `ValidationError`, `NotFoundError`, and `ServerError` subclasses keyed off HTTP status) in `src/utils/errors.ts`. Every tool call still surfaces the same error response shape on failure — the typed hierarchy just makes the message specific to what went wrong instead of a single generic "Substack API error" string.
+
+| Class | Status | Triggered by |
+|---|---|---|
+| `AuthenticationError` | 401/403 | Expired/invalid session token, or a Cloudflare `error code: 1010` block (see above) |
+| `RateLimitError` | 429 | Too many requests against the Substack API in a short window |
+| `ValidationError` | 400 | Malformed or invalid arguments passed to a tool (e.g. a missing required field) |
+| `NotFoundError` | 404 | The referenced draft, post, or note doesn't exist |
+| `ServerError` | 5xx | Failure on Substack's side |
+| `SubstackAPIError` | any other status | Fallback for unmapped status codes |
+
+Substack error response bodies are inconsistent — sometimes JSON (`{"error": "..."}` or `{"errors": [...]}`), sometimes plain text, and sometimes a large Cloudflare HTML block page. `extractErrorDetail` handles all three: it tries `JSON.parse` first, falls back to the raw text (trimmed and capped at ~500 characters so a multi-KB HTML page doesn't become the whole error message), and only uses a generic fallback string if the body is empty.
+
 ## Markdown support
 
 The `create_draft` and `update_draft` tools accept markdown and convert it to Substack's native format. Supported:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@conorbronsdon/substack-mcp",
-  "version": "0.2.1",
+  "version": "0.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@conorbronsdon/substack-mcp",
-      "version": "0.2.1",
+      "version": "0.4.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.12.0",
@@ -898,7 +898,6 @@
       "integrity": "sha512-F0R/h2+dsy5wJAUe3tAU6oqa2qbWY5TpNfL/RGmo1y38hiyO1w3x2jPtt76wmuaJI4DQnOBu21cNXQ2STIUUWg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~6.21.0"
       }
@@ -1427,7 +1426,6 @@
       "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
       "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "accepts": "^2.0.0",
         "body-parser": "^2.2.1",
@@ -1678,7 +1676,6 @@
       "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.5.tgz",
       "integrity": "sha512-3qq+FUBtlTHhtYxbxheZgY8NIFnkkC/MR8u5TTsr7YZ3wixryQ3cCwn3iZbg8p8B88iDBBAYSfZDS75t8MN7Vg==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -2237,7 +2234,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -2661,7 +2657,6 @@
       "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "~0.27.0",
         "get-tsconfig": "^4.7.5"
@@ -2735,7 +2730,6 @@
       "integrity": "sha512-wt+Z2qIhfFt85uiyRt5LPU4oVEJBXj8hZNWKeqFG4gRG/0RaRGJ7njQCwzFVjO+v4+Ipmf5CY7VdmZRAYYBPHw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.3",
@@ -2933,7 +2927,6 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
       "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@conorbronsdon/substack-mcp",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "MCP server for Substack — read posts, manage drafts, publish Notes. Long-form posts are draft-only by design (no publish, no delete); Notes publish immediately.",
   "type": "module",
   "bin": {

--- a/src/__tests__/client.test.ts
+++ b/src/__tests__/client.test.ts
@@ -1,5 +1,13 @@
 import { describe, it, expect, vi, afterEach } from "vitest";
 import { SubstackClient } from "../api/client.js";
+import {
+  AuthenticationError,
+  RateLimitError,
+  ValidationError,
+  NotFoundError,
+  ServerError,
+  SubstackAPIError,
+} from "../utils/errors.js";
 
 describe("SubstackClient constructor", () => {
   it("parses valid numeric userId without throwing", () => {
@@ -99,5 +107,97 @@ describe("SubstackClient requests", () => {
 
     const opts = fetchMock.mock.calls[0][1] as { headers: Record<string, string> };
     expect(opts.headers["Content-Type"]).toBe("application/json");
+  });
+});
+
+describe("SubstackClient error mapping (end-to-end through request())", () => {
+  afterEach(() => vi.unstubAllGlobals());
+
+  function stubFetchError(status: number, body: string) {
+    const fetchMock = vi.fn(async (..._args: any[]) => ({
+      ok: false,
+      status,
+      json: async () => JSON.parse(body),
+      text: async () => body,
+    }));
+    vi.stubGlobal("fetch", fetchMock);
+    return fetchMock;
+  }
+
+  it("maps a 401 response to AuthenticationError", async () => {
+    stubFetchError(401, "Not authorized");
+    const client = new SubstackClient("https://example.substack.com", "tok", "1");
+    await expect(client.getDrafts()).rejects.toBeInstanceOf(AuthenticationError);
+  });
+
+  it("maps a 403 Cloudflare-style block to AuthenticationError", async () => {
+    stubFetchError(403, "error code: 1010");
+    const client = new SubstackClient("https://example.substack.com", "tok", "1");
+    await expect(client.getDrafts()).rejects.toBeInstanceOf(AuthenticationError);
+  });
+
+  it("maps a 429 response to RateLimitError with the body as detail", async () => {
+    stubFetchError(429, JSON.stringify({ error: "Too many requests" }));
+    const client = new SubstackClient("https://example.substack.com", "tok", "1");
+    try {
+      await client.getDrafts();
+      throw new Error("should have thrown");
+    } catch (err) {
+      expect(err).toBeInstanceOf(RateLimitError);
+      expect((err as RateLimitError).message).toContain("Too many requests");
+    }
+  });
+
+  it("maps a 400 response to ValidationError", async () => {
+    stubFetchError(400, JSON.stringify({ error: "draft_title is required" }));
+    const client = new SubstackClient("https://example.substack.com", "tok", "1");
+    try {
+      await client.createDraft("");
+      throw new Error("should have thrown");
+    } catch (err) {
+      expect(err).toBeInstanceOf(ValidationError);
+      expect((err as ValidationError).message).toContain("draft_title is required");
+    }
+  });
+
+  it("maps a 404 response to NotFoundError", async () => {
+    stubFetchError(404, "Draft not found");
+    const client = new SubstackClient("https://example.substack.com", "tok", "1");
+    try {
+      await client.getDraft(999);
+      throw new Error("should have thrown");
+    } catch (err) {
+      expect(err).toBeInstanceOf(NotFoundError);
+      expect((err as NotFoundError).message).toContain("Draft not found");
+    }
+  });
+
+  it("maps a 500 response to ServerError", async () => {
+    stubFetchError(500, "Internal Server Error");
+    const client = new SubstackClient("https://example.substack.com", "tok", "1");
+    try {
+      await client.getDrafts();
+      throw new Error("should have thrown");
+    } catch (err) {
+      expect(err).toBeInstanceOf(ServerError);
+      expect((err as ServerError).message).toContain("Internal Server Error");
+    }
+  });
+
+  it("falls back to base SubstackAPIError for an unmapped status", async () => {
+    stubFetchError(418, "I'm a teapot");
+    const client = new SubstackClient("https://example.substack.com", "tok", "1");
+    try {
+      await client.getDrafts();
+      throw new Error("should have thrown");
+    } catch (err) {
+      expect(err).toBeInstanceOf(SubstackAPIError);
+      expect(err).not.toBeInstanceOf(AuthenticationError);
+      expect(err).not.toBeInstanceOf(RateLimitError);
+      expect(err).not.toBeInstanceOf(ValidationError);
+      expect(err).not.toBeInstanceOf(NotFoundError);
+      expect(err).not.toBeInstanceOf(ServerError);
+      expect((err as SubstackAPIError).message).toContain("I'm a teapot");
+    }
   });
 });

--- a/src/__tests__/errors.test.ts
+++ b/src/__tests__/errors.test.ts
@@ -1,5 +1,14 @@
 import { describe, it, expect } from "vitest";
-import { SubstackAPIError, AuthenticationError } from "../utils/errors.js";
+import {
+  SubstackAPIError,
+  AuthenticationError,
+  RateLimitError,
+  ValidationError,
+  NotFoundError,
+  ServerError,
+  mapHttpStatusToError,
+  extractErrorDetail,
+} from "../utils/errors.js";
 
 describe("SubstackAPIError", () => {
   it("formats message with status code and endpoint", () => {
@@ -39,5 +48,151 @@ describe("AuthenticationError", () => {
   it("is an instance of SubstackAPIError", () => {
     const err = new AuthenticationError("/api");
     expect(err).toBeInstanceOf(SubstackAPIError);
+  });
+});
+
+describe("RateLimitError", () => {
+  it("is a 429 with rate-limit guidance", () => {
+    const err = new RateLimitError("/api/v1/drafts", "too many requests");
+    expect(err.statusCode).toBe(429);
+    expect(err.endpoint).toBe("/api/v1/drafts");
+    expect(err.message).toContain("too many requests");
+    expect(err.message).toContain("Slow down");
+  });
+
+  it("has correct name property and extends SubstackAPIError", () => {
+    const err = new RateLimitError("/api", "x");
+    expect(err.name).toBe("RateLimitError");
+    expect(err).toBeInstanceOf(SubstackAPIError);
+  });
+});
+
+describe("ValidationError", () => {
+  it("is a 400 with argument-checking guidance", () => {
+    const err = new ValidationError("/api/v1/drafts", "missing draft_title");
+    expect(err.statusCode).toBe(400);
+    expect(err.message).toContain("missing draft_title");
+    expect(err.message).toContain("Check the arguments passed to this tool");
+  });
+
+  it("has correct name property and extends SubstackAPIError", () => {
+    const err = new ValidationError("/api", "x");
+    expect(err.name).toBe("ValidationError");
+    expect(err).toBeInstanceOf(SubstackAPIError);
+  });
+});
+
+describe("NotFoundError", () => {
+  it("is a 404 mentioning the missing resource", () => {
+    const err = new NotFoundError("/api/v1/drafts/99", "no such draft");
+    expect(err.statusCode).toBe(404);
+    expect(err.message).toContain("no such draft");
+    expect(err.message).toContain("draft, post, or note");
+  });
+
+  it("has correct name property and extends SubstackAPIError", () => {
+    const err = new NotFoundError("/api", "x");
+    expect(err.name).toBe("NotFoundError");
+    expect(err).toBeInstanceOf(SubstackAPIError);
+  });
+});
+
+describe("ServerError", () => {
+  it("is a 5xx with retry-later guidance", () => {
+    const err = new ServerError("/api/v1/drafts", "internal error");
+    expect(err.statusCode).toBe(500);
+    expect(err.message).toContain("internal error");
+    expect(err.message).toContain("try again later");
+  });
+
+  it("has correct name property and extends SubstackAPIError", () => {
+    const err = new ServerError("/api", "x");
+    expect(err.name).toBe("ServerError");
+    expect(err).toBeInstanceOf(SubstackAPIError);
+  });
+});
+
+describe("mapHttpStatusToError", () => {
+  it("maps 401 and 403 to AuthenticationError, discarding detail", () => {
+    const err401 = mapHttpStatusToError(401, "some raw body that should be ignored", "/api/v1/drafts");
+    const err403 = mapHttpStatusToError(403, "some raw body that should be ignored", "/api/v1/drafts");
+    expect(err401).toBeInstanceOf(AuthenticationError);
+    expect(err403).toBeInstanceOf(AuthenticationError);
+    // Message must match AuthenticationError's own hardcoded guidance exactly,
+    // not the discarded detail string — this is the 401/403 tradeoff.
+    expect(err401.message).toBe(new AuthenticationError("/api/v1/drafts").message);
+    expect(err401.message).not.toContain("some raw body");
+  });
+
+  it("maps 429 to RateLimitError", () => {
+    const err = mapHttpStatusToError(429, "slow down", "/api");
+    expect(err).toBeInstanceOf(RateLimitError);
+    expect(err.message).toContain("slow down");
+  });
+
+  it("maps 400 to ValidationError", () => {
+    const err = mapHttpStatusToError(400, "bad params", "/api");
+    expect(err).toBeInstanceOf(ValidationError);
+    expect(err.message).toContain("bad params");
+  });
+
+  it("maps 404 to NotFoundError", () => {
+    const err = mapHttpStatusToError(404, "no such post", "/api");
+    expect(err).toBeInstanceOf(NotFoundError);
+    expect(err.message).toContain("no such post");
+  });
+
+  it("maps 500-599 to ServerError", () => {
+    expect(mapHttpStatusToError(500, "boom", "/api")).toBeInstanceOf(ServerError);
+    expect(mapHttpStatusToError(502, "bad gateway", "/api")).toBeInstanceOf(ServerError);
+    expect(mapHttpStatusToError(503, "unavailable", "/api")).toBeInstanceOf(ServerError);
+  });
+
+  it("falls back to base SubstackAPIError for unmapped status codes", () => {
+    const err = mapHttpStatusToError(418, "teapot", "/api");
+    expect(err).toBeInstanceOf(SubstackAPIError);
+    expect(err).not.toBeInstanceOf(AuthenticationError);
+    expect(err).not.toBeInstanceOf(RateLimitError);
+    expect(err).not.toBeInstanceOf(ValidationError);
+    expect(err).not.toBeInstanceOf(NotFoundError);
+    expect(err).not.toBeInstanceOf(ServerError);
+    expect(err.message).toContain("Substack API error (418)");
+    expect(err.message).toContain("teapot");
+  });
+});
+
+describe("extractErrorDetail", () => {
+  it("returns the .error field from a JSON object body", () => {
+    expect(extractErrorDetail('{"error": "Invalid parameters"}', "fallback")).toBe("Invalid parameters");
+  });
+
+  it("returns the .message field from a JSON object body when .error is absent", () => {
+    expect(extractErrorDetail('{"message": "Draft is locked"}', "fallback")).toBe("Draft is locked");
+  });
+
+  it("joins a JSON .errors array into a single string", () => {
+    const result = extractErrorDetail('{"errors": ["title is required", "body is too long"]}', "fallback");
+    expect(result).toContain("title is required");
+    expect(result).toContain("body is too long");
+  });
+
+  it("returns a plain-text response body as-is", () => {
+    expect(extractErrorDetail("Not authorized", "fallback")).toBe("Not authorized");
+  });
+
+  it("falls back when response data is an empty string", () => {
+    expect(extractErrorDetail("", "fallback")).toBe("fallback");
+  });
+
+  it("trims and caps a Cloudflare-style HTML block page", () => {
+    const htmlPage =
+      "\n\n  <!DOCTYPE html><html><head><title>Attention Required! | Cloudflare</title></head>" +
+      "<body>" +
+      "error code: 1010".repeat(100) +
+      "</body></html>\n\n";
+    const result = extractErrorDetail(htmlPage, "fallback");
+    expect(result.length).toBeLessThanOrEqual(503); // 500 chars + "..."
+    expect(result.startsWith("<!DOCTYPE html>")).toBe(true);
+    expect(result.endsWith("...")).toBe(true);
   });
 });

--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -10,7 +10,7 @@ import {
   DraftUpdatePayload,
   ImageUploadResult,
 } from "./types.js";
-import { SubstackAPIError, AuthenticationError } from "../utils/errors.js";
+import { mapHttpStatusToError, extractErrorDetail } from "../utils/errors.js";
 
 export class SubstackClient {
   private publicationUrl: string;
@@ -71,13 +71,10 @@ export class SubstackClient {
       redirect: "follow",
     });
 
-    if (response.status === 401 || response.status === 403) {
-      throw new AuthenticationError(url);
-    }
-
     if (!response.ok) {
       const body = await response.text().catch(() => "unknown error");
-      throw new SubstackAPIError(response.status, body, url);
+      const detail = extractErrorDetail(body, "unknown error");
+      throw mapHttpStatusToError(response.status, detail, url);
     }
 
     return response.json() as Promise<T>;

--- a/src/server.ts
+++ b/src/server.ts
@@ -7,7 +7,7 @@ import { markdownToProseMirror, markdownToProseMirrorContent } from "./utils/mar
 export function createServer(client: SubstackClient): McpServer {
   const server = new McpServer({
     name: "substack-mcp",
-    version: "0.3.0",
+    version: "0.4.0",
   });
 
   // Every tool is registered with MCP annotations derived from its declared

--- a/src/utils/errors.ts
+++ b/src/utils/errors.ts
@@ -15,3 +15,92 @@ export class AuthenticationError extends SubstackAPIError {
     this.name = "AuthenticationError";
   }
 }
+
+/** HTTP 429 — too many requests against the Substack API. */
+export class RateLimitError extends SubstackAPIError {
+  constructor(endpoint: string, detail: string) {
+    super(429, "Rate limited by Substack: " + detail + ". Slow down requests and try again shortly.", endpoint);
+    this.name = "RateLimitError";
+  }
+}
+
+/** HTTP 400 — malformed or invalid request parameters. */
+export class ValidationError extends SubstackAPIError {
+  constructor(endpoint: string, detail: string) {
+    super(400, "Validation error: " + detail + ". Check the arguments passed to this tool.", endpoint);
+    this.name = "ValidationError";
+  }
+}
+
+/** HTTP 404 — the requested draft, post, or note does not exist. */
+export class NotFoundError extends SubstackAPIError {
+  constructor(endpoint: string, detail: string) {
+    super(404, "Not found: " + detail + ". The draft, post, or note may not exist or may have been deleted.", endpoint);
+    this.name = "NotFoundError";
+  }
+}
+
+/** HTTP 5xx — failure on Substack's side. */
+export class ServerError extends SubstackAPIError {
+  constructor(endpoint: string, detail: string) {
+    super(500, "Server error: " + detail + ". Substack may be having issues — try again later.", endpoint);
+    this.name = "ServerError";
+  }
+}
+
+/**
+ * Maps an HTTP status code + error detail string to the appropriate typed
+ * error. 401/403 route to AuthenticationError with `detail` intentionally
+ * discarded — AuthenticationError's constructor takes only `endpoint` so its
+ * message stays the exact hardcoded cookie-refresh guidance the existing
+ * tests assert on verbatim; threading `detail` through would either change
+ * that message or require duplicating it. Falls back to the base
+ * `SubstackAPIError` for status codes outside the mapped classes.
+ */
+export function mapHttpStatusToError(status: number, detail: string, endpoint: string): SubstackAPIError {
+  if (status === 401 || status === 403) return new AuthenticationError(endpoint);
+  if (status === 429) return new RateLimitError(endpoint, detail);
+  if (status === 400) return new ValidationError(endpoint, detail);
+  if (status === 404) return new NotFoundError(endpoint, detail);
+  if (status >= 500) return new ServerError(endpoint, detail);
+  return new SubstackAPIError(status, detail, endpoint);
+}
+
+/**
+ * Pulls a human-readable detail string out of a Substack error response
+ * body. Substack error bodies are inconsistent: some are JSON objects
+ * (`{"error": "..."}` or `{"errors": [...]}`), some are plain text, and
+ * some — notably a Cloudflare block page on custom domains, see README's
+ * "403 error code: 1010" section — are large HTML documents. This function
+ * tries JSON first, then falls back to the raw text (trimmed and capped so
+ * a multi-KB Cloudflare HTML blob doesn't become the entire error message).
+ */
+export function extractErrorDetail(responseData: string, fallback: string): string {
+  const MAX_LENGTH = 500;
+
+  try {
+    const parsed = JSON.parse(responseData);
+    if (parsed && typeof parsed === "object") {
+      if (typeof parsed.error === "string" && parsed.error.length > 0) {
+        return parsed.error;
+      }
+      if (typeof parsed.message === "string" && parsed.message.length > 0) {
+        return parsed.message;
+      }
+      if (Array.isArray(parsed.errors) && parsed.errors.length > 0) {
+        return parsed.errors
+          .map((e: unknown) => (typeof e === "string" ? e : JSON.stringify(e)))
+          .join("; ");
+      }
+    }
+  } catch {
+    // Not JSON — fall through to raw-text handling below.
+  }
+
+  const trimmed = responseData.trim();
+  if (trimmed.length > 0) {
+    return trimmed.length > MAX_LENGTH ? trimmed.slice(0, MAX_LENGTH) + "..." : trimmed;
+  }
+
+  return fallback;
+}


### PR DESCRIPTION
## Summary

Ports the typed-error pattern from `conorbronsdon/podcastindex-mcp` v0.3.0 to this repo. That repo's `src/errors.ts` maps every HTTP failure to a status-specific error class (`AuthenticationError`, `RateLimitError`, `ValidationError`, `NotFoundError`, `ServerError`) via `mapHttpStatusToError`, with `extractErrorDetail` pulling a detail string out of an inconsistently-shaped error response body.

This repo already had a two-class start (`SubstackAPIError` base + `AuthenticationError` for 401/403). This PR extends it rather than replacing it:

- Added `RateLimitError` (429), `ValidationError` (400), `NotFoundError` (404), `ServerError` (5xx) to `src/utils/errors.ts`, following `AuthenticationError`'s existing constructor convention.
- Added `mapHttpStatusToError(status, detail, endpoint)` to route a status code to the right class, falling back to the base `SubstackAPIError` for unmapped codes.
- Added `extractErrorDetail(responseData, fallback)` to pull a detail string out of an error response body.
- `src/api/client.ts`'s `request()` now calls `extractErrorDetail` once on the error body, then `mapHttpStatusToError` to throw the right class — replacing the old two-branch (401/403 vs. everything-else) logic.
- Bumped `package.json` and the hardcoded MCP server version in `src/server.ts` from `0.3.0` → `0.4.0`.
- Added a "Typed errors" section to the README.

## Substack-specific adaptations (vs. podcastindex-mcp)

- **Response body shape.** podcastindex-mcp's `extractErrorDetail` branches on a bare string vs. a `{ description }` JSON object (Axios leaves `response.data` already parsed or not). This repo's `client.ts` calls `fetch` directly and always gets a raw string from `response.text()`, and Substack's own error bodies vary further — JSON with `.error`, JSON with `.message`, JSON with an `.errors` array, plain text, or (per the README's existing Cloudflare section) a full HTML block page on custom domains returning `403 error code: 1010`. `extractErrorDetail` here tries `JSON.parse` first, checks `.error`/`.message`/`.errors`, and otherwise falls back to the raw text — trimmed and capped at ~500 characters so a multi-KB Cloudflare HTML page doesn't become the whole error message.
- **401/403 detail is intentionally discarded.** `mapHttpStatusToError` routes 401/403 to `new AuthenticationError(endpoint)` without passing `detail` through, because `AuthenticationError`'s constructor signature (`endpoint: string` only) was left unchanged on purpose — it's the exact hardcoded cookie-refresh message the 3 pre-existing tests assert on verbatim. This is called out in a code comment in `errors.ts`.
- **`ServerError`'s `statusCode` is hardcoded to 500** rather than threading through the real 5xx code (502/503/etc.), because its constructor follows the same `(endpoint, detail)` shape as the other three new classes (no separate status parameter). The typed class and message are still correct for any 5xx; only the numeric `statusCode` field on the error object loses precision for non-500 server errors.

## Test plan

- [x] `npm ci`
- [x] `npm run lint` (tsc --noEmit)
- [x] `npm run build`
- [x] `npm test` — extended `src/__tests__/errors.test.ts` with new classes, `mapHttpStatusToError` (all 6 buckets incl. unmapped-status fallback), and `extractErrorDetail` (JSON `.error`/`.message`/`.errors`, plain text, empty-string fallback, Cloudflare-HTML-style trim/cap); extended `src/__tests__/client.test.ts` with end-to-end coverage of 401/403/429/400/404/500/418 hitting `request()`
- [x] `npm audit --audit-level=high` — 11 pre-existing findings (vitest/vite/hono/express toolchain, all dev-only transitive deps), unrelated to this change, not touched

Test count: 52 → 79 unique tests (158 reported by `npm test` after `npm run build`, because this repo's `dist/` build output is picked up by vitest alongside the `src/` sources and every test runs twice — a pre-existing quirk, reproduced on unmodified `main`, not introduced by this PR).

**Merging this PR will trigger `publish.yml`**, which auto-publishes to npm on any push to `main` that changes `package.json`'s version. This PR changes it from `0.3.0` to `0.4.0`. Not merging — leaving that to Conor.