### PR TITLE
Add UTM tags to chainofthought.show and conorbronsdon.com links

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ An MCP server for Substack. Read your publication data and manage drafts from yo
 [![Language: TypeScript](https://img.shields.io/badge/TypeScript-3178c6?style=flat-square&logo=typescript&logoColor=white)](https://www.typescriptlang.org/)
 [![npm version](https://img.shields.io/npm/v/@conorbronsdon/substack-mcp?style=flat-square)](https://www.npmjs.com/package/@conorbronsdon/substack-mcp)
 [![MCP](https://img.shields.io/badge/MCP-Model_Context_Protocol-1f6feb?style=flat-square)](https://modelcontextprotocol.io/)
-[![Podcast](https://img.shields.io/badge/Podcast-Chain_of_Thought-purple?style=flat-square)](https://chainofthought.show)
+[![Podcast](https://img.shields.io/badge/Podcast-Chain_of_Thought-purple?style=flat-square)](https://chainofthought.show/?utm_source=github&utm_medium=referral&utm_campaign=repo-readme&utm_content=substack-mcp)
 [![X](https://img.shields.io/badge/X-@ConorBronsdon-black?style=flat-square&logo=x)](https://x.com/ConorBronsdon)
 
 </div>
@@ -27,7 +27,7 @@ An MCP server for Substack that lets AI assistants read your publication data an
 
 ## About
 
-Built and maintained by [Conor Bronsdon](https://github.com/conorbronsdon) for the [Chain of Thought](https://chainofthought.show) podcast production workflow, where it drafts and reviews newsletter posts before a human hits publish. Conor hosts Chain of Thought, a show about AI infrastructure and how practitioners actually build with it. More tools for creators live in [ai-tools-for-creators](https://github.com/conorbronsdon/ai-tools-for-creators). Find Conor on X at [@ConorBronsdon](https://x.com/ConorBronsdon).
+Built and maintained by [Conor Bronsdon](https://github.com/conorbronsdon) for the [Chain of Thought](https://chainofthought.show/?utm_source=github&utm_medium=referral&utm_campaign=repo-readme&utm_content=substack-mcp) podcast production workflow, where it drafts and reviews newsletter posts before a human hits publish. Conor hosts Chain of Thought, a show about AI infrastructure and how practitioners actually build with it. More tools for creators live in [ai-tools-for-creators](https://github.com/conorbronsdon/ai-tools-for-creators). Find Conor on X at [@ConorBronsdon](https://x.com/ConorBronsdon).
 
 **Sibling MCP servers:**
 - [Transistor-MCP](https://github.com/conorbronsdon/Transistor-MCP): manage podcast episodes, analytics, and transcripts on Transistor.fm


### PR DESCRIPTION
Part of the repo-wide sweep in conorbronsdon/cot-production#115.

Tags the 2 link(s) in this repo's markdown so referral traffic to the show and to conorbronsdon.com is attributable:

```
?utm_source=github&utm_medium=referral&utm_campaign=repo-readme&utm_content=substack-mcp
```

Untagged, every repo's About footer and Chain of Thought badge lands in GA4's **Direct** bucket, indistinguishable from every other repo. `utm_content` carries the repo name so this one reports as its own row.

Applied by `scripts/utm-tag-links.py` in cot-production; `--check` exits 0 on this branch. Link targets and anchor text are unchanged — only the query string is added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)