### PR TITLE
feat(upload_image): accept a local image file path (closes #20)

### DIFF
--- a/src/__tests__/image.test.ts
+++ b/src/__tests__/image.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { writeFile, mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { fileToDataUri, SUPPORTED_IMAGE_EXTENSIONS } from "../utils/image.js";
+
+describe("fileToDataUri", () => {
+  let dir: string;
+  const pngBytes = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
+
+  beforeAll(async () => {
+    dir = await mkdtemp(join(tmpdir(), "substack-image-"));
+  });
+
+  afterAll(async () => {
+    await rm(dir, { recursive: true, force: true });
+  });
+
+  it("encodes a png file as a data URI with the right MIME type", async () => {
+    const path = join(dir, "pic.png");
+    await writeFile(path, pngBytes);
+    const uri = await fileToDataUri(path);
+    expect(uri).toBe(`data:image/png;base64,${pngBytes.toString("base64")}`);
+  });
+
+  it("maps .jpg and .jpeg to image/jpeg", async () => {
+    const jpg = join(dir, "a.jpg");
+    const jpeg = join(dir, "b.jpeg");
+    await writeFile(jpg, pngBytes);
+    await writeFile(jpeg, pngBytes);
+    expect(await fileToDataUri(jpg)).toMatch(/^data:image\/jpeg;base64,/);
+    expect(await fileToDataUri(jpeg)).toMatch(/^data:image\/jpeg;base64,/);
+  });
+
+  it("is case-insensitive on the extension", async () => {
+    const path = join(dir, "PIC.PNG");
+    await writeFile(path, pngBytes);
+    expect(await fileToDataUri(path)).toMatch(/^data:image\/png;base64,/);
+  });
+
+  it("throws on an unsupported extension", async () => {
+    const path = join(dir, "notes.txt");
+    await writeFile(path, "hello");
+    await expect(fileToDataUri(path)).rejects.toThrow(/Unsupported image file extension/);
+  });
+
+  it("throws when the file does not exist", async () => {
+    await expect(fileToDataUri(join(dir, "missing.png"))).rejects.toThrow();
+  });
+
+  it("exposes the supported extension list", () => {
+    expect(SUPPORTED_IMAGE_EXTENSIONS).toContain(".png");
+    expect(SUPPORTED_IMAGE_EXTENSIONS).toContain(".webp");
+  });
+});

--- a/src/__tests__/markdown-to-prosemirror.test.ts
+++ b/src/__tests__/markdown-to-prosemirror.test.ts
@@ -300,6 +300,26 @@ describe("markdownToProseMirror", () => {
       expect(image.attrs.height).toBeNull();
       expect(image.attrs.type).toBeNull();
     });
+
+    it("does not read an aspect-ratio filename on a non-CDN URL as dimensions", () => {
+      // `hero_16x9.jpg` matches the `_WxH_` shape but is an aspect-ratio label,
+      // not pixel dimensions — only Substack-hosted URLs use it for real dims.
+      const doc = parse("![logo](https://example.com/hero_16x9.jpg)");
+      const image = doc.content[0].content[0];
+      expect(image.attrs.width).toBeNull();
+      expect(image.attrs.height).toBeNull();
+      expect(image.attrs.type).toBeNull();
+    });
+
+    it("parses dimensions from a substackcdn.com fetch URL", () => {
+      const doc = parse(
+        "![t](https://substackcdn.com/image/fetch/w_1456/abc_800x600.png)",
+      );
+      const image = doc.content[0].content[0];
+      expect(image.attrs.width).toBe(800);
+      expect(image.attrs.height).toBe(600);
+      expect(image.attrs.type).toBe("image/png");
+    });
   });
 });
 

