### PR TITLE
Add a security policy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,15 @@
+# Security
+
+This server holds a live session credential, so it deserves more care than a read-only API client.
+
+`SUBSTACK_SESSION_TOKEN` is your `connect.sid` cookie. Anyone holding it can act as you on Substack for as long as it stays valid, which is roughly 90 days. It is read from the environment and never logged. The browser-login flow stores a session under `~/.substack-mcp/session.json` encrypted with a key derived from your OS account and hostname, so the file does not decrypt on another machine. If you think a token has leaked, log out of Substack to invalidate the session and mint a new one.
+
+The server talks to Substack's unofficial API. Endpoints can change without notice, and a change can alter what a tool does.
+
+Long-form posts are draft-only by design: there is no publish and no delete tool. Notes are the exception, because Notes have no draft state on Substack. `create_note` and `create_note_with_link` publish immediately, with no preview and no undo. Treat them as public-publish actions when you decide what an agent is allowed to call.
+
+## Reporting a vulnerability
+
+Use GitHub's private vulnerability reporting: open the **Security** tab on this repo and click **Report a vulnerability**. Do not open a public issue for security problems.
+
+I aim to respond within a week. Credit goes to the reporter in the fix notes unless you prefer otherwise.


### PR DESCRIPTION
Docker's `mcp-registry` pull request template has a Basic Requirements checklist with a **Security Contact** line, and this repo had no disclosure route beyond opening a public issue. Registry PR #4613 is sitting in draft with that box honestly unchecked.

This one gets more than the two-line version the sibling servers have, because this server is the one that holds a live credential. The file states what `SUBSTACK_SESSION_TOKEN` actually is, what someone holding it can do, how long it lasts, and how to revoke it. It also records that the stored session at `~/.substack-mcp/session.json` derives its key from the OS account and hostname (`src/auth/session-store.ts`), so the file does not decrypt elsewhere.

It repeats the Notes boundary too. Long-form posts are draft-only, but `create_note` and `create_note_with_link` publish immediately with no undo, and that is the kind of thing someone deciding what an agent may call should find in the security policy rather than only in the README.

Merging this unblocks ticking the box on #4613.