### PR TITLE
docs: generalize disclaimer to company-neutral wording

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,7 +237,7 @@ Issues and pull requests are welcome. Because this server uses Substack's unoffi
 
 ## Disclaimer
 
-*All views, opinions, and statements expressed on this account are solely my own and are made in my personal capacity. They do not reflect, and should not be construed as reflecting, the views, positions, or policies of Modular. This account is not affiliated with, authorized by, or endorsed by Modular in any way.*
+*This is an independent personal project, not affiliated with, sponsored by, or endorsed by any company. All views expressed are my own.*
 
 ## License
 


### PR DESCRIPTION
Disclosure update: replaces employer-specific disclaimer text with the standard independent-project wording used across these repos. No functional change.