### PR TITLE
fix: never report the subscriber sample as the count

### DIFF
--- a/src/__tests__/client.test.ts
+++ b/src/__tests__/client.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, afterEach } from "vitest";
-import { SubstackClient } from "../api/client.js";
+import { SubstackClient, parseMagnitude } from "../api/client.js";
 import {
   AuthenticationError,
   RateLimitError,
@@ -297,5 +297,86 @@ describe("SubstackClient error mapping (end-to-end through request())", () => {
       expect(err).not.toBeInstanceOf(ServerError);
       expect((err as SubstackAPIError).message).toContain("I'm a teapot");
     }
+  });
+});
+
+describe("parseMagnitude", () => {
+  it("parses whole-K buckets", () => {
+    expect(parseMagnitude("1K+")).toBe(1000);
+    expect(parseMagnitude("2K")).toBe(2000);
+  });
+
+  it("parses fractional-K buckets (regression: .replace('K','000') produced NaN)", () => {
+    expect(parseMagnitude("2.5K+")).toBe(2500);
+    expect(parseMagnitude("1.2K")).toBe(1200);
+  });
+
+  it("parses bare numbers and M buckets", () => {
+    expect(parseMagnitude("750+")).toBe(750);
+    expect(parseMagnitude("1,500+")).toBe(1500);
+    expect(parseMagnitude("1M+")).toBe(1000000);
+  });
+
+  it("returns null for unparseable or zero values", () => {
+    expect(parseMagnitude("")).toBeNull();
+    expect(parseMagnitude("lots")).toBeNull();
+    expect(parseMagnitude("0")).toBeNull();
+    expect(parseMagnitude("0K")).toBeNull();
+  });
+});
+
+describe("SubstackClient.getSubscriberCount", () => {
+  const client = () =>
+    new SubstackClient("https://example.substack.com", "tok123", "42");
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  const jsonResponse = (body: unknown) =>
+    ({ ok: true, status: 200, json: async () => body, text: async () => JSON.stringify(body) }) as Response;
+  const htmlResponse = (html: string) =>
+    ({ ok: true, status: 200, text: async () => html }) as Response;
+
+  it("reports exact when the API returns subscriber_count", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(jsonResponse({ subscriber_count: 1073 }));
+    const r = await client().getSubscriberCount();
+    expect(r).toMatchObject({ count: 1073, precision: "exact" });
+  });
+
+  it("NEVER counts the paginated subscribers sample as the total", async () => {
+    // The regression this guards: an 11-item sample was returned as count: 11
+    // for a publication with >1,000 subscribers.
+    const sample = { subscribers: Array.from({ length: 11 }, (_, i) => ({ id: i })) };
+    vi.spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(jsonResponse(sample))
+      .mockResolvedValueOnce(htmlResponse('{"freeSubscriberCount":"1,000"}'));
+    const r = await client().getSubscriberCount();
+    expect(r.count).not.toBe(11);
+    expect(r).toMatchObject({ count: 1000, precision: "approximate" });
+  });
+
+  it("falls back to the rounded public value and marks it approximate", async () => {
+    vi.spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(jsonResponse({ audience: null }))
+      .mockResolvedValueOnce(htmlResponse('{\\"freeSubscriberCount\\":\\"1,000\\"}'));
+    const r = await client().getSubscriberCount();
+    expect(r.precision).toBe("approximate");
+    expect(r.count).toBe(1000);
+    expect(r.note).toMatch(/or higher/);
+  });
+
+  it("uses the order-of-magnitude bucket when no numeric count is present", async () => {
+    vi.spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(jsonResponse({}))
+      .mockResolvedValueOnce(htmlResponse('{"freeSubscriberCountOrderOfMagnitude":"2.5K+"}'));
+    const r = await client().getSubscriberCount();
+    expect(r).toMatchObject({ count: 2500, precision: "approximate" });
+  });
+
+  it("returns unavailable rather than a fabricated number when everything fails", async () => {
+    vi.spyOn(globalThis, "fetch").mockRejectedValue(new Error("network down"));
+    const r = await client().getSubscriberCount();
+    expect(r).toMatchObject({ count: -1, precision: "unavailable" });
   });
 });

--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -14,6 +14,25 @@ import {
 } from "./types.js";
 import { mapHttpStatusToError, extractErrorDetail } from "../utils/errors.js";
 
