### PR TITLE
Release 0.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and the git tag history (`v0.1.0`–`v0.5.0`).
 
 ## [Unreleased]
 
+## [0.6.0] - 2026-07-10
+
 ### Added
 - `upload_image` accepts a local file path via `image_path` (mutually exclusive
   with `image_base64`). The file is read and encoded to a data URI internally,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@conorbronsdon/substack-mcp",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "MCP server for Substack — read posts, manage drafts, publish Notes. Long-form posts are draft-only by design (no publish, no delete); Notes publish immediately.",
   "type": "module",
   "bin": {

--- a/src/server.ts
+++ b/src/server.ts
@@ -8,7 +8,7 @@ import { fileToDataUri } from "./utils/image.js";
 export function createServer(client: SubstackClient): McpServer {
   const server = new McpServer({
     name: "substack-mcp",
-    version: "0.5.0",
+    version: "0.6.0",
   });
 
   // Every tool is registered with MCP annotations derived from its declared


### PR DESCRIPTION
Bumps version 0.5.0 → 0.6.0 in `package.json` and `server.ts`, and dates the CHANGELOG `[0.6.0]` entry. Merging this to main triggers the trusted-publishing workflow (`npm publish --provenance` via OIDC + GitHub release).

### Since 0.5.0
- **#21** `upload_image` accepts a local file path (`image_path`), reading and encoding the file internally (closes #20). Converter fix: images now nest an `image2` node inside `captionedImage` (Substack's editor schema) instead of a flat node that crashed the editor on render; the `_WxH_` dimension parse is gated to Substack CDN hosts so foreign aspect-ratio filenames aren't misread as pixel dimensions.
- **#22** Add `CHANGELOG.md`, `CONTRIBUTING.md`, and a PR template.

125 tests pass; lint clean.