### PR TITLE
docs: add CHANGELOG, CONTRIBUTING, and PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,19 @@
+<!-- Thanks for contributing! Keep this short — delete sections that don't apply. -->
+
+## What & why
+
+<!-- What does this change, and what problem does it solve? Link issues, e.g. "Closes #20". -->
+
+## How verified
+
+- [ ] `npm run lint` clean
+- [ ] `npm test` passing
+
+<!-- For converter / image / rendering changes: verified against a LIVE publication
+     by opening the draft in Substack's editor (not just an API round-trip), and
+     covered images with and without captions. -->
+
+## Safe-by-design checklist
+
+- [ ] No new publish / delete / schedule capability for long-form posts
+- [ ] Any immediate-publish behavior (Notes) stays loudly documented in the tool description

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,25 @@
+# Changelog
+
+All notable changes to this project are documented here. The format is based on
+[Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres
+to [Semantic Versioning](https://semver.org/spec/v2.0.0.html). Releases before
+`0.6.0` are recorded in the [GitHub Releases](https://github.com/conorbronsdon/substack-mcp/releases)
+and the git tag history (`v0.1.0`–`v0.5.0`).
+
+## [Unreleased]
+
+### Added
+- `upload_image` accepts a local file path via `image_path` (mutually exclusive
+  with `image_base64`). The file is read and encoded to a data URI internally,
+  with the MIME type inferred from the extension — the agent no longer has to
+  read and pass raw image bytes. (#20, #21)
+
+### Fixed
+- Markdown image conversion now nests an `image2` node inside `captionedImage`,
+  matching Substack's editor schema, instead of emitting a flat `captionedImage`
+  node. The flat node was accepted by the drafts API but crashed Substack's
+  editor on render. Applies to `create_draft`, `update_draft`, and
+  `create_note`. (#21)
+- The image `_WxH_` dimension suffix is now only parsed on Substack CDN URLs, so
+  a hand-embedded external image with an aspect-ratio filename (e.g.
+  `hero_16x9.jpg`) no longer gets bogus 16×9-pixel dimensions. (#21)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,8 +19,8 @@ an issue with the tool name and the exact error.
 ## Verifying rendering changes
 
 If you touch the markdown → ProseMirror converter or image handling, the drafts
-API accepting your payload is **not** enough — Substack stores structures its
-editor then fails to render. Verify the change against a live publication by
+API accepting your payload is **not** enough — Substack stores structures that
+its editor then fails to render. Verify the change against a live publication by
 opening the resulting draft in Substack's editor, and note that you did so in
 the PR. Cover the cases your change can hit (e.g. images with and without a
 caption, and non-CDN image URLs where dimensions are unknown).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,36 @@
+# Contributing
+
+Thanks for helping improve substack-mcp. Issues and pull requests are welcome.
+
+## Before you open a PR
+
+- `npm run lint` passes (this runs `tsc --noEmit` — the type checker is the linter).
+- `npm test` passes (`vitest run`). Add or update tests for any behavior you change.
+- The safe-by-design boundary stays: no publish, no delete, no schedule for
+  long-form posts. Notes publish immediately by design and their descriptions
+  must keep saying so loudly.
+
+## Working against the unofficial API
+
+This server talks to Substack's unofficial API, so the highest-value
+contributions are fixes when an endpoint changes. If a tool stops working, open
+an issue with the tool name and the exact error.
+
+## Verifying rendering changes
+
+If you touch the markdown → ProseMirror converter or image handling, the drafts
+API accepting your payload is **not** enough — Substack stores structures its
+editor then fails to render. Verify the change against a live publication by
+opening the resulting draft in Substack's editor, and note that you did so in
+the PR. Cover the cases your change can hit (e.g. images with and without a
+caption, and non-CDN image URLs where dimensions are unknown).
+
+## Local setup
+
+See [Development](README.md#development) in the README for clone/build/run steps
+and the `SUBSTACK_*` environment variables.
+
+## Commits & PRs
+
+- Conventional-commit-style titles are appreciated (`feat:`, `fix:`, `ci:` …).
+- Describe what changed and how you verified it.


### PR DESCRIPTION
Adds project docs now that the repo is taking outside contributions (see #21).

## What's here
- **`CHANGELOG.md`** — [Keep a Changelog](https://keepachangelog.com/) format. `[Unreleased]` captures the #21 work: the `upload_image` local-path feature, the `captionedImage > image2` nesting fix, and the CDN-only dimension-parse fix. Prior releases point to the existing git tags / GitHub Releases.
- **`CONTRIBUTING.md`** — the mechanical bar (`npm run lint` + `npm test` must pass), the safe-by-design boundary (no publish/delete/schedule for long-form posts; Notes publish immediately and must say so), and a "verify rendering against a live publication, not just the API round-trip" section — the lesson from #21, where the drafts API happily stored a structure the editor then failed to render.
- **`.github/PULL_REQUEST_TEMPLATE.md`** — verified-how checklist plus a safe-by-design checklist.

No code changes. The README's existing Contributing blurb stays; CONTRIBUTING.md expands on it and gives GitHub the standard contributing link on issues/PRs.