+/**
+ * Parse Substack's order-of-magnitude subscriber bucket into a number.
+ *
+ * Values look like "1K+", "2.5K+", "750+", "1M+". Exported for tests.
+ *
+ * The previous implementation did `.replace("K", "000")`, which turns "2.5K"
+ * into "2.5000" and then NaN — so any publication in a fractional-K bucket
+ * silently lost its count.
+ */
+export function parseMagnitude(raw: string): number | null {
+  const m = raw.trim().replace(/,/g, "").match(/^([\d.]+)\s*([KMkm]?)\+?$/);
+  if (!m) return null;
+  const base = parseFloat(m[1]);
+  if (!Number.isFinite(base)) return null;
+  const scale = m[2].toUpperCase() === "M" ? 1_000_000 : m[2].toUpperCase() === "K" ? 1_000 : 1;
+  const n = Math.round(base * scale);
+  return n > 0 ? n : null;
+}
+
 export class SubstackClient {
   private publicationUrl: string;
   private cookie: string;
@@ -90,29 +109,96 @@ export class SubstackClient {
     return { id: byline?.id ?? this.userId, name: "authenticated" };
   }
 
-  async getSubscriberCount(): Promise<{ count: number; note: string }> {
-    // Try multiple endpoints — Substack's API is inconsistent
+  /**
+   * Subscriber count, with its precision stated rather than implied.
+   *
+   * As of 2026-07, `publication_launch_checklist` no longer returns
+   * `subscriber_count`/`subscriberCount` — it returns `subscribers` as an
+   * ~11-item paginated SAMPLE. This method used to fall back to that array's
+   * length, which reported "11 subscribers" for a publication with over a
+   * thousand. A wrong number with a caveat attached is still a wrong number:
+   * callers (and models reading the tool result) use the integer, not the prose.
+   * So the sample is never counted.
+   *
+   * Substack rounds the free subscriber count on every surface reachable without
+   * its internal dashboard API — the public page AND the authenticated
+   * /publish/home payload both report e.g. "1,000" for a true 1,073. So
+   * `approximate` is the honest ceiling for the fallback path, and callers should
+   * render it hedged ("1,000+") rather than as an exact figure.
+   */
+  async getSubscriberCount(): Promise<{
+    count: number;
+    precision: "exact" | "approximate" | "unavailable";
+    note: string;
+  }> {
     try {
       const data = await this.request<Record<string, unknown>>(
         `${this.publicationUrl}/api/v1/publication_launch_checklist`,
       );
+      // Kept in case Substack restores these fields.
       if (typeof data.subscriber_count === "number") {
-        return { count: data.subscriber_count, note: "exact" };
+        return { count: data.subscriber_count, precision: "exact", note: "Exact count from the publication API." };
       }
       if (typeof data.subscriberCount === "number") {
-        return { count: data.subscriberCount, note: "exact" };
-      }
-      // The subscribers field is a paginated sample, not the full list
-      if (Array.isArray(data.subscribers)) {
-        return {
-          count: data.subscribers.length,
-          note: "sample only — this is a paginated subset, not the total. Check your Substack dashboard for the exact count.",
-        };
+        return { count: data.subscriberCount, precision: "exact", note: "Exact count from the publication API." };
       }
     } catch {
-      // Fall through
+      // Fall through to the public page.
     }
-    return { count: -1, note: "Could not retrieve subscriber count. Check your Substack dashboard." };
+
+    const rounded = await this.getRoundedSubscriberCount();
+    if (rounded !== null) {
+      return {
+        count: rounded,
+        precision: "approximate",
+        note:
+          `Approximate — Substack rounds this value, so the true count is ${rounded} or higher. ` +
+          "Render it hedged (e.g. \"" + rounded.toLocaleString("en-US") + "+\"), not as exact. " +
+          "The publication API no longer exposes an exact count; see your Substack dashboard.",
+      };
+    }
+
+    return {
+      count: -1,
+      precision: "unavailable",
+      note: "Could not retrieve subscriber count. Check your Substack dashboard.",
+    };
+  }
+
+  /**
+   * Scrape the rounded free-subscriber count off the publication page.
+   * Returns null when no count can be parsed. Never throws.
+   */
+  private async getRoundedSubscriberCount(): Promise<number | null> {
+    let html: string;
+    try {
+      const res = await fetch(`${this.publicationUrl}/`, {
+        headers: { "User-Agent": this.userAgent },
+        redirect: "follow",
+      });
+      if (!res.ok) return null;
+      html = await res.text();
+    } catch {
+      return null;
+    }
+
+    // Substack embeds JSON in script tags with escaped quotes.
+    const normalized = html.replace(/\\"/g, '"');
+
+    const exactish = normalized.match(/"freeSubscriberCount"\s*:\s*"?([\d,]+)"?/);
+    if (exactish) {
+      const n = parseInt(exactish[1].replace(/,/g, ""), 10);
+      if (Number.isFinite(n) && n > 0) return n;
+    }
+
+    // Order-of-magnitude bucket, e.g. "1K+", "2.5K+", "750+".
+    const oom = normalized.match(/"freeSubscriberCountOrderOfMagnitude"\s*:\s*"([^"]+)"/);
+    if (oom) {
+      const n = parseMagnitude(oom[1]);
+      if (n !== null) return n;
+    }
+
+    return null;
   }
 
   async getPublishedPosts(

--- a/src/server.ts
+++ b/src/server.ts
@@ -21,7 +21,11 @@ export function createServer(client: SubstackClient): McpServer {
   server.registerTool(
     "get_subscriber_count",
     {
-      description: "Get the current subscriber count for your Substack publication",
+      description:
+        "Get the current subscriber count for your Substack publication. Returns `precision`: " +
+        "'exact' when the API reports a true count, 'approximate' when only Substack's rounded " +
+        "value is available (the real number is that or higher — render it hedged, e.g. '1,000+'), " +
+        "or 'unavailable' with count -1. Never treat an approximate value as exact.",
       inputSchema: {},
       annotations: buildAnnotations("get_subscriber_count"),
     },


### PR DESCRIPTION
## The bug

`getSubscriberCount()` fell back to `data.subscribers.length` when the API didn't return an exact count. As of 2026-07, Substack's `publication_launch_checklist` **no longer returns** `subscriber_count`/`subscriberCount` — it returns `subscribers` as an ~11-item paginated sample, and `audience: null`.

So the tool reported **11 subscribers for a publication with over a thousand.**

Found while tracing why a downstream dashboard was publishing a wrong newsletter figure.

## Why the existing note wasn't enough

`client.ts:106-110` did attach `note: "sample only — this is a paginated subset..."`. That isn't sufficient: callers — and models reading the tool result — use the **integer**, not the prose. A wrong number with a caveat attached is still a wrong number. The sample is now never counted.

## The fix

Falls back to the rounded free-subscriber count from the publication page and *labels its precision*. Return shape gains `precision`:

| Value | Meaning |
|---|---|
| `exact` | API reported a true count (kept, in case Substack restores the field) |
| `approximate` | Only Substack's rounded value available — real count is that **or higher**, render hedged |
| `unavailable` | `count: -1`, nothing parseable |

The tool description now tells the model to render approximate values hedged and never treat them as exact.

**Why `approximate` is the honest ceiling:** Substack rounds this value on every surface reachable without its internal dashboard API. I checked the public page *and* the authenticated `/publish/home` and `/publish/subscribers` payloads — all three embed `freeSubscriberCount: "1,000"` for a publication whose true count is 1,073. There is no endpoint left that returns the exact number.

## Live verification

Against a real publication, same credentials:

```
before:  { count: 11, note: "sample only — ..." }
after:   { count: 1000, precision: "approximate",
           note: "Approximate — Substack rounds this value, so the true count is 1000 or higher..." }
```

## Also fixed: a latent NaN

The order-of-magnitude bucket was decoded with `.replace("K", "000")`, which turns `"2.5K"` into `"2.5000"` → `NaN`. Any publication in a fractional-K bucket silently lost its count. `parseMagnitude()` now handles whole and fractional K/M buckets, is null-safe, and is exported for tests.

## Tests

10 new, including a named regression test that the 11-item sample is never returned as the total, and cases for `2.5K+`, `1,500+`, `1M+`, `0K`, and the all-paths-fail case.

- `npm test` → **249 passed**, 13 files
- `npm run lint` (`tsc --noEmit`) → clean
- `npm run build` → clean

## ⚠️ Breaking

`get_subscriber_count` output gains a `precision` field and the `note` text changed. `count` keeps its meaning, except that it is no longer ever a sample length. Worth a minor version bump — currently 0.6.0.