### PR TITLE
Converter: nested lists, GFM table fallback, h4-h6 paragraph fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,10 +170,12 @@ The `create_draft` and `update_draft` tools accept markdown and convert it to Su
 - **Bold**, *italic*, `inline code`
 - [Links](https://example.com)
 - Images
-- Bullet and numbered lists
+- Bullet and numbered lists, including **nested lists** (arbitrary depth, mixed ordered/unordered)
 - Code blocks (with language)
 - Blockquotes
 - Horizontal rules
+
+**Tables:** Substack's post editor has no table node, so a markdown table cannot be rendered natively. Rather than mangle the pipes into a paragraph, a detected GFM table is preserved verbatim inside a code block — the content survives so you can reformat it (as an image or embed) in Substack's editor.
 
 ## Important notes
 

--- a/src/__tests__/markdown-to-prosemirror.test.ts
+++ b/src/__tests__/markdown-to-prosemirror.test.ts
@@ -198,6 +198,25 @@ describe("markdownToProseMirror", () => {
     });
   });
 
+  describe("nested list robustness (no data loss)", () => {
+    it("keeps a leading over-indented item as its own top-level list", () => {
+      // Regression: the old min-indent recursion silently dropped a leading
+      // deeper-indented item. Nothing may be lost.
+      const doc = parse("  - deep first\n- shallow");
+      const json = JSON.stringify(doc);
+      expect(json).toContain("deep first");
+      expect(json).toContain("shallow");
+    });
+
+    it("preserves every item when indentation jumps 0 -> 4 -> 2", () => {
+      const doc = parse("- a\n    - b\n  - c");
+      const json = JSON.stringify(doc);
+      expect(json).toContain('"a"');
+      expect(json).toContain('"b"');
+      expect(json).toContain('"c"');
+    });
+  });
+
   describe("paragraph termination", () => {
     it("does not swallow a following h4-h6 heading into the paragraph", () => {
       const doc = parse("Some text\n#### Deep heading");
@@ -206,6 +225,29 @@ describe("markdownToProseMirror", () => {
       expect(doc.content[0].content[0].text).toBe("Some text");
       expect(doc.content[1].type).toBe("heading");
       expect(doc.content[1].attrs.level).toBe(4);
+    });
+
+    it("consumes an indented heading (no hang) and emits a heading node", () => {
+      const doc = parse("   # Indented heading");
+      expect(doc.content).toHaveLength(1);
+      expect(doc.content[0].type).toBe("heading");
+      expect(doc.content[0].attrs.level).toBe(1);
+      expect(doc.content[0].content[0].text).toBe("Indented heading");
+    });
+
+    it("consumes an indented image line (no hang) and emits captionedImage", () => {
+      const doc = parse("  ![alt](https://example.com/y.png)");
+      expect(doc.content).toHaveLength(1);
+      expect(doc.content[0].type).toBe("captionedImage");
+      expect(doc.content[0].attrs.src).toBe("https://example.com/y.png");
+    });
+
+    it("separates a paragraph from a following indented heading", () => {
+      const doc = parse("intro\n   ## Sub");
+      expect(doc.content).toHaveLength(2);
+      expect(doc.content[0].type).toBe("paragraph");
+      expect(doc.content[1].type).toBe("heading");
+      expect(doc.content[1].attrs.level).toBe(2);
     });
   });
 

--- a/src/__tests__/markdown-to-prosemirror.test.ts
+++ b/src/__tests__/markdown-to-prosemirror.test.ts
@@ -104,6 +104,111 @@ describe("markdownToProseMirror", () => {
     });
   });
 
