### PR TITLE
Release 0.5.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@conorbronsdon/substack-mcp",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "MCP server for Substack — read posts, manage drafts, publish Notes. Long-form posts are draft-only by design (no publish, no delete); Notes publish immediately.",
   "type": "module",
   "bin": {

--- a/src/server.ts
+++ b/src/server.ts
@@ -7,7 +7,7 @@ import { markdownToProseMirror, markdownToProseMirrorContent } from "./utils/mar
 export function createServer(client: SubstackClient): McpServer {
   const server = new McpServer({
     name: "substack-mcp",
-    version: "0.4.0",
+    version: "0.5.0",
   });
 
   // Every tool is registered with MCP annotations derived from its declared


### PR DESCRIPTION
Bumps version 0.4.0 → 0.5.0 in `package.json` and `server.ts`. Merging this to main triggers the trusted-publishing workflow (`npm publish --provenance` via OIDC + GitHub release).

### Since 0.4.0
- **#15** Converter: nested lists, GFM table → `code_block` fallback, indented-heading hang fix, list data-loss fix
- **#16** Read tools: `get_sections`, `get_post_analytics`, `list_scheduled_posts`
- **#17** Optional browser-login flow (`substack-mcp-login`) + AES-256-GCM machine-bound local session storage

230 tests pass; build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)