--- a/src/__tests__/markdown-to-prosemirror.test.ts
+++ b/src/__tests__/markdown-to-prosemirror.test.ts
@@ -239,7 +239,9 @@ describe("markdownToProseMirror", () => {
       const doc = parse("  ![alt](https://example.com/y.png)");
       expect(doc.content).toHaveLength(1);
       expect(doc.content[0].type).toBe("captionedImage");
-      expect(doc.content[0].attrs.src).toBe("https://example.com/y.png");
+      expect(doc.content[0].content[0].attrs.src).toBe(
+        "https://example.com/y.png",
+      );
     });
 
     it("separates a paragraph from a following indented heading", () => {
@@ -259,20 +261,44 @@ describe("markdownToProseMirror", () => {
   });
 
   describe("images", () => {
-    it("converts standalone image to captionedImage node", () => {
+    it("wraps a standalone image in captionedImage > image2 with a caption", () => {
       const doc = parse("![Alt text](https://example.com/img.png)");
       const node = doc.content[0];
       expect(node.type).toBe("captionedImage");
-      expect(node.attrs.src).toBe("https://example.com/img.png");
-      expect(node.attrs.alt).toBe("Alt text");
-      expect(node.attrs.caption).toBe("Alt text");
+      const [image, caption] = node.content;
+      expect(image.type).toBe("image2");
+      expect(image.attrs.src).toBe("https://example.com/img.png");
+      expect(image.attrs.alt).toBe("Alt text");
+      expect(caption.type).toBe("caption");
+      expect(caption.content[0].text).toBe("Alt text");
     });
 
-    it("handles image with empty alt text", () => {
+    it("omits the caption node and nulls alt for empty alt text", () => {
       const doc = parse("![](https://example.com/img.png)");
       const node = doc.content[0];
-      expect(node.attrs.alt).toBe("");
-      expect(node.attrs.caption).toBeNull();
+      expect(node.type).toBe("captionedImage");
+      expect(node.content).toHaveLength(1);
+      expect(node.content[0].type).toBe("image2");
+      expect(node.content[0].attrs.alt).toBeNull();
+    });
+
+    it("parses width/height and MIME from a Substack CDN filename", () => {
+      const doc = parse(
+        "![t](https://substack-post-media.s3.amazonaws.com/public/images/abc_1265x5808.png)",
+      );
+      const image = doc.content[0].content[0];
+      expect(image.attrs.width).toBe(1265);
+      expect(image.attrs.height).toBe(5808);
+      expect(image.attrs.resizeWidth).toBe(1265);
+      expect(image.attrs.type).toBe("image/png");
+    });
+
+    it("falls back to null dimensions for a non-CDN URL", () => {
+      const doc = parse("![t](https://example.com/plain.png)");
+      const image = doc.content[0].content[0];
+      expect(image.attrs.width).toBeNull();
+      expect(image.attrs.height).toBeNull();
+      expect(image.attrs.type).toBeNull();
     });
   });
 });

--- a/src/server.ts
+++ b/src/server.ts
@@ -3,6 +3,7 @@ import { z } from "zod";
 import { SubstackClient } from "./api/client.js";
 import { buildAnnotations } from "./annotations.js";
 import { markdownToProseMirror, markdownToProseMirrorContent } from "./utils/markdown-to-prosemirror.js";
+import { fileToDataUri } from "./utils/image.js";
 
 export function createServer(client: SubstackClient): McpServer {
   const server = new McpServer({
@@ -380,18 +381,33 @@ export function createServer(client: SubstackClient): McpServer {
     "upload_image",
     {
       description:
-        "Upload a base64-encoded image to Substack's CDN. Returns a hosted image URL that is publicly fetchable by anyone with the link (an unlisted asset — not attributed to you or added to your feed).",
+        "Upload an image to Substack's CDN. Provide exactly one of `image_base64` (a base64 data URI) or `image_path` (a local file path). Returns a hosted image URL that is publicly fetchable by anyone with the link (an unlisted asset — not attributed to you or added to your feed).",
       inputSchema: {
         image_base64: z
           .string()
+          .optional()
           .describe(
-            'Base64-encoded image with data URI prefix (e.g., "data:image/png;base64,...")',
+            'Base64-encoded image with data URI prefix (e.g., "data:image/png;base64,..."). Mutually exclusive with image_path.',
+          ),
+        image_path: z
+          .string()
+          .optional()
+          .describe(
+            'Absolute path to a local image file (e.g., "/Users/me/pic.png"). Read and encoded automatically; MIME type inferred from the extension. Mutually exclusive with image_base64.',
           ),
       },
       annotations: buildAnnotations("upload_image"),
     },
-    async ({ image_base64 }) => {
-      const result = await client.uploadImage(image_base64);
+    async ({ image_base64, image_path }) => {
+      if (!image_base64 === !image_path) {
+        throw new Error(
+          "Provide exactly one of `image_base64` or `image_path`.",
+        );
+      }
+      const dataUri = image_path
+        ? await fileToDataUri(image_path)
+        : (image_base64 as string);
+      const result = await client.uploadImage(dataUri);
       return {
         content: [
           { type: "text", text: JSON.stringify({ image_url: result.url }) },

--- a/src/utils/image.ts
+++ b/src/utils/image.ts
@@ -1,0 +1,37 @@
+import { readFile } from "node:fs/promises";
+import { extname } from "node:path";
+
+// Substack's image endpoint takes a base64 data URI. When a caller passes a
+// local file path instead, we read the bytes and build that data URI here,
+// inferring the MIME type from the file extension.
+const MIME_BY_EXT: Record<string, string> = {
+  ".png": "image/png",
+  ".jpg": "image/jpeg",
+  ".jpeg": "image/jpeg",
+  ".gif": "image/gif",
+  ".webp": "image/webp",
+  ".svg": "image/svg+xml",
+  ".bmp": "image/bmp",
+  ".avif": "image/avif",
+  ".tif": "image/tiff",
+  ".tiff": "image/tiff",
+};
+
+export const SUPPORTED_IMAGE_EXTENSIONS = Object.keys(MIME_BY_EXT);
+
+/**
+ * Read a local image file and encode it as a base64 data URI
+ * (e.g. "data:image/png;base64,...") suitable for Substack's image upload.
+ */
+export async function fileToDataUri(filePath: string): Promise<string> {
+  const ext = extname(filePath).toLowerCase();
+  const mime = MIME_BY_EXT[ext];
+  if (!mime) {
+    throw new Error(
+      `Unsupported image file extension "${ext || "(none)"}" for "${filePath}". ` +
+        `Supported extensions: ${SUPPORTED_IMAGE_EXTENSIONS.join(", ")}.`,
+    );
+  }
+  const buffer = await readFile(filePath);
+  return `data:${mime};base64,${buffer.toString("base64")}`;
+}

--- a/src/utils/markdown-to-prosemirror.ts
+++ b/src/utils/markdown-to-prosemirror.ts
@@ -46,6 +46,11 @@ const IMAGE_LINE_RE = /^!\[([^\]]*)\]\(([^)]+)\)\s*$/;
 // same suffix also tells us the MIME type. Non-CDN URLs simply yield nulls.
 const IMAGE_DIMENSIONS_RE =
   /_(\d+)x(\d+)\.(png|jpe?g|gif|webp|avif|bmp|tiff?)(?:$|[?#])/i;
+// The `_WxH_` suffix is a Substack CDN convention, so only trust it on
+// Substack-hosted URLs. A foreign URL like `hero_16x9.jpg` uses that shape as
+// an aspect-ratio label, not pixel dimensions — parsing it would emit a bogus
+// 16x9-pixel layout. Those fall through to null, which the editor tolerates.
+const SUBSTACK_CDN_RE = /(?:substackcdn\.com|substack-post-media\.s3\.amazonaws\.com)/i;
 
 // Build a Substack image node. Substack renders an image as a `captionedImage`
 // that WRAPS an `image2` child — the `src` and dimensions live on that child,
@@ -54,7 +59,7 @@ const IMAGE_DIMENSIONS_RE =
 // tries to render the (missing) child, so we always nest an `image2` here and
 // attach a `caption` node when alt text is present.
 function buildImageNode(alt: string, src: string): PMNode {
-  const dims = src.match(IMAGE_DIMENSIONS_RE);
+  const dims = SUBSTACK_CDN_RE.test(src) ? src.match(IMAGE_DIMENSIONS_RE) : null;
   const width = dims ? parseInt(dims[1], 10) : null;
   const height = dims ? parseInt(dims[2], 10) : null;
   const ext = dims ? dims[3].toLowerCase() : null;

--- a/src/utils/markdown-to-prosemirror.ts
+++ b/src/utils/markdown-to-prosemirror.ts
@@ -41,6 +41,54 @@ const LIST_ITEM_RE = /^(\s*)([-*+]|\d+\.)\s+(.*)$/;
 const HEADING_RE = /^(#{1,6})\s+(.+)$/;
 const HR_RE = /^(-{3,}|\*{3,}|_{3,})\s*$/;
 const IMAGE_LINE_RE = /^!\[([^\]]*)\]\(([^)]+)\)\s*$/;
+// Substack CDN uploads encode the pixel dimensions in the filename, e.g.
+// `..._1265x5808.png`. We parse them so the editor can lay the image out; the
+// same suffix also tells us the MIME type. Non-CDN URLs simply yield nulls.
+const IMAGE_DIMENSIONS_RE =
+  /_(\d+)x(\d+)\.(png|jpe?g|gif|webp|avif|bmp|tiff?)(?:$|[?#])/i;
+
+// Build a Substack image node. Substack renders an image as a `captionedImage`
+// that WRAPS an `image2` child — the `src` and dimensions live on that child,
+// not on the wrapper. Emitting a flat `{type:"captionedImage", attrs:{src}}`
+// node is accepted by the drafts API but crashes Substack's editor when it
+// tries to render the (missing) child, so we always nest an `image2` here and
+// attach a `caption` node when alt text is present.
+function buildImageNode(alt: string, src: string): PMNode {
+  const dims = src.match(IMAGE_DIMENSIONS_RE);
+  const width = dims ? parseInt(dims[1], 10) : null;
+  const height = dims ? parseInt(dims[2], 10) : null;
+  const ext = dims ? dims[3].toLowerCase() : null;
+  const mime = ext
+    ? `image/${ext === "jpg" ? "jpeg" : ext === "tif" ? "tiff" : ext}`
+    : null;
+
+  const image2: PMNode = {
+    type: "image2",
+    attrs: {
+      src,
+      srcNoWatermark: null,
+      fullscreen: false,
+      imageSize: "normal",
+      height,
+      width,
+      resizeWidth: width,
+      bytes: null,
+      alt: alt || null,
+      title: null,
+      type: mime,
+      href: null,
+      belowTheFold: false,
+      topImage: false,
+      internalRedirect: null,
+    },
+  };
+
+  const content: PMNode[] = [image2];
+  if (alt) {
+    content.push({ type: "caption", content: [{ type: "text", text: alt }] });
+  }
+  return { type: "captionedImage", content };
+}
 
 /**
  * True for a GFM table delimiter row — the `|---|:--:|` line under the header.
@@ -278,15 +326,7 @@ export function markdownToProseMirror(markdown: string): string {
     // it must agree with startsBlock so an indented image line is consumed.
     const imgMatch = line.trimStart().match(IMAGE_LINE_RE);
     if (imgMatch) {
-      nodes.push({
-        type: "captionedImage",
-        attrs: {
-          src: imgMatch[2],
-          alt: imgMatch[1],
-          title: null,
-          caption: imgMatch[1] || null,
-        },
-      });
+      nodes.push(buildImageNode(imgMatch[1], imgMatch[2]));
       i++;
       continue;
     }


### PR DESCRIPTION
Two related fixes that make image support work end-to-end — getting an image **into** Substack (`upload_image` local path) and getting it to **render** once it's in a post (converter fix).

Closes #20

## 1. `upload_image` accepts a local file path (closes #20)

`upload_image` now accepts a **local file path** in addition to a base64 data URI. Callers provide **exactly one** of:

- `image_base64` — base64 data URI (existing behavior)
- `image_path` — absolute path to a local image file (new)

When `image_path` is given, the file is read and encoded to a base64 data URI internally, with the MIME type inferred from the extension (png, jpg/jpeg, gif, webp, svg, bmp, avif, tif/tiff). This removes the need for agents to read and pass raw image bytes themselves — the motivation in #20.

The Substack API contract is unchanged: both paths resolve to a data URI passed to the same `client.uploadImage()` call.

### Changes
- `src/utils/image.ts` (new) — `fileToDataUri(path)` helper + `SUPPORTED_IMAGE_EXTENSIONS`. Throws a clear error on unsupported extensions or unreadable files.
- `src/server.ts` — `upload_image` gains the optional `image_path` param with an XOR guard requiring exactly one input; updated description.
- `src/__tests__/image.test.ts` (new) — 6 unit tests: MIME mapping, jpg/jpeg, case-insensitive extensions, unsupported extension, missing file, exported list.

## 2. Converter: nest `image2` inside `captionedImage` so images render

While testing #1 end-to-end, every draft that embedded an uploaded image failed to open in Substack's editor with **"Something has gone wrong. Please refresh the page…"**.

Root cause: the markdown converter emitted a **flat** image node —
`{ type: "captionedImage", attrs: { src, alt, caption } }`. The drafts API happily stores it, but Substack's editor expects `captionedImage` to be a **container** whose `content` holds an `image2` child that carries the `src` and dimensions. The renderer reaches for the missing child and throws — which is why the API calls all succeed yet the page won't load.

The converter now builds the correct structure:

```jsonc
{
  "type": "captionedImage",
  "content": [
    { "type": "image2", "attrs": { "src": "…", "width": 1265, "height": 5808, "type": "image/png", /* … */ } },
    { "type": "caption", "content": [{ "type": "text", "text": "alt text" }] }
  ]
}
```

- Substack CDN uploads encode the pixel dimensions in the filename (e.g. `…_1265x5808.png`), so `width`/`height`/`resizeWidth` and the MIME `type` are parsed from the URL; non-CDN URLs fall back to `null` dimensions.
- A `caption` node is added only when alt text is present.
- Applies to `create_draft`, `update_draft`, **and** `create_note` (shared converter).

### Changes
- `src/utils/markdown-to-prosemirror.ts` — new `buildImageNode()` helper + `IMAGE_DIMENSIONS_RE`; standalone-image handling now emits `captionedImage > [image2, caption]`.
- `src/__tests__/markdown-to-prosemirror.test.ts` — updated/added tests: nested structure + caption, empty-alt fallback (caption omitted, `alt: null`), CDN width/height/MIME parsing, and non-CDN null fallback.

## Testing
- `npm run lint` — clean
- `npm test` — all passing (converter suite extended with the cases above)
- Verified end-to-end against a live publication: a draft that previously threw "Something has gone wrong" now opens with all images rendering inline. Confirmed via an API round-trip that Substack accepts and preserves the nested `captionedImage > image2` structure with populated `width`/`height`.