+  describe("nested lists", () => {
+    it("nests a deeper-indented bullet inside the parent list_item", () => {
+      const md = "- Parent\n  - Child\n- Sibling";
+      const doc = parse(md);
+      const list = doc.content[0];
+      expect(doc.content).toHaveLength(1);
+      expect(list.type).toBe("bullet_list");
+      expect(list.content).toHaveLength(2); // Parent, Sibling
+
+      const parent = list.content[0];
+      expect(parent.content[0].content[0].text).toBe("Parent");
+      // Parent's second child is the nested list
+      const nested = parent.content[1];
+      expect(nested.type).toBe("bullet_list");
+      expect(nested.content).toHaveLength(1);
+      expect(nested.content[0].content[0].content[0].text).toBe("Child");
+
+      // Sibling stays at the top level, no nested list
+      expect(list.content[1].content[0].content[0].text).toBe("Sibling");
+      expect(list.content[1].content).toHaveLength(1);
+    });
+
+    it("nests to arbitrary depth", () => {
+      const md = "- L1\n  - L2\n    - L3";
+      const doc = parse(md);
+      const l1Item = doc.content[0].content[0];
+      const l2 = l1Item.content[1];
+      expect(l2.type).toBe("bullet_list");
+      const l2Item = l2.content[0];
+      const l3 = l2Item.content[1];
+      expect(l3.type).toBe("bullet_list");
+      expect(l3.content[0].content[0].content[0].text).toBe("L3");
+    });
+
+    it("nests an ordered list inside a bullet item (mixed types)", () => {
+      const md = "- Bullet\n  1. One\n  2. Two";
+      const doc = parse(md);
+      const bulletItem = doc.content[0].content[0];
+      const nested = bulletItem.content[1];
+      expect(nested.type).toBe("ordered_list");
+      expect(nested.content).toHaveLength(2);
+      expect(nested.content[1].content[0].content[0].text).toBe("Two");
+    });
+
+    it("starts a new sibling list when the marker type flips at the same level", () => {
+      const md = "- Bullet\n1. Number";
+      const doc = parse(md);
+      expect(doc.content).toHaveLength(2);
+      expect(doc.content[0].type).toBe("bullet_list");
+      expect(doc.content[1].type).toBe("ordered_list");
+    });
+
+    it("treats 4-space indentation as one nesting level", () => {
+      const md = "- Parent\n    - Child";
+      const doc = parse(md);
+      const parent = doc.content[0].content[0];
+      expect(parent.content[1].type).toBe("bullet_list");
+      expect(parent.content[1].content[0].content[0].content[0].text).toBe(
+        "Child",
+      );
+    });
+  });
+
+  describe("tables (Substack has no table node — code_block fallback)", () => {
+    it("preserves a GFM table verbatim inside a code_block", () => {
+      const md = "| A | B |\n| --- | --- |\n| 1 | 2 |";
+      const doc = parse(md);
+      expect(doc.content).toHaveLength(1);
+      const node = doc.content[0];
+      expect(node.type).toBe("code_block");
+      expect(node.content[0].text).toBe(md);
+    });
+
+    it("supports alignment colons in the delimiter row", () => {
+      const md = "| L | R |\n|:---|---:|\n| a | b |";
+      const doc = parse(md);
+      expect(doc.content[0].type).toBe("code_block");
+      expect(doc.content[0].content[0].text).toContain(":---");
+    });
+
+    it("separates a preceding paragraph from the table", () => {
+      const doc = parse("Intro line\n| A | B |\n| --- | --- |\n| 1 | 2 |");
+      expect(doc.content).toHaveLength(2);
+      expect(doc.content[0].type).toBe("paragraph");
+      expect(doc.content[0].content[0].text).toBe("Intro line");
+      expect(doc.content[1].type).toBe("code_block");
+    });
+
+    it("does not treat a paragraph containing a lone pipe as a table", () => {
+      const doc = parse("a | b is just prose");
+      expect(doc.content[0].type).toBe("paragraph");
+    });
+  });
+
+  describe("paragraph termination", () => {
+    it("does not swallow a following h4-h6 heading into the paragraph", () => {
+      const doc = parse("Some text\n#### Deep heading");
+      expect(doc.content).toHaveLength(2);
+      expect(doc.content[0].type).toBe("paragraph");
+      expect(doc.content[0].content[0].text).toBe("Some text");
+      expect(doc.content[1].type).toBe("heading");
+      expect(doc.content[1].attrs.level).toBe(4);
+    });
+  });
+
   describe("horizontal rules", () => {
     it("converts --- to horizontal_rule", () => {
       const doc = parse("---");

--- a/src/utils/markdown-to-prosemirror.ts
+++ b/src/utils/markdown-to-prosemirror.ts
@@ -97,60 +97,76 @@ function startsBlock(line: string): boolean {
   );
 }
 
+/** A live nesting level while lists are being assembled. */
+interface ListFrame {
+  indent: number;
+  ordered: boolean;
+  list: PMNode;
+  lastItem: PMNode | null;
+}
+
 /**
  * Build ProseMirror list nodes from a flat, ordered run of list items.
  *
- * Nesting is recovered from indentation: items at the run's minimum indent are
- * siblings; any deeper-indented items immediately following an item become a
- * nested list inside that item's `list_item` (after its paragraph). A change
- * of marker type at the same indent starts a new sibling list, matching how
- * ProseMirror models "a bullet list then a numbered list".
+ * A stack tracks the open nesting levels. A deeper indent opens a nested list
+ * inside the current item; a shallower indent closes levels; a marker-type
+ * flip at the same indent starts a sibling list of the other kind. The design
+ * goal is that NO item is ever dropped — a leading over-indented item with no
+ * parent simply becomes its own top-level list rather than being discarded, so
+ * even malformed indentation round-trips its content.
  */
 function buildListNodes(raws: ListItemRaw[]): PMNode[] {
-  const result: PMNode[] = [];
-  if (raws.length === 0) return result;
+  const root: PMNode[] = [];
+  const stack: ListFrame[] = [];
 
-  const baseIndent = Math.min(...raws.map((r) => r.indent));
-  let currentList: PMNode | null = null;
-  let currentOrdered: boolean | null = null;
-  let idx = 0;
+  const openList = (ordered: boolean): PMNode => ({
+    type: ordered ? "ordered_list" : "bullet_list",
+    content: [],
+  });
 
-  while (idx < raws.length) {
-    const raw = raws[idx];
-
-    if (raw.indent === baseIndent) {
-      // Start a new list when there is none yet or the marker type flipped.
-      if (currentList === null || currentOrdered !== raw.ordered) {
-        currentList = {
-          type: raw.ordered ? "ordered_list" : "bullet_list",
-          content: [],
-        };
-        currentOrdered = raw.ordered;
-        result.push(currentList);
-      }
-
-      const item: PMNode = {
-        type: "list_item",
-        content: [{ type: "paragraph", content: parseInline(raw.text) }],
-      };
-      currentList.content!.push(item);
-
-      // Gather the contiguous, deeper-indented items that belong under this
-      // one and recurse to build the nested list(s).
-      let j = idx + 1;
-      while (j < raws.length && raws[j].indent > baseIndent) j++;
-      if (j > idx + 1) {
-        item.content!.push(...buildListNodes(raws.slice(idx + 1, j)));
-      }
-      idx = j;
-    } else {
-      // baseIndent is the minimum, so this branch is unreachable for
-      // well-formed input; advance defensively to avoid a stuck loop.
-      idx++;
+  for (const raw of raws) {
+    // Close any levels deeper than this item.
+    while (stack.length && raw.indent < stack[stack.length - 1].indent) {
+      stack.pop();
     }
+
+    let top: ListFrame | undefined = stack[stack.length - 1];
+
+    if (!top || raw.indent > top.indent) {
+      // Open a nested list under the current item, or a new root list when
+      // there is no enclosing item (including a leading over-indented item).
+      const list = openList(raw.ordered);
+      if (top && top.lastItem) {
+        top.lastItem.content!.push(list);
+      } else {
+        root.push(list);
+      }
+      top = { indent: raw.indent, ordered: raw.ordered, list, lastItem: null };
+      stack.push(top);
+    } else if (raw.ordered !== top.ordered) {
+      // Same level, different marker → a sibling list of the other kind,
+      // attached wherever the current list lives (parent item, or root).
+      const list = openList(raw.ordered);
+      const parent = stack[stack.length - 2];
+      if (parent && parent.lastItem) {
+        parent.lastItem.content!.push(list);
+      } else {
+        root.push(list);
+      }
+      stack.pop();
+      top = { indent: raw.indent, ordered: raw.ordered, list, lastItem: null };
+      stack.push(top);
+    }
+
+    const item: PMNode = {
+      type: "list_item",
+      content: [{ type: "paragraph", content: parseInline(raw.text) }],
+    };
+    top.list.content!.push(item);
+    top.lastItem = item;
   }
 
-  return result;
+  return root;
 }
 
 export function markdownToProseMirror(markdown: string): string {
@@ -192,8 +208,11 @@ export function markdownToProseMirror(markdown: string): string {
       continue;
     }
 
-    // Heading
-    const headingMatch = line.match(HEADING_RE);
+    // Heading. Match the left-trimmed line so an indented `  # h` (valid up to
+    // 3 leading spaces in CommonMark) is consumed here — this MUST agree with
+    // startsBlock's trimmed test, or such a line would be flagged as a block
+    // start yet consumed by nothing, stalling the loop.
+    const headingMatch = line.trimStart().match(HEADING_RE);
     if (headingMatch) {
       const level = headingMatch[1].length;
       nodes.push({
@@ -255,8 +274,9 @@ export function markdownToProseMirror(markdown: string): string {
       continue;
     }
 
-    // Image (standalone line)
-    const imgMatch = line.match(IMAGE_LINE_RE);
+    // Image (standalone line). Left-trimmed for the same reason as headings:
+    // it must agree with startsBlock so an indented image line is consumed.
+    const imgMatch = line.trimStart().match(IMAGE_LINE_RE);
     if (imgMatch) {
       nodes.push({
         type: "captionedImage",
@@ -291,6 +311,12 @@ export function markdownToProseMirror(markdown: string): string {
           content: inlineContent,
         });
       }
+    } else {
+      // Safety net: a line was flagged as a block start (startsBlock/startsTable)
+      // but no dispatch branch above consumed it. Advance unconditionally so
+      // the main loop can never stall, whatever future edits do to the two
+      // sets of predicates.
+      i++;
     }
   }
 

--- a/src/utils/markdown-to-prosemirror.ts
+++ b/src/utils/markdown-to-prosemirror.ts
@@ -2,7 +2,15 @@
  * Converts markdown to Substack's ProseMirror JSON format.
  *
  * Supports: paragraphs, headings (h1-h6), bold, italic, links, images,
- * bullet lists, ordered lists, code blocks, blockquotes, horizontal rules.
+ * bullet lists, ordered lists, NESTED lists (arbitrary depth, mixed
+ * ordered/unordered), code blocks, blockquotes, horizontal rules.
+ *
+ * Tables: Substack's post schema has NO table node (its editor never
+ * integrated prosemirror-tables), so a GFM table cannot be represented
+ * natively. Rather than let the pipes collapse into a mangled paragraph, a
+ * detected table is preserved verbatim inside a `code_block` — monospace
+ * keeps the columns aligned and the content survives round-trip so the author
+ * can reformat it (as an image/embed) in Substack's editor.
  */
 
 interface PMNode {
@@ -16,6 +24,133 @@ interface PMNode {
 interface PMMark {
   type: string;
   attrs?: Record<string, unknown>;
+}
+
+/** A single markdown list item, flattened with its indentation depth. */
+interface ListItemRaw {
+  /** Leading-whitespace width, tabs counted as 4 columns. */
+  indent: number;
+  ordered: boolean;
+  text: string;
+}
+
+// A list item: optional leading whitespace, a bullet (-, *, +) or an ordered
+// marker (`1.`), one or more spaces, then the item text. The capture groups
+// are used to recover indentation, list type, and content.
+const LIST_ITEM_RE = /^(\s*)([-*+]|\d+\.)\s+(.*)$/;
+const HEADING_RE = /^(#{1,6})\s+(.+)$/;
+const HR_RE = /^(-{3,}|\*{3,}|_{3,})\s*$/;
+const IMAGE_LINE_RE = /^!\[([^\]]*)\]\(([^)]+)\)\s*$/;
+
+/**
+ * True for a GFM table delimiter row — the `|---|:--:|` line under the header.
+ * Every pipe-separated cell must be dashes with optional alignment colons.
+ */
+function isTableDelimiter(line: string): boolean {
+  const trimmed = line.trim();
+  if (!trimmed.includes("-")) return false;
+  const cells = trimmed.replace(/^\|/, "").replace(/\|$/, "").split("|");
+  return cells.length > 0 && cells.every((c) => /^\s*:?-+:?\s*$/.test(c));
+}
+
+/** A line that could be a table row: non-blank and containing a pipe. */
+function looksLikeTableRow(line: string): boolean {
+  return line.trim().length > 0 && line.includes("|");
+}
+
+/**
+ * True when a GFM table starts at `lines[idx]`: a pipe row immediately
+ * followed by a delimiter row. Requires the two-line lookahead so an ordinary
+ * paragraph that merely contains a pipe is not misread as a table.
+ */
+function startsTable(lines: string[], idx: number): boolean {
+  return (
+    looksLikeTableRow(lines[idx]) &&
+    idx + 1 < lines.length &&
+    isTableDelimiter(lines[idx + 1])
+  );
+}
+
+/** Width of a leading-whitespace run, counting each tab as 4 columns. */
+function indentWidth(whitespace: string): number {
+  let width = 0;
+  for (const ch of whitespace) width += ch === "\t" ? 4 : 1;
+  return width;
+}
+
+/**
+ * True when a line begins a block that is NOT a plain paragraph — used to
+ * terminate paragraph accumulation. Kept in sync with the block handlers in
+ * the main loop so a paragraph never swallows a following heading (h1-h6),
+ * list, blockquote, code fence, rule, or standalone image.
+ */
+function startsBlock(line: string): boolean {
+  const trimmed = line.trimStart();
+  return (
+    trimmed === "" ||
+    trimmed.startsWith("```") ||
+    HEADING_RE.test(trimmed) ||
+    trimmed.startsWith("> ") ||
+    HR_RE.test(line.trim()) ||
+    LIST_ITEM_RE.test(line) ||
+    IMAGE_LINE_RE.test(trimmed)
+  );
+}
+
+/**
+ * Build ProseMirror list nodes from a flat, ordered run of list items.
+ *
+ * Nesting is recovered from indentation: items at the run's minimum indent are
+ * siblings; any deeper-indented items immediately following an item become a
+ * nested list inside that item's `list_item` (after its paragraph). A change
+ * of marker type at the same indent starts a new sibling list, matching how
+ * ProseMirror models "a bullet list then a numbered list".
+ */
+function buildListNodes(raws: ListItemRaw[]): PMNode[] {
+  const result: PMNode[] = [];
+  if (raws.length === 0) return result;
+
+  const baseIndent = Math.min(...raws.map((r) => r.indent));
+  let currentList: PMNode | null = null;
+  let currentOrdered: boolean | null = null;
+  let idx = 0;
+
+  while (idx < raws.length) {
+    const raw = raws[idx];
+
+    if (raw.indent === baseIndent) {
+      // Start a new list when there is none yet or the marker type flipped.
+      if (currentList === null || currentOrdered !== raw.ordered) {
+        currentList = {
+          type: raw.ordered ? "ordered_list" : "bullet_list",
+          content: [],
+        };
+        currentOrdered = raw.ordered;
+        result.push(currentList);
+      }
+
+      const item: PMNode = {
+        type: "list_item",
+        content: [{ type: "paragraph", content: parseInline(raw.text) }],
+      };
+      currentList.content!.push(item);
+
+      // Gather the contiguous, deeper-indented items that belong under this
+      // one and recurse to build the nested list(s).
+      let j = idx + 1;
+      while (j < raws.length && raws[j].indent > baseIndent) j++;
+      if (j > idx + 1) {
+        item.content!.push(...buildListNodes(raws.slice(idx + 1, j)));
+      }
+      idx = j;
+    } else {
+      // baseIndent is the minimum, so this branch is unreachable for
+      // well-formed input; advance defensively to avoid a stuck loop.
+      idx++;
+    }
+  }
+
+  return result;
 }
 
 export function markdownToProseMirror(markdown: string): string {
@@ -51,14 +186,14 @@ export function markdownToProseMirror(markdown: string): string {
     }
 
     // Horizontal rule
-    if (/^(-{3,}|\*{3,}|_{3,})\s*$/.test(line.trim())) {
+    if (HR_RE.test(line.trim())) {
       nodes.push({ type: "horizontal_rule" });
       i++;
       continue;
     }
 
     // Heading
-    const headingMatch = line.match(/^(#{1,6})\s+(.+)$/);
+    const headingMatch = line.match(HEADING_RE);
     if (headingMatch) {
       const level = headingMatch[1].length;
       nodes.push({
@@ -89,48 +224,39 @@ export function markdownToProseMirror(markdown: string): string {
       continue;
     }
 
-    // Unordered list
-    if (/^[\s]*[-*+]\s/.test(line)) {
-      const items: PMNode[] = [];
-      while (i < lines.length && /^[\s]*[-*+]\s/.test(lines[i])) {
-        const itemText = lines[i].replace(/^[\s]*[-*+]\s/, "");
-        items.push({
-          type: "list_item",
-          content: [
-            { type: "paragraph", content: parseInline(itemText) },
-          ],
+    // List (ordered, unordered, and nested — one contiguous run)
+    if (LIST_ITEM_RE.test(line)) {
+      const raws: ListItemRaw[] = [];
+      while (i < lines.length && LIST_ITEM_RE.test(lines[i])) {
+        const m = lines[i].match(LIST_ITEM_RE)!;
+        raws.push({
+          indent: indentWidth(m[1]),
+          ordered: /\d/.test(m[2]),
+          text: m[3],
         });
         i++;
       }
-      nodes.push({
-        type: "bullet_list",
-        content: items,
-      });
+      nodes.push(...buildListNodes(raws));
       continue;
     }
 
-    // Ordered list
-    if (/^[\s]*\d+\.\s/.test(line)) {
-      const items: PMNode[] = [];
-      while (i < lines.length && /^[\s]*\d+\.\s/.test(lines[i])) {
-        const itemText = lines[i].replace(/^[\s]*\d+\.\s/, "");
-        items.push({
-          type: "list_item",
-          content: [
-            { type: "paragraph", content: parseInline(itemText) },
-          ],
-        });
+    // Table (GFM) — Substack has no table node, so preserve it verbatim in a
+    // code_block instead of mangling the pipes into a paragraph.
+    if (startsTable(lines, i)) {
+      const tableLines: string[] = [];
+      while (i < lines.length && looksLikeTableRow(lines[i])) {
+        tableLines.push(lines[i].replace(/\s+$/, ""));
         i++;
       }
       nodes.push({
-        type: "ordered_list",
-        content: items,
+        type: "code_block",
+        content: [{ type: "text", text: tableLines.join("\n") }],
       });
       continue;
     }
 
     // Image (standalone line)
-    const imgMatch = line.match(/^!\[([^\]]*)\]\(([^)]+)\)\s*$/);
+    const imgMatch = line.match(IMAGE_LINE_RE);
     if (imgMatch) {
       nodes.push({
         type: "captionedImage",
@@ -145,20 +271,12 @@ export function markdownToProseMirror(markdown: string): string {
       continue;
     }
 
-    // Default: paragraph — collect consecutive non-blank, non-special lines
+    // Default: paragraph — collect consecutive lines until the next block.
     const paraLines: string[] = [];
     while (
       i < lines.length &&
-      lines[i].trim() !== "" &&
-      !lines[i].trimStart().startsWith("```") &&
-      !lines[i].trimStart().startsWith("# ") &&
-      !lines[i].trimStart().startsWith("## ") &&
-      !lines[i].trimStart().startsWith("### ") &&
-      !lines[i].trimStart().startsWith("> ") &&
-      !/^(-{3,}|\*{3,}|_{3,})\s*$/.test(lines[i].trim()) &&
-      !/^[\s]*[-*+]\s/.test(lines[i]) &&
-      !/^[\s]*\d+\.\s/.test(lines[i]) &&
-      !/^!\[/.test(lines[i])
+      !startsBlock(lines[i]) &&
+      !startsTable(lines, i)
     ) {
       paraLines.push(lines[i]);
       i++;


### PR DESCRIPTION
## What

Three fidelity fixes to the markdown → ProseMirror converter, all driven by the review of `abanoub-ashraf/substack-mcp-plus` (whose regex converter has the same nested-list/table gaps).

### 1. Nested lists
Indentation was ignored — a sub-list became a sibling `list_item`. Now an indented run builds a real nested `bullet_list`/`ordered_list` inside the parent `list_item`, arbitrary depth, mixed marker types. A marker-type flip at the same indent starts a new sibling list (matching ProseMirror's model).

### 2. GFM tables → `code_block` fallback
Substack's post schema has **no table node** — verified against `python-substack`'s `NodeType` enum (`substack/nodes.py`): the full set is `doc, paragraph, heading, text, blockquote, codeBlock, horizontal_rule, bullet_list, ordered_list, list_item, footnote, footnoteAnchor, captionedImage, caption` — no `table`/`table_row`/`table_cell`. Emitting table nodes would produce invalid ProseMirror. So a detected GFM table is now preserved verbatim in a `code_block` (monospace keeps columns aligned; content round-trips for manual reformat) instead of collapsing into a pipe-soup paragraph.

### 3. h4–h6 paragraph terminator
The paragraph collector only stopped at h1–h3, so a deeper heading right after a paragraph got absorbed. The terminator now reuses a shared `startsBlock`/`startsTable` predicate covering every block type.

## Tests
+13 tests: nesting depth, mixed types, sibling-type flip, 4-space indent, table fallback, delimiter alignment, paragraph separation, lone-pipe false-positive, h4 termination. **178 pass, build clean.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)