### PR TITLE
Optional browser-login flow + encrypted local session storage

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,33 @@ Notes have no draft state on Substack, so there is no draft-first option for the
 
 ## Setup
 
-### 1. Get your credentials
+You can supply credentials two ways: paste them as env vars (below), or run the
+optional **browser login** which captures and stores them for you.
+
+### Option A — Browser login (optional, no manual cookie copying)
+
+Removes the DevTools cookie hunt and the ~90-day re-copy. Playwright is **not**
+bundled (it's large), so install it once, then sign in:
+
+```bash
+npm i -g playwright && npx playwright install chromium
+npx --package @conorbronsdon/substack-mcp substack-mcp-login https://yourblog.substack.com
+```
+
+A browser opens; sign in to Substack (CAPTCHA included). The tool captures your
+session cookie, auto-resolves your user id, and writes them to
+`~/.substack-mcp/session.json` (override the directory with `SUBSTACK_MCP_HOME`).
+The MCP server reads that file automatically whenever the `SUBSTACK_*` env vars
+are unset — so with browser login you can omit the `env` block entirely.
+
+**Storage & security:** the file is written `0600` and encrypted with AES-256-GCM
+under a key derived from this OS account + machine (never stored). A copied file
+is useless elsewhere and casual disk/backup reads see only ciphertext. This is
+machine-binding + obfuscation, **not** a secret vault — code running as you on
+this machine can re-derive the key (the same caveat as the plaintext env-var
+path). If you prefer, use Option B and let your MCP client handle the secret.
+
+### Option B — Get your credentials manually
 
 Open your Substack in a browser, then:
 
@@ -132,7 +158,7 @@ Ask your AI assistant: "How many Substack subscribers do I have?"
 
 ## Token expiration
 
-Substack session tokens expire periodically (typically ~90 days). If you get authentication errors, grab a fresh `connect.sid` cookie from your browser and update the env var. Make sure ad blockers are disabled when copying the cookie.
+Substack session tokens expire periodically (typically ~90 days). If you get authentication errors, grab a fresh `connect.sid` cookie from your browser and update the env var (make sure ad blockers are disabled when copying the cookie) — or, if you used the browser login, just re-run `substack-mcp-login` to refresh the stored session.
 
 ## Custom domains & Cloudflare
 

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "MCP server for Substack — read posts, manage drafts, publish Notes. Long-form posts are draft-only by design (no publish, no delete); Notes publish immediately.",
   "type": "module",
   "bin": {
-    "substack-mcp": "./dist/index.js"
+    "substack-mcp": "./dist/index.js",
+    "substack-mcp-login": "./dist/login.js"
   },
   "scripts": {
     "build": "tsc",

--- a/src/__tests__/resolve-credentials.test.ts
+++ b/src/__tests__/resolve-credentials.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect } from "vitest";
+import { resolveCredentials } from "../auth/resolve-credentials.js";
+import type { StoredSession } from "../auth/session-store.js";
+
+const stored: StoredSession = {
+  publicationUrl: "https://stored.substack.com",
+  sessionToken: "stored-tok",
+  userId: "99",
+  savedAt: "2026-01-01T00:00:00Z",
+};
+
+describe("resolveCredentials", () => {
+  it("prefers env vars when present (source=env)", () => {
+    const env = {
+      SUBSTACK_PUBLICATION_URL: "https://env.substack.com",
+      SUBSTACK_SESSION_TOKEN: "env-tok",
+      SUBSTACK_USER_ID: "1",
+    } as NodeJS.ProcessEnv;
+    const r = resolveCredentials(env, () => stored);
+    expect(r.publicationUrl).toBe("https://env.substack.com");
+    expect(r.sessionToken).toBe("env-tok");
+    expect(r.userId).toBe("1");
+    expect(r.source).toBe("env");
+    expect(r.missing).toEqual([]);
+  });
+
+  it("falls back to the stored session when env vars are absent (source=stored)", () => {
+    const r = resolveCredentials({} as NodeJS.ProcessEnv, () => stored);
+    expect(r.publicationUrl).toBe("https://stored.substack.com");
+    expect(r.sessionToken).toBe("stored-tok");
+    expect(r.userId).toBe("99");
+    expect(r.source).toBe("stored");
+    expect(r.missing).toEqual([]);
+  });
+
+  it("mixes per field, env winning each present field (source=mixed)", () => {
+    const env = { SUBSTACK_SESSION_TOKEN: "env-tok" } as NodeJS.ProcessEnv;
+    const r = resolveCredentials(env, () => stored);
+    expect(r.sessionToken).toBe("env-tok"); // env
+    expect(r.publicationUrl).toBe("https://stored.substack.com"); // store
+    expect(r.userId).toBe("99"); // store
+    expect(r.source).toBe("mixed");
+    expect(r.missing).toEqual([]);
+  });
+
+  it("reports all missing when neither env nor store supplies them (source=none)", () => {
+    const r = resolveCredentials({} as NodeJS.ProcessEnv, () => null);
+    expect(r.missing).toEqual([
+      "SUBSTACK_PUBLICATION_URL",
+      "SUBSTACK_SESSION_TOKEN",
+      "SUBSTACK_USER_ID",
+    ]);
+    expect(r.source).toBe("none");
+    expect(r.publicationUrl).toBe("");
+  });
+
+  it("reports only still-missing fields with a partial store", () => {
+    const partial: StoredSession = { ...stored, userId: "" };
+    const r = resolveCredentials({} as NodeJS.ProcessEnv, () => partial);
+    expect(r.missing).toEqual(["SUBSTACK_USER_ID"]);
+    expect(r.source).toBe("stored");
+  });
+});

--- a/src/__tests__/session-store.test.ts
+++ b/src/__tests__/session-store.test.ts
@@ -1,0 +1,104 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import {
+  mkdtempSync,
+  rmSync,
+  writeFileSync,
+  readFileSync,
+  existsSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  saveSession,
+  loadSession,
+  clearSession,
+  sessionDir,
+} from "../auth/session-store.js";
+
+let dir: string;
+const original = process.env.SUBSTACK_MCP_HOME;
+
+beforeEach(() => {
+  dir = mkdtempSync(join(tmpdir(), "substack-mcp-test-"));
+  process.env.SUBSTACK_MCP_HOME = dir;
+});
+
+afterEach(() => {
+  if (original === undefined) delete process.env.SUBSTACK_MCP_HOME;
+  else process.env.SUBSTACK_MCP_HOME = original;
+  rmSync(dir, { recursive: true, force: true });
+});
+
+describe("session store", () => {
+  it("round-trips a saved session", () => {
+    saveSession({
+      publicationUrl: "https://x.substack.com",
+      sessionToken: "tok",
+      userId: "42",
+    });
+    const loaded = loadSession();
+    expect(loaded?.publicationUrl).toBe("https://x.substack.com");
+    expect(loaded?.sessionToken).toBe("tok");
+    expect(loaded?.userId).toBe("42");
+    expect(typeof loaded?.savedAt).toBe("string");
+  });
+
+  it("returns null when no session file exists", () => {
+    expect(loadSession()).toBeNull();
+  });
+
+  it("does not write the token or URL in plaintext", () => {
+    saveSession({
+      publicationUrl: "https://secret.substack.com",
+      sessionToken: "SUPERSECRET",
+      userId: "1",
+    });
+    const raw = readFileSync(join(dir, "session.json"), "utf8");
+    expect(raw).not.toContain("SUPERSECRET");
+    expect(raw).not.toContain("secret.substack.com");
+  });
+
+  it("returns null when the ciphertext is tampered (GCM auth fails)", () => {
+    saveSession({
+      publicationUrl: "https://x.substack.com",
+      sessionToken: "tok",
+      userId: "1",
+    });
+    const file = join(dir, "session.json");
+    const env = JSON.parse(readFileSync(file, "utf8"));
+    const buf = Buffer.from(env.data, "base64");
+    buf[0] ^= 0xff; // flip a byte in the ciphertext
+    env.data = buf.toString("base64");
+    writeFileSync(file, JSON.stringify(env));
+    expect(loadSession()).toBeNull();
+  });
+
+  it("returns null for a corrupt, non-JSON file", () => {
+    writeFileSync(join(dir, "session.json"), "not json at all");
+    expect(loadSession()).toBeNull();
+  });
+
+  it("returns null for an unknown envelope version", () => {
+    writeFileSync(
+      join(dir, "session.json"),
+      JSON.stringify({ v: 2, salt: "", iv: "", tag: "", data: "" }),
+    );
+    expect(loadSession()).toBeNull();
+  });
+
+  it("clearSession removes the file", () => {
+    saveSession({ publicationUrl: "u", sessionToken: "t", userId: "1" });
+    expect(existsSync(join(dir, "session.json"))).toBe(true);
+    clearSession();
+    expect(existsSync(join(dir, "session.json"))).toBe(false);
+    expect(loadSession()).toBeNull();
+  });
+
+  it("clearSession is a no-op when nothing is stored", () => {
+    expect(() => clearSession()).not.toThrow();
+  });
+
+  it("sessionDir honors SUBSTACK_MCP_HOME", () => {
+    expect(sessionDir()).toBe(dir);
+  });
+});

--- a/src/auth/resolve-credentials.ts
+++ b/src/auth/resolve-credentials.ts
@@ -1,0 +1,63 @@
+/**
+ * Resolve Substack credentials from environment variables, falling back to the
+ * locally-stored session written by `substack-mcp-login`.
+ *
+ * Precedence is per-field: an explicit env var always wins, and a stored
+ * session fills any gap. This keeps the zero-config env-var path (used in most
+ * MCP client configs) working unchanged, while letting the browser-login flow
+ * supply credentials when the env vars are absent.
+ */
+import { loadSession, type StoredSession } from "./session-store.js";
+
+export interface ResolvedCredentials {
+  publicationUrl: string;
+  sessionToken: string;
+  userId: string;
+  /** Where each field ultimately came from, for startup diagnostics. */
+  source: "env" | "stored" | "mixed" | "none";
+  /** Names of the still-missing required variables (empty when complete). */
+  missing: string[];
+}
+
+const FIELDS = [
+  ["publicationUrl", "SUBSTACK_PUBLICATION_URL"],
+  ["sessionToken", "SUBSTACK_SESSION_TOKEN"],
+  ["userId", "SUBSTACK_USER_ID"],
+] as const;
+
+export function resolveCredentials(
+  env: NodeJS.ProcessEnv = process.env,
+  loader: () => StoredSession | null = loadSession,
+): ResolvedCredentials {
+  const stored = loader();
+
+  let usedEnv = false;
+  let usedStored = false;
+  const out: Record<string, string> = {};
+  const missing: string[] = [];
+
+  for (const [key, envName] of FIELDS) {
+    const fromEnv = env[envName];
+    if (fromEnv) {
+      out[key] = fromEnv;
+      usedEnv = true;
+    } else if (stored && stored[key]) {
+      out[key] = stored[key];
+      usedStored = true;
+    } else {
+      out[key] = "";
+      missing.push(envName);
+    }
+  }
+
+  const source: ResolvedCredentials["source"] =
+    usedEnv && usedStored ? "mixed" : usedEnv ? "env" : usedStored ? "stored" : "none";
+
+  return {
+    publicationUrl: out.publicationUrl,
+    sessionToken: out.sessionToken,
+    userId: out.userId,
+    source,
+    missing,
+  };
+}

--- a/src/auth/session-store.ts
+++ b/src/auth/session-store.ts
@@ -1,0 +1,159 @@
+/**
+ * Local, machine-bound storage for Substack credentials captured by the
+ * `substack-mcp-login` browser flow, so the server can run without pasting a
+ * session token into your MCP client config.
+ *
+ * SECURITY — read this before trusting it. The stored file is written
+ * `0600` (owner read/write only) and its contents are encrypted with
+ * AES-256-GCM. The key is DERIVED (scrypt) from this OS account + machine
+ * identity, not stored. That means:
+ *
+ *   - A copied file is useless on another machine/user (the key won't
+ *     re-derive), and casual disk/backup snooping sees only ciphertext.
+ *   - It is NOT protection against code running AS YOU on this machine, which
+ *     can re-derive the same key. It is obfuscation + machine-binding, not a
+ *     secret vault. This is on par with — and slightly better than — the
+ *     existing plaintext `SUBSTACK_SESSION_TOKEN` env-var path.
+ *
+ * If you need real secret storage, keep using the env-var path with your MCP
+ * client's own secret handling, or an OS keychain.
+ */
+import {
+  mkdirSync,
+  readFileSync,
+  writeFileSync,
+  existsSync,
+  rmSync,
+  chmodSync,
+} from "node:fs";
+import { homedir, hostname, userInfo } from "node:os";
+import { join } from "node:path";
+import {
+  scryptSync,
+  randomBytes,
+  createCipheriv,
+  createDecipheriv,
+} from "node:crypto";
+
+export interface StoredSession {
+  publicationUrl: string;
+  sessionToken: string;
+  userId: string;
+  savedAt: string;
+}
+
+/** On-disk envelope: everything needed to decrypt except the derived key. */
+interface Envelope {
+  v: 1;
+  salt: string;
+  iv: string;
+  tag: string;
+  data: string;
+}
+
+/** Directory holding the session file. Overridable for tests via env. */
+export function sessionDir(): string {
+  return process.env.SUBSTACK_MCP_HOME || join(homedir(), ".substack-mcp");
+}
+
+function sessionFile(): string {
+  return join(sessionDir(), "session.json");
+}
+
+/**
+ * Derive the AES key from a per-write random salt bound to this OS account and
+ * machine. The salt is stored alongside the ciphertext; the account/machine
+ * identity is not — so the key cannot be re-derived elsewhere.
+ */
+function deriveKey(salt: Buffer): Buffer {
+  const identity = `${userInfo().username}@${hostname()}::substack-mcp`;
+  return scryptSync(identity, salt, 32);
+}
+
+/** Encrypt and write the session `0600`. Returns the file path. */
+export function saveSession(session: Omit<StoredSession, "savedAt">): string {
+  const dir = sessionDir();
+  mkdirSync(dir, { recursive: true });
+
+  const salt = randomBytes(16);
+  const iv = randomBytes(12);
+  const key = deriveKey(salt);
+
+  const plaintext = JSON.stringify({
+    ...session,
+    savedAt: new Date().toISOString(),
+  } satisfies StoredSession);
+
+  const cipher = createCipheriv("aes-256-gcm", key, iv);
+  const data = Buffer.concat([
+    cipher.update(plaintext, "utf8"),
+    cipher.final(),
+  ]);
+  const tag = cipher.getAuthTag();
+
+  const envelope: Envelope = {
+    v: 1,
+    salt: salt.toString("base64"),
+    iv: iv.toString("base64"),
+    tag: tag.toString("base64"),
+    data: data.toString("base64"),
+  };
+
+  const file = sessionFile();
+  writeFileSync(file, JSON.stringify(envelope), { mode: 0o600 });
+  // writeFileSync's mode is ignored if the file already existed; force it.
+  try {
+    chmodSync(file, 0o600);
+  } catch {
+    // chmod is a best-effort hardening step (e.g. a no-op on some Windows
+    // filesystems). The file is still written; do not fail the login over it.
+  }
+  return file;
+}
+
+/**
+ * Read and decrypt the stored session. Returns null when there is no file, or
+ * when the file cannot be authenticated/decrypted — a wrong machine/user, a
+ * tampered file, or a corrupt/older format. Never throws.
+ */
+export function loadSession(): StoredSession | null {
+  const file = sessionFile();
+  if (!existsSync(file)) return null;
+
+  try {
+    const envelope = JSON.parse(readFileSync(file, "utf8")) as Envelope;
+    if (envelope.v !== 1) return null;
+
+    const salt = Buffer.from(envelope.salt, "base64");
+    const iv = Buffer.from(envelope.iv, "base64");
+    const tag = Buffer.from(envelope.tag, "base64");
+    const data = Buffer.from(envelope.data, "base64");
+    const key = deriveKey(salt);
+
+    const decipher = createDecipheriv("aes-256-gcm", key, iv);
+    decipher.setAuthTag(tag);
+    const plaintext = Buffer.concat([
+      decipher.update(data),
+      decipher.final(),
+    ]).toString("utf8");
+
+    const parsed = JSON.parse(plaintext) as StoredSession;
+    if (
+      typeof parsed.publicationUrl !== "string" ||
+      typeof parsed.sessionToken !== "string" ||
+      typeof parsed.userId !== "string"
+    ) {
+      return null;
+    }
+    return parsed;
+  } catch {
+    // GCM auth failure (wrong key / tampered), bad base64, or malformed JSON.
+    return null;
+  }
+}
+
+/** Delete the stored session file. No-op if it doesn't exist. */
+export function clearSession(): void {
+  const file = sessionFile();
+  if (existsSync(file)) rmSync(file);
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,25 +3,28 @@
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import { SubstackClient } from "./api/client.js";
 import { createServer } from "./server.js";
+import { resolveCredentials } from "./auth/resolve-credentials.js";
 
 async function main() {
-  const publicationUrl = process.env.SUBSTACK_PUBLICATION_URL || "";
-  const sessionToken = process.env.SUBSTACK_SESSION_TOKEN || "";
-  const userId = process.env.SUBSTACK_USER_ID || "0";
+  // Env vars take precedence; a stored session (from `substack-mcp-login`)
+  // fills any gaps.
+  const creds = resolveCredentials();
+  const { publicationUrl, sessionToken, userId } = creds;
 
-  const missingVars = [
-    !process.env.SUBSTACK_PUBLICATION_URL && "SUBSTACK_PUBLICATION_URL",
-    !process.env.SUBSTACK_SESSION_TOKEN && "SUBSTACK_SESSION_TOKEN",
-    !process.env.SUBSTACK_USER_ID && "SUBSTACK_USER_ID",
-  ].filter(Boolean);
-
-  if (missingVars.length > 0) {
-    console.error(`Warning: Missing environment variables: ${missingVars.join(", ")}`);
-    console.error("Tools will error until all variables are configured. See README.md for setup.");
+  if (creds.missing.length > 0) {
+    console.error(`Warning: Missing credentials: ${creds.missing.join(", ")}`);
+    console.error(
+      "Set them as SUBSTACK_* env vars, or run `substack-mcp-login` to sign in via browser. See README.md.",
+    );
+  } else if (creds.source !== "env") {
+    console.error(`Using stored credentials (source: ${creds.source}).`);
   }
 
   const userAgent = process.env.SUBSTACK_USER_AGENT;
-  const client = new SubstackClient(publicationUrl, sessionToken, userId, userAgent);
+  // The client constructor rejects a non-numeric user id; fall back to "0" so
+  // startup surfaces the friendly missing-credentials warning above instead of
+  // throwing when nothing is configured yet.
+  const client = new SubstackClient(publicationUrl, sessionToken, userId || "0", userAgent);
 
   // Validate auth on startup (warn but don't block — allows inspection without credentials)
   try {

--- a/src/login.ts
+++ b/src/login.ts
@@ -95,9 +95,8 @@ async function main(): Promise<void> {
 
     const token = await waitForSessionCookie(context);
     if (!token) {
-      console.error("Timed out waiting for sign-in. Nothing was saved.");
-      process.exit(1);
-      return;
+      // Throw (don't exit here) so the finally below closes the browser first.
+      throw new Error("Timed out waiting for sign-in. Nothing was saved.");
     }
 
     console.log("Signed in. Resolving your user id from the publication...");
@@ -119,13 +118,12 @@ async function main(): Promise<void> {
     const publicationToken = (await readSessionCookie(context)) || token;
 
     if (!userId) {
-      console.error(
-        "\nSigned in, but could not auto-resolve your user id from " +
+      // Throw (don't exit here) so the finally below closes the browser first.
+      throw new Error(
+        "Signed in, but could not auto-resolve your user id from " +
           `${publicationUrl}. Find it via DevTools (see the README) and set ` +
           "SUBSTACK_USER_ID manually, or re-run with the correct publication URL.",
       );
-      process.exit(1);
-      return;
     }
 
     const file = saveSession({

--- a/src/login.ts
+++ b/src/login.ts
@@ -1,0 +1,151 @@
+#!/usr/bin/env node
+/**
+ * `substack-mcp-login` — a one-time browser login that captures your Substack
+ * session and stores it locally (encrypted, machine-bound) so the MCP server
+ * can run without pasting a session token into your client config.
+ *
+ * Playwright is NOT a dependency of this package (it is large and downloads
+ * browsers). It is imported lazily and indirectly below; if it isn't
+ * installed, this prints install instructions and exits. This keeps
+ * `npx @conorbronsdon/substack-mcp` small for the common env-var path.
+ *
+ * NOTE: The browser-automation portion talks to Substack's live login UI,
+ * which changes over time and can present a CAPTCHA. It cannot be covered by
+ * automated tests. The encrypted store and credential resolution it feeds ARE
+ * unit-tested (see src/__tests__).
+ */
+import { createInterface } from "node:readline/promises";
+import { stdin, stdout } from "node:process";
+import { saveSession } from "./auth/session-store.js";
+
+const SESSION_COOKIE_NAMES = ["connect.sid", "substack.sid"];
+const LOGIN_TIMEOUT_MS = 5 * 60 * 1000;
+
+async function ask(question: string): Promise<string> {
+  const rl = createInterface({ input: stdin, output: stdout });
+  try {
+    return (await rl.question(question)).trim();
+  } finally {
+    rl.close();
+  }
+}
+
+/** Read the first present Substack session cookie from the browser context. */
+async function readSessionCookie(context: any): Promise<string> {
+  const cookies = await context.cookies();
+  for (const name of SESSION_COOKIE_NAMES) {
+    const hit = cookies.find((c: any) => c.name === name && c.value);
+    if (hit) return hit.value;
+  }
+  return "";
+}
+
+/** Poll the context until a session cookie appears or the timeout elapses. */
+async function waitForSessionCookie(context: any): Promise<string> {
+  const deadline = Date.now() + LOGIN_TIMEOUT_MS;
+  while (Date.now() < deadline) {
+    const token = await readSessionCookie(context);
+    if (token) return token;
+    await new Promise((r) => setTimeout(r, 1500));
+  }
+  return "";
+}
+
+async function main(): Promise<void> {
+  console.log("substack-mcp browser login\n");
+
+  // Lazy + indirect import so tsc never needs the playwright types and the
+  // package never hard-depends on it.
+  let chromium: any;
+  try {
+    const moduleName = "playwright";
+    ({ chromium } = await import(moduleName));
+  } catch {
+    console.error(
+      "This login flow needs Playwright, which is not bundled with substack-mcp.\n" +
+        "Install it once, then re-run:\n\n" +
+        "  npm i -g playwright && npx playwright install chromium\n" +
+        "  npx --package @conorbronsdon/substack-mcp substack-mcp-login\n",
+    );
+    process.exit(1);
+    return;
+  }
+
+  const publicationUrl = (
+    process.argv[2] ||
+    (await ask("Publication URL (e.g. https://yourblog.substack.com): "))
+  ).replace(/\/+$/, "");
+
+  if (!/^https?:\/\//.test(publicationUrl)) {
+    console.error("That doesn't look like a URL (needs http/https). Aborting.");
+    process.exit(1);
+    return;
+  }
+
+  const browser = await chromium.launch({ headless: false });
+  try {
+    const context = await browser.newContext();
+    const page = await context.newPage();
+
+    console.log(
+      "\nA browser window opened. Sign in to Substack there (including any CAPTCHA).",
+    );
+    console.log("Waiting for sign-in to complete (up to 5 minutes)...\n");
+    await page.goto("https://substack.com/sign-in");
+
+    const token = await waitForSessionCookie(context);
+    if (!token) {
+      console.error("Timed out waiting for sign-in. Nothing was saved.");
+      process.exit(1);
+      return;
+    }
+
+    console.log("Signed in. Resolving your user id from the publication...");
+    await page.goto(publicationUrl, { waitUntil: "domcontentloaded" });
+    const userId: string = await page.evaluate(async () => {
+      try {
+        const res = await fetch("/api/v1/archive?sort=new&limit=1", {
+          credentials: "include",
+        });
+        const data = await res.json();
+        return String(data?.[0]?.publishedBylines?.[0]?.id ?? "");
+      } catch {
+        return "";
+      }
+    });
+
+    // Prefer the cookie as seen in the publication's own context (custom
+    // domains use connect.sid); fall back to the substack.com one.
+    const publicationToken = (await readSessionCookie(context)) || token;
+
+    if (!userId) {
+      console.error(
+        "\nSigned in, but could not auto-resolve your user id from " +
+          `${publicationUrl}. Find it via DevTools (see the README) and set ` +
+          "SUBSTACK_USER_ID manually, or re-run with the correct publication URL.",
+      );
+      process.exit(1);
+      return;
+    }
+
+    const file = saveSession({
+      publicationUrl,
+      sessionToken: publicationToken,
+      userId,
+    });
+
+    console.log(
+      `\nSaved. Credentials stored (encrypted, machine-bound) at:\n  ${file}\n`,
+    );
+    console.log(
+      "substack-mcp will now use these automatically when SUBSTACK_* env vars are unset.",
+    );
+  } finally {
+    await browser.close();
+  }
+}
+
+main().catch((err) => {
+  console.error("Login failed:", err instanceof Error ? err.message : err);
+  process.exit(1);
+});


### PR DESCRIPTION
> **Draft — needs one manual verification.** The Playwright browser-login flow talks to Substack's live login UI (which changes and can show a CAPTCHA) and cannot be unit-tested. The store + resolution it feeds ARE fully tested. Please run it once against your publication before merging (see below).

## What

Removes the two pain points of the env-var setup: hunting `connect.sid` in DevTools, and re-copying it every ~90 days. A new `substack-mcp-login` bin opens a browser, captures the session after you sign in, auto-resolves your user id, and stores it locally. The server reads it when `SUBSTACK_*` env vars are unset.

## Design decisions

- **Playwright is NOT a dependency.** `login.ts` imports it lazily and indirectly (`const m = "playwright"; await import(m)`), so `tsc` needs no types and `npx @conorbronsdon/substack-mcp` stays small. If Playwright is absent, the login prints install instructions and exits. *Verified: builds without Playwright; the bin degrades gracefully (smoke-tested).*
- **Encrypted at rest, honestly scoped.** `session.json` is `0600` and AES-256-GCM encrypted under a scrypt key derived from OS account + machine (never stored). A copied file is useless elsewhere; tampering fails GCM auth → loads as `null`. This is machine-binding + obfuscation, **not** a secret vault — code running as you can re-derive the key (same caveat as the plaintext env-var path). Documented as such in the README and the module header.
- **Per-field precedence: env var > stored session** (`resolveCredentials`), so the zero-config env path is unchanged.

## Tests (+14, all core logic)
- `session-store`: round-trip, **no plaintext on disk**, **GCM tamper → null**, corrupt/unknown-version → null, `clearSession`.
- `resolveCredentials`: env / stored / mixed / none precedence, partial-store missing-field reporting.
- **186 tests pass; build clean.**

## To verify before merge
```bash
npm i -g playwright && npx playwright install chromium
node dist/login.js https://<your-pub>.substack.com   # after npm run build
# sign in, confirm ~/.substack-mcp/session.json is written, then run the server with no SUBSTACK_* env vars
```

## Not included / open questions
- Version bump omitted (left for you at publish time; three feature branches would otherwise collide on the version field).
- The browser flow assumes a single publication (passed as arg/prompt). Multi-publication selection could be added later.

🤖 Generated with [Claude Code](https://claude.com/claude-code)