### PR TITLE
ci: fix publish (Node 24 base, drop fragile npm self-upgrade)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -19,7 +19,12 @@ jobs:
 
       - uses: actions/setup-node@v6
         with:
-          node-version: 22
+          # Node 24 bundles npm >= 11.5.1 (required for trusted publishing) with
+          # sigstore intact. Self-upgrading npm on the Node 22 runner
+          # (npm install -g npm@latest) left provenance's `sigstore` dependency
+          # unresolvable — "Cannot find module 'sigstore'" — so we take a base
+          # image that already has a modern npm instead of upgrading in place.
+          node-version: 24
           registry-url: https://registry.npmjs.org
 
       - name: Check if package.json version is already published
@@ -50,9 +55,9 @@ jobs:
         if: steps.version.outputs.changed == 'true'
         run: npm test --if-present
 
-      - name: Update npm for trusted publishing
+      - name: Show tool versions
         if: steps.version.outputs.changed == 'true'
-        run: npm install -g npm@latest
+        run: node --version && npm --version
 
       - name: Publish to npm
         if: steps.version.outputs.changed == 'true'


### PR DESCRIPTION
The 0.5.0 publish run failed at `npm publish --provenance` with `Cannot find module 'sigstore'` (build + test passed). The workflow's `npm install -g npm@latest` self-upgraded npm 10→11 on the Node 22 runner and left provenance's `sigstore` dependency unresolvable — reproduced on a rerun.

**Fix:** run the publish job on **Node 24** (bundled npm ≥ 11.5.1, required for trusted publishing, with `sigstore` intact) and drop the in-place npm upgrade. Keeps `--provenance` and OIDC trusted publishing; adds a version echo for diagnostics.

After merge I'll trigger the publish via `workflow_dispatch` (version is still 0.5.0 / unpublished).

🤖 Generated with [Claude Code](https://claude.com/claude-code)