### PR TITLE
Add read tools: get_sections, get_post_analytics, list_scheduled_posts

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,9 @@ Every tool declares MCP [tool annotations](https://modelcontextprotocol.io/docs/
 | `get_post` | Get full content of a published post by ID |
 | `get_draft` | Get full content of a draft by ID |
 | `get_post_comments` | Get comments on a published post |
+| `get_sections` | List your publication's sections (categories) with their IDs |
+| `get_post_analytics` | Get a published post's stats (views, opens, signups, subscribes, reactions) by ID |
+| `list_scheduled_posts` | List posts scheduled for future publication (read-only; scheduling stays in Substack's editor) |
 
 ### Write (private drafts; image upload returns a public URL)
 
@@ -69,7 +72,7 @@ Notes have no draft state on Substack, so there is no draft-first option for the
 
 - **Publish posts** — Publishing long-form posts should be a deliberate human action (Notes are the documented exception above)
 - **Delete** — Too destructive for an AI tool
-- **Schedule** — Use Substack's editor for scheduling
+- **Schedule** — Use Substack's editor for scheduling. (`list_scheduled_posts` *reads* what you've queued there, but this server never creates, edits, or cancels a schedule.)
 
 ## Setup
 

--- a/src/__tests__/annotations.test.ts
+++ b/src/__tests__/annotations.test.ts
@@ -24,6 +24,9 @@ const READ_TOOLS: ToolName[] = [
   "get_post",
   "get_draft",
   "get_post_comments",
+  "get_sections",
+  "get_post_analytics",
+  "list_scheduled_posts",
 ];
 
 const DRAFT_WRITE_TOOLS: ToolName[] = ["create_draft", "update_draft"];

--- a/src/__tests__/client.test.ts
+++ b/src/__tests__/client.test.ts
@@ -109,6 +109,20 @@ describe("SubstackClient requests", () => {
     expect(fetchMock.mock.calls[0][0]).toContain("/api/v1/subscriptions");
   });
 
+  it("getSections does not substring-match an unrelated publication host", async () => {
+    // `ample.substack.com` is a substring of `example.substack.com`; exact-host
+    // matching must skip it and return the real publication's sections.
+    stubFetch({
+      publications: [
+        { hostname: "ample.substack.com", sections: [{ id: 1, name: "Wrong" }] },
+        { hostname: "example.substack.com", sections: [{ id: 2, name: "Right" }] },
+      ],
+    });
+    const client = new SubstackClient("https://example.substack.com", "tok", "1");
+    const sections = await client.getSections();
+    expect(sections).toEqual([{ id: 2, name: "Right" }]);
+  });
+
   it("getSections returns [] when no publication matches", async () => {
     stubFetch({ publications: [{ hostname: "nope.substack.com", sections: [{ id: 1, name: "X" }] }] });
     const client = new SubstackClient("https://example.substack.com", "tok", "1");

--- a/src/__tests__/client.test.ts
+++ b/src/__tests__/client.test.ts
@@ -72,6 +72,90 @@ describe("SubstackClient requests", () => {
     expect(calledUrl).not.toContain("/api/v1/drafts?");
   });
 
+  it("getSections matches the publication by hostname and returns its sections", async () => {
+    const fetchMock = stubFetch({
+      publications: [
+        { hostname: "other.substack.com", sections: [{ id: 1, name: "Other" }] },
+        {
+          hostname: "example.substack.com",
+          sections: [
+            { id: 10, name: "Essays" },
+            { id: 11, name: "Notes" },
+          ],
+        },
+      ],
+    });
+    const client = new SubstackClient("https://example.substack.com", "tok", "1");
+    const sections = await client.getSections();
+
+    expect(sections).toHaveLength(2);
+    expect(sections[0]).toEqual({ id: 10, name: "Essays" });
+    expect(fetchMock.mock.calls[0][0]).toContain("/api/v1/subscriptions");
+  });
+
+  it("getSections matches on custom_domain when hostname does not match", async () => {
+    const fetchMock = stubFetch({
+      publications: [
+        {
+          hostname: "example.substack.com",
+          custom_domain: "newsletter.example.com",
+          sections: [{ id: 7, name: "Custom" }],
+        },
+      ],
+    });
+    const client = new SubstackClient("https://newsletter.example.com", "tok", "1");
+    const sections = await client.getSections();
+    expect(sections).toEqual([{ id: 7, name: "Custom" }]);
+    expect(fetchMock.mock.calls[0][0]).toContain("/api/v1/subscriptions");
+  });
+
+  it("getSections returns [] when no publication matches", async () => {
+    stubFetch({ publications: [{ hostname: "nope.substack.com", sections: [{ id: 1, name: "X" }] }] });
+    const client = new SubstackClient("https://example.substack.com", "tok", "1");
+    expect(await client.getSections()).toEqual([]);
+  });
+
+  it("getScheduledPosts uses the scheduled view ordered by trigger_at asc", async () => {
+    const fetchMock = stubFetch({
+      posts: [{ id: 5, draft_title: "Queued", audience: "everyone", trigger_at: "2030-01-01T00:00:00Z" }],
+    });
+    const client = new SubstackClient("https://example.substack.com", "tok", "1");
+    const posts = await client.getScheduledPosts(0, 10);
+
+    expect(posts).toHaveLength(1);
+    expect(posts[0].id).toBe(5);
+    const url = fetchMock.mock.calls[0][0] as string;
+    expect(url).toContain("/api/v1/post_management/scheduled");
+    expect(url).toContain("order_by=trigger_at");
+    expect(url).toContain("order_direction=asc");
+  });
+
+  it("getPostAnalytics finds a post's stats row in the published feed", async () => {
+    const fetchMock = stubFetch({
+      posts: [
+        { id: 100, title: "A", stats: { views: 1 } },
+        { id: 200, title: "B", stats: { views: 42, opened: 10 } },
+      ],
+      total: 2,
+    });
+    const client = new SubstackClient("https://example.substack.com", "tok", "1");
+    const post = await client.getPostAnalytics(200);
+
+    expect(post?.id).toBe(200);
+    expect(post?.stats?.views).toBe(42);
+    expect(fetchMock.mock.calls[0][0]).toContain("/api/v1/post_management/published");
+  });
+
+  it("getPostAnalytics returns null and stops paging when the feed is exhausted", async () => {
+    const fetchMock = stubFetch({ posts: [{ id: 1, title: "only" }], total: 1 });
+    const client = new SubstackClient("https://example.substack.com", "tok", "1");
+    const post = await client.getPostAnalytics(999);
+
+    expect(post).toBeNull();
+    // A short page (1 < 100) means end-of-feed: exactly one request, no over-paging.
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
   it("sends a browser User-Agent and a Referer by default", async () => {
     const fetchMock = stubFetch({ posts: [] });
     const client = new SubstackClient("https://example.substack.com", "tok", "1");

--- a/src/annotations.ts
+++ b/src/annotations.ts
@@ -61,6 +61,9 @@ export const TOOL_KINDS = {
   get_post: "read",
   get_draft: "read",
   get_post_comments: "read",
+  get_sections: "read",
+  get_post_analytics: "read",
+  list_scheduled_posts: "read",
   // Additive writes to private draft state (nothing reachable outside account)
   create_draft: "draft-write",
   update_draft: "draft-write",

--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -9,6 +9,8 @@ import {
   DraftCreatePayload,
   DraftUpdatePayload,
   ImageUploadResult,
+  SubstackSection,
+  SubstackScheduledPost,
 } from "./types.js";
 import { mapHttpStatusToError, extractErrorDetail } from "../utils/errors.js";
 
@@ -203,6 +205,57 @@ export class SubstackClient {
     );
     const comments = data.comments || [];
     return comments.slice(0, limit);
+  }
+
+  async getSections(): Promise<SubstackSection[]> {
+    // Substack exposes no dedicated sections endpoint; the sections list rides
+    // along on the subscriptions payload, one entry per publication you belong
+    // to. Pick the entry whose hostname (or custom domain) matches this
+    // publication. Mirrors python-substack's approach, extended to also match
+    // on custom_domain so custom-domain publications resolve correctly.
+    const data = await this.request<{
+      publications?: Array<{
+        hostname?: string;
+        custom_domain?: string | null;
+        sections?: SubstackSection[];
+      }>;
+    }>(`${this.publicationUrl}/api/v1/subscriptions`);
+
+    const publications = data.publications || [];
+    const match = publications.find(
+      (p) =>
+        (p.hostname && this.publicationUrl.includes(p.hostname)) ||
+        (p.custom_domain && this.publicationUrl.includes(p.custom_domain)),
+    );
+    return match?.sections || [];
+  }
+
+  async getScheduledPosts(
+    offset = 0,
+    limit = 25,
+  ): Promise<SubstackScheduledPost[]> {
+    // `scheduled` is a distinct post_management view (sibling of `published`
+    // and `drafts`). Each row carries a `trigger_at` future publish time.
+    const data = await this.request<{ posts?: SubstackScheduledPost[] }>(
+      `${this.publicationUrl}/api/v1/post_management/scheduled?offset=${offset}&limit=${limit}&order_by=trigger_at&order_direction=asc`,
+    );
+    return data.posts || [];
+  }
+
+  async getPostAnalytics(postId: number): Promise<SubstackPost | null> {
+    // Substack has no per-post stats endpoint. Each row of the published
+    // feed already carries a `stats` object, so page through the feed
+    // (newest first) until the matching id turns up. Bounded so a bad id
+    // can't scan forever: up to 500 of the most recent published posts.
+    const pageSize = 100;
+    const maxPages = 5;
+    for (let page = 0; page < maxPages; page++) {
+      const { posts } = await this.getPublishedPosts(page * pageSize, pageSize);
+      const found = posts.find((p) => p.id === postId);
+      if (found) return found;
+      if (posts.length < pageSize) break; // reached the end of the feed
+    }
+    return null;
   }
 
   async createNote(

--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -222,10 +222,18 @@ export class SubstackClient {
     }>(`${this.publicationUrl}/api/v1/subscriptions`);
 
     const publications = data.publications || [];
+    // Match on exact host, not substring — the subscriptions payload lists
+    // every publication you follow, so `includes` would let an unrelated
+    // `ample.substack.com` match `example.substack.com` and return the wrong
+    // sections.
+    let host: string;
+    try {
+      host = new URL(this.publicationUrl).hostname;
+    } catch {
+      host = this.publicationUrl;
+    }
     const match = publications.find(
-      (p) =>
-        (p.hostname && this.publicationUrl.includes(p.hostname)) ||
-        (p.custom_domain && this.publicationUrl.includes(p.custom_domain)),
+      (p) => p.hostname === host || p.custom_domain === host,
     );
     return match?.sections || [];
   }

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -59,7 +59,6 @@ export interface SubstackPost {
 export interface SubstackSection {
   id: number;
   name: string;
-  hostname?: string;
 }
 
 /**
@@ -72,7 +71,7 @@ export interface SubstackScheduledPost {
   title?: string | null;
   audience: string;
   trigger_at: string | null;
-  post_date: string | null;
+  post_date?: string | null;
 }
 
 export interface SubstackDraft {

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -16,6 +16,22 @@ export interface SubstackPublication {
   theme_var_background_pop: string | null;
 }
 
+/**
+ * Per-post performance metrics. Substack has no dedicated per-post stats
+ * endpoint — these fields ride along on each row of the
+ * `post_management/published` feed. All are optional because Substack omits
+ * them for posts that were never emailed.
+ */
+export interface PostStats {
+  views?: number;
+  sent?: number;
+  delivered?: number;
+  opened?: number;
+  signups?: number;
+  subscribes?: number;
+  estimated_value?: number | null;
+}
+
 export interface SubstackPost {
   id: number;
   title: string;
@@ -33,6 +49,30 @@ export interface SubstackPost {
   description: string | null;
   cover_image: string | null;
   section_id: number | null;
+  stats?: PostStats;
+  comment_count?: number;
+  reaction_count?: number;
+  email_sent_at?: string | null;
+}
+
+/** A publication section (category). Assign a draft via `section_id`. */
+export interface SubstackSection {
+  id: number;
+  name: string;
+  hostname?: string;
+}
+
+/**
+ * A row from the `post_management/scheduled` feed: a draft with a future
+ * publish time. `trigger_at` is what distinguishes it from a plain draft.
+ */
+export interface SubstackScheduledPost {
+  id: number;
+  draft_title: string | null;
+  title?: string | null;
+  audience: string;
+  trigger_at: string | null;
+  post_date: string | null;
 }
 
 export interface SubstackDraft {

--- a/src/server.ts
+++ b/src/server.ts
@@ -186,6 +186,104 @@ export function createServer(client: SubstackClient): McpServer {
     },
   );
 
+  server.registerTool(
+    "get_sections",
+    {
+      description:
+        "List your publication's sections (categories). Returns each section's id and name. Use a section id as `section_id` when creating or updating a draft to file it under that section.",
+      inputSchema: {},
+      annotations: buildAnnotations("get_sections"),
+    },
+    async () => {
+      const sections = await client.getSections();
+      const summary = sections.map((s) => ({ id: s.id, name: s.name }));
+      return {
+        content: [{ type: "text", text: JSON.stringify(summary, null, 2) }],
+      };
+    },
+  );
+
+  server.registerTool(
+    "get_post_analytics",
+    {
+      description:
+        "Get performance stats (views, emails sent/delivered/opened, signups, subscribes, comments, reactions) for a published post by ID. Substack has no per-post stats endpoint, so this searches your 500 most recent published posts for the ID; returns a not-found note if it isn't among them.",
+      inputSchema: {
+        post_id: z.number().describe("The published post ID to get stats for"),
+      },
+      annotations: buildAnnotations("get_post_analytics"),
+    },
+    async ({ post_id }) => {
+      const post = await client.getPostAnalytics(post_id);
+      if (!post) {
+        return {
+          content: [
+            {
+              type: "text",
+              text: JSON.stringify({
+                found: false,
+                post_id,
+                note: "Post not found among the 500 most recent published posts. Check the ID with list_published_posts.",
+              }),
+            },
+          ],
+        };
+      }
+      const stats = post.stats ?? {};
+      return {
+        content: [
+          {
+            type: "text",
+            text: JSON.stringify(
+              {
+                found: true,
+                id: post.id,
+                title: post.title,
+                post_date: post.post_date,
+                views: stats.views ?? null,
+                sent: stats.sent ?? null,
+                delivered: stats.delivered ?? null,
+                opened: stats.opened ?? null,
+                signups: stats.signups ?? null,
+                subscribes: stats.subscribes ?? null,
+                estimated_value: stats.estimated_value ?? null,
+                comment_count: post.comment_count ?? null,
+                reaction_count: post.reaction_count ?? null,
+              },
+              null,
+              2,
+            ),
+          },
+        ],
+      };
+    },
+  );
+
+  server.registerTool(
+    "list_scheduled_posts",
+    {
+      description:
+        "List posts scheduled for future publication, soonest first. Read-only visibility into what's queued — scheduling itself is done in Substack's editor (this server does not schedule, publish, or delete long-form posts). Returns id, title, audience, and scheduled time (`trigger_at`).",
+      inputSchema: {
+        offset: z.number().optional().default(0).describe("Number of posts to skip"),
+        limit: z.number().optional().default(25).describe("Max posts to return (1-100)"),
+      },
+      annotations: buildAnnotations("list_scheduled_posts"),
+    },
+    async ({ offset, limit }) => {
+      const posts = await client.getScheduledPosts(offset, Math.min(limit, 100));
+      const summary = posts.map((p) => ({
+        id: p.id,
+        title: p.draft_title ?? p.title ?? null,
+        audience: p.audience,
+        scheduled_at: p.trigger_at,
+      }));
+      return {
+        content: [{ type: "text", text: JSON.stringify(summary, null, 2) }],
+      };
+    },
+  );
+
   // --- Write tools (additive: private drafts + a public-URL image upload) ---
 
   server.registerTool(

--- a/src/server.ts
+++ b/src/server.ts
@@ -207,7 +207,7 @@ export function createServer(client: SubstackClient): McpServer {
     "get_post_analytics",
     {
       description:
-        "Get performance stats (views, emails sent/delivered/opened, signups, subscribes, comments, reactions) for a published post by ID. Substack has no per-post stats endpoint, so this searches your 500 most recent published posts for the ID; returns a not-found note if it isn't among them.",
+        "Get performance stats (views, emails sent/delivered/opened, signups, subscribes, estimated value, comments, reactions) for a published post by ID. Substack has no per-post stats endpoint, so this searches your 500 most recent published posts for the ID; returns a not-found note if it isn't among them.",
       inputSchema: {
         post_id: z.number().describe("The published post ID to get stats for"),
       },
@@ -220,11 +220,15 @@ export function createServer(client: SubstackClient): McpServer {
           content: [
             {
               type: "text",
-              text: JSON.stringify({
-                found: false,
-                post_id,
-                note: "Post not found among the 500 most recent published posts. Check the ID with list_published_posts.",
-              }),
+              text: JSON.stringify(
+                {
+                  found: false,
+                  post_id,
+                  note: "Post not found among the 500 most recent published posts. Check the ID with list_published_posts.",
+                },
+                null,
+                2,
+              ),
             },
           ],
         };


### PR DESCRIPTION
## What

Three new **read** tools, filling gaps found while reviewing `abanoub-ashraf/substack-mcp-plus`. Every endpoint path is verified against `python-substack`'s source (the library that server is built on). All reads — the no-publish/no-schedule/no-delete boundary is unchanged.

| Tool | Endpoint | Notes |
|------|----------|-------|
| `get_sections` | `GET /api/v1/subscriptions` | Picks the publication matching our hostname **or custom_domain**, returns its `sections` (`{id, name}`). Section ids feed the existing draft `section_id`. |
| `get_post_analytics` | `GET /api/v1/post_management/published` | Substack has **no per-post stats endpoint** — stats ride on each published-feed row. Pages the feed (newest first, **capped at 500 posts**) to find the id; returns views/sent/delivered/opened/signups/subscribes/reactions, or a clear not-found note past the cap. |
| `list_scheduled_posts` | `GET /api/v1/post_management/scheduled` | Distinct management view; rows carry `trigger_at`. Read-only visibility into what's queued in the editor. |

### Design notes
- **`get_post_analytics` is bounded on purpose.** No id-lookup endpoint exists, so it linearly scans up to 5×100 posts and stops early at end-of-feed. For a typical newsletter that's every post; past 500 it returns a not-found note rather than paging forever.
- **`get_sections` extends python-substack's hostname-only match** to also match `custom_domain`, so custom-domain publications resolve.
- **A fourth candidate — `preview_draft` — was intentionally dropped.** Substack exposes no API for a shareable draft-preview token (verified: both reference libs fall back to author-only login URLs). Shipping it would fake a capability, so it's omitted.

## Tests
+8 client tests (hostname & custom_domain matching, no-match `[]`, scheduled-view ordering, analytics hit, analytics end-of-feed stops paging). Annotations completeness test now covers 14 tools. **170 pass, build clean.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)