### PR TITLE
Add a Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,33 @@
+# substack-mcp — stdio MCP server for Substack
+# Build:  docker build -t substack-mcp .
+# Run:    docker run -i --rm \
+#           -e SUBSTACK_PUBLICATION_URL=https://example.substack.com \
+#           -e SUBSTACK_SESSION_TOKEN=... \
+#           -e SUBSTACK_USER_ID=... \
+#           substack-mcp
+
+FROM node:22-alpine AS builder
+WORKDIR /app
+COPY package.json package-lock.json tsconfig.json ./
+COPY src ./src
+RUN npm ci --ignore-scripts && npm run build
+
+FROM node:22-alpine
+WORKDIR /app
+ENV NODE_ENV=production
+COPY package.json package-lock.json ./
+RUN npm ci --omit=dev --ignore-scripts
+COPY --from=builder /app/dist ./dist
+
+# Credentials come from the environment and are never baked into the image:
+#   SUBSTACK_PUBLICATION_URL — e.g. https://example.substack.com
+#   SUBSTACK_SESSION_TOKEN   — the `substack.sid` cookie value
+#   SUBSTACK_USER_ID         — numeric Substack user id
+# All three are optional at startup. The server starts without them and answers
+# introspection (initialize, tools/list); each tool call then fails with a clear
+# error until the credentials are set. The browser-login flow that writes
+# ~/.substack-mcp/session.json binds its key to the OS account and hostname, so
+# a stored session is not portable into a container — use the env vars here.
+
+USER node
+CMD ["node", "dist/index.js"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,14 +18,21 @@ ENV NODE_ENV=production
 COPY package.json package-lock.json ./
 RUN npm ci --omit=dev --ignore-scripts
 COPY --from=builder /app/dist ./dist
+# tsconfig has no test exclusion, so tsc emits src/__tests__ into dist. Those
+# files import vitest, which --omit=dev correctly leaves out, so they are dead
+# weight and scanner surface in a published image.
+RUN rm -rf dist/__tests__
 
 # Credentials come from the environment and are never baked into the image:
 #   SUBSTACK_PUBLICATION_URL — e.g. https://example.substack.com
-#   SUBSTACK_SESSION_TOKEN   — the `substack.sid` cookie value
+#   SUBSTACK_SESSION_TOKEN   — the `connect.sid` cookie value (`substack.sid`
+#                              on a *.substack.com domain)
 #   SUBSTACK_USER_ID         — numeric Substack user id
 # All three are optional at startup. The server starts without them and answers
-# introspection (initialize, tools/list); each tool call then fails with a clear
-# error until the credentials are set. The browser-login flow that writes
+# introspection (initialize, tools/list); each tool call then returns
+# isError: true until the credentials are set. The message points at the failing
+# request path rather than naming the missing variable, which is worth tightening
+# in the server itself. The browser-login flow that writes
 # ~/.substack-mcp/session.json binds its key to the OS account and hostname, so
 # a stored session is not portable into a container — use the env vars here.
 


### PR DESCRIPTION
Adds a Dockerfile. `docker/mcp-registry` and Glama both require the server to start in a container and answer an MCP introspection request, and there was no image to run.

Same two-stage pattern as podcastindex-mcp, op3-mcp, gsc-mcp, postlint-mcp, and apple-podcasts-mcp: `node:22-alpine` builder installs dev dependencies and runs `npm run build`, the runtime stage does a `--omit=dev` install and copies `dist/` in, and the process runs as the `node` user over stdio. Credentials are read from `SUBSTACK_PUBLICATION_URL`, `SUBSTACK_SESSION_TOKEN`, and `SUBSTACK_USER_ID` at runtime and are never baked into the image. The comment block also notes that a session saved by `substack-mcp-login` is not portable into a container, because its encryption key is derived from the OS account and hostname.

The server starts without credentials, warns on stderr, and answers `initialize` and `tools/list`. Tool calls then return `isError: true` until credentials are set. That is what lets an introspection-only check pass with no Substack account attached.

Verification, run against a clean `docker build --no-cache -t substack-mcp-test .`:

```
$ printf '%s\n' \
  '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"c","version":"1"}}}' \
  '{"jsonrpc":"2.0","method":"notifications/initialized"}' \
  '{"jsonrpc":"2.0","id":2,"method":"tools/list"}' \
  | docker run -i --rm substack-mcp-test

Warning: Missing credentials: SUBSTACK_PUBLICATION_URL, SUBSTACK_SESSION_TOKEN, SUBSTACK_USER_ID
Set them as SUBSTACK_* env vars, or run `substack-mcp-login` to sign in via browser. See README.md.
Warning: Authentication failed. Tools will error until a valid session token is provided.
Failed to parse URL from /api/v1/post_management/drafts?offset=0&limit=1&order_by=draft_updated_at&order_direction=desc
Substack MCP server running on stdio
{"result":{"protocolVersion":"2024-11-05","capabilities":{"tools":{"listChanged":true}},"serverInfo":{"name":"substack-mcp","version":"0.6.0"}},"jsonrpc":"2.0","id":1}
{"result":{"tools":[{"name":"get_subscriber_count", ... }]},"jsonrpc":"2.0","id":2}
```

14 tools listed: `get_subscriber_count`, `list_published_posts`, `list_drafts`, `get_post`, `get_draft`, `get_post_comments`, `get_sections`, `get_post_analytics`, `list_scheduled_posts`, `create_draft`, `update_draft`, `upload_image`, `create_note`, `create_note_with_link`.

A follow-up `tools/call` for `get_sections` with no credentials returned `{"result":{"content":[{"type":"text","text":"Failed to parse URL from /api/v1/subscriptions"}],"isError":true},"jsonrpc":"2.0","id":3}` — it fails per-call as intended, though the message names a URL rather than the missing env vars. Worth tightening separately; it is existing behavior, not something this PR changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
