### PR TITLE
fix: cap pagination limit at Substack's 50, unbreaking get_post_analytics (#28)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,31 @@ and the git tag history (`v0.1.0`–`v0.5.0`).
 
 ## [Unreleased]
 
+## [0.6.1] - 2026-08-03
+
+### Fixed
+- `get_post_analytics` no longer fails on every call. It paged the published
+  feed with a hardcoded `pageSize = 100`, and Substack's `post_management`
+  endpoints reject any `limit` above 50 — so the very first page request 400'd
+  regardless of which post ID was passed. Page size is now the new exported
+  `MAX_PAGE_SIZE` (50) and the page bound rises from 5 to 10, preserving the
+  documented 500-post scan depth. Pages are still awaited one at a time, so the
+  worst case is 10 sequential requests, and only when the ID is absent from the
+  feed entirely. (#28)
+- `list_published_posts`, `list_drafts`, and `list_scheduled_posts` clamp
+  `limit` to 50 rather than 100. The default of 25 kept this latent, but any
+  caller passing a larger value got a 400 from Substack. Over-cap values are
+  still clamped rather than rejected, so existing callers passing 100 keep
+  working. (#28)
+
+### Changed
+- The three `limit` parameters now advertise `1-50` instead of `1-100`. The tool
+  description is what tells a model which values are legal, so the wrong number
+  there was actively producing the failing calls. (#28)
+- `get_post_analytics` derives the "500 most recent posts" figure in its
+  description and its not-found note from `MAX_PAGE_SIZE * ANALYTICS_MAX_PAGES`
+  instead of restating the literal, so it cannot rot when either changes. (#28)
+
 ## [0.6.0] - 2026-07-10
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@conorbronsdon/substack-mcp",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "MCP server for Substack — read posts, manage drafts, publish Notes. Long-form posts are draft-only by design (no publish, no delete); Notes publish immediately.",
   "type": "module",
   "bin": {

--- a/src/__tests__/client.test.ts
+++ b/src/__tests__/client.test.ts
@@ -1,5 +1,11 @@
 import { describe, it, expect, vi, afterEach } from "vitest";
-import { SubstackClient, parseMagnitude } from "../api/client.js";
+import {
+  SubstackClient,
+  parseMagnitude,
+  MAX_PAGE_SIZE,
+  ANALYTICS_MAX_PAGES,
+  ANALYTICS_SCAN_DEPTH,
+} from "../api/client.js";
 import {
   AuthenticationError,
   RateLimitError,
@@ -166,7 +172,8 @@ describe("SubstackClient requests", () => {
     const post = await client.getPostAnalytics(999);
 
     expect(post).toBeNull();
-    // A short page (1 < 100) means end-of-feed: exactly one request, no over-paging.
+    // A short page (1 < MAX_PAGE_SIZE) means end-of-feed: exactly one request,
+    // no over-paging.
     expect(fetchMock).toHaveBeenCalledTimes(1);
   });
 
@@ -205,6 +212,109 @@ describe("SubstackClient requests", () => {
 
     const opts = fetchMock.mock.calls[0][1] as { headers: Record<string, string> };
     expect(opts.headers["Content-Type"]).toBe("application/json");
+  });
+});
+
+describe("pagination limit cap (regression: #28)", () => {
+  afterEach(() => vi.unstubAllGlobals());
+
+  // Substack 400s on limit=51 and above, so every request this client issues on
+  // its own initiative must carry a limit VALUE within the cap. The pre-fix
+  // suite passed with limit=100 on the wire because it only asserted that the
+  // URL *contained* the endpoint path — a shape assertion cannot see a bad
+  // value. These read the query params back off the URLs the client actually
+  // built.
+  function paramValues(
+    fetchMock: { mock: { calls: any[][] } },
+    name: string,
+  ): number[] {
+    return fetchMock.mock.calls
+      .map((call) => new URL(String(call[0])).searchParams.get(name))
+      .filter((v): v is string => v !== null)
+      .map(Number);
+  }
+
+  /**
+   * A published feed that honors offset/limit, so paging behavior follows the
+   * page size the client asks for rather than a fixture hardcoded around one.
+   */
+  function stubPagedFeed(totalPosts: number) {
+    const fetchMock = vi.fn(async (url: any) => {
+      const params = new URL(String(url)).searchParams;
+      const offset = Number(params.get("offset") ?? 0);
+      const limit = Number(params.get("limit") ?? 0);
+      const count = Math.max(0, Math.min(limit, totalPosts - offset));
+      const body = {
+        posts: Array.from({ length: count }, (_, i) => ({
+          id: offset + i + 1,
+          title: `Post ${offset + i + 1}`,
+          stats: { views: 1 },
+        })),
+        total: totalPosts,
+      };
+      return {
+        ok: true,
+        status: 200,
+        json: async () => body,
+        text: async () => JSON.stringify(body),
+      };
+    });
+    vi.stubGlobal("fetch", fetchMock);
+    return fetchMock;
+  }
+
+  it("MAX_PAGE_SIZE is within Substack's observed 50 cap", () => {
+    // limit=50 → 200, limit=51 → 400 "Invalid value" (probed 2026-08-02).
+    expect(MAX_PAGE_SIZE).toBeLessThanOrEqual(50);
+    expect(MAX_PAGE_SIZE).toBeGreaterThan(0);
+  });
+
+  it("preserves the documented 500-post analytics scan depth", () => {
+    expect(MAX_PAGE_SIZE * ANALYTICS_MAX_PAGES).toBe(500);
+    expect(ANALYTICS_SCAN_DEPTH).toBe(500);
+  });
+
+  it("getPostAnalytics sends a limit value within the cap on every page", async () => {
+    const fetchMock = stubPagedFeed(10_000); // feed deeper than the scan bound
+    const client = new SubstackClient("https://example.substack.com", "tok", "1");
+
+    // An id past the scan depth, so the loop runs to its bound.
+    const post = await client.getPostAnalytics(9_999);
+    expect(post).toBeNull();
+
+    const limits = paramValues(fetchMock, "limit");
+    // Every request carries a limit — none slipped through unparameterized.
+    expect(limits).toHaveLength(fetchMock.mock.calls.length);
+    expect(fetchMock).toHaveBeenCalledTimes(ANALYTICS_MAX_PAGES);
+    // The value, not the shape: no page may exceed what Substack accepts.
+    expect(Math.max(...limits)).toBeLessThanOrEqual(MAX_PAGE_SIZE);
+    expect(limits).toEqual(Array(ANALYTICS_MAX_PAGES).fill(MAX_PAGE_SIZE));
+  });
+
+  it("getPostAnalytics tiles offsets across exactly the scan depth", async () => {
+    const fetchMock = stubPagedFeed(10_000);
+    const client = new SubstackClient("https://example.substack.com", "tok", "1");
+    await client.getPostAnalytics(9_999);
+
+    const offsets = paramValues(fetchMock, "offset");
+    expect(offsets).toEqual(
+      Array.from({ length: ANALYTICS_MAX_PAGES }, (_, i) => i * MAX_PAGE_SIZE),
+    );
+    // Last page starts one page short of the bound, so the scan covers
+    // ANALYTICS_SCAN_DEPTH posts with no gap and no overshoot.
+    expect(Math.max(...offsets)).toBe(ANALYTICS_SCAN_DEPTH - MAX_PAGE_SIZE);
+    expect(Math.max(...offsets) + MAX_PAGE_SIZE).toBe(ANALYTICS_SCAN_DEPTH);
+  });
+
+  it("getPostAnalytics stops as soon as the post is found", async () => {
+    const fetchMock = stubPagedFeed(10_000);
+    const client = new SubstackClient("https://example.substack.com", "tok", "1");
+
+    // Post 60 lands on page 1 (offset 50), so page 2 must never be requested.
+    const post = await client.getPostAnalytics(60);
+    expect(post?.id).toBe(60);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(paramValues(fetchMock, "limit")).toEqual([MAX_PAGE_SIZE, MAX_PAGE_SIZE]);
   });
 });
 

--- a/src/__tests__/server.test.ts
+++ b/src/__tests__/server.test.ts
@@ -1,0 +1,122 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+import { createServer } from "../server.js";
+import {
+  SubstackClient,
+  MAX_PAGE_SIZE,
+  ANALYTICS_SCAN_DEPTH,
+} from "../api/client.js";
+
+/**
+ * Tool-layer regressions for #28.
+ *
+ * The clamp and the `describe` strings live in server.ts, so a client-only test
+ * cannot reach them — and the description is the load-bearing half: it is what
+ * tells a model that limit=100 is a legal argument. These drive the real
+ * registered tools over an in-memory MCP transport and assert the limit VALUE
+ * that reaches the wire.
+ */
+describe("tool pagination limits (regression: #28)", () => {
+  afterEach(() => vi.unstubAllGlobals());
+
+  function stubFetch() {
+    const body = { posts: [], total: 0 };
+    const fetchMock = vi.fn(async (..._args: any[]) => ({
+      ok: true,
+      status: 200,
+      json: async () => body,
+      text: async () => JSON.stringify(body),
+    }));
+    vi.stubGlobal("fetch", fetchMock);
+    return fetchMock;
+  }
+
+  async function connect() {
+    const server = createServer(
+      new SubstackClient("https://example.substack.com", "tok", "1"),
+    );
+    const [clientTransport, serverTransport] =
+      InMemoryTransport.createLinkedPair();
+    const client = new Client({ name: "test", version: "0.0.0" });
+    await Promise.all([
+      client.connect(clientTransport),
+      server.connect(serverTransport),
+    ]);
+    return client;
+  }
+
+  function limitOf(fetchMock: { mock: { calls: any[][] } }): number {
+    const url = new URL(String(fetchMock.mock.calls[0][0]));
+    return Number(url.searchParams.get("limit"));
+  }
+
+  const paginatedTools = [
+    "list_published_posts",
+    "list_drafts",
+    "list_scheduled_posts",
+  ] as const;
+
+  for (const name of paginatedTools) {
+    it(`${name} clamps an over-cap limit instead of sending it`, async () => {
+      const fetchMock = stubFetch();
+      const client = await connect();
+
+      // A caller (or a model reading the old "1-100" description) passing 100
+      // must not error — it gets clamped, not rejected.
+      const result = await client.callTool({
+        name,
+        arguments: { limit: 100 },
+      });
+
+      expect(result.isError).toBeFalsy();
+      expect(limitOf(fetchMock)).toBe(MAX_PAGE_SIZE);
+      expect(limitOf(fetchMock)).toBeLessThanOrEqual(MAX_PAGE_SIZE);
+    });
+
+    it(`${name} passes an under-cap limit through unchanged`, async () => {
+      const fetchMock = stubFetch();
+      const client = await connect();
+
+      await client.callTool({ name, arguments: { limit: 7 } });
+      expect(limitOf(fetchMock)).toBe(7);
+    });
+
+    it(`${name} advertises the real cap, not 100`, async () => {
+      const client = await connect();
+      const { tools } = await client.listTools();
+      const tool = tools.find((t) => t.name === name);
+      expect(tool).toBeDefined();
+
+      const described = String(
+        (tool!.inputSchema as any).properties?.limit?.description ?? "",
+      );
+      expect(described).toContain(`1-${MAX_PAGE_SIZE}`);
+      expect(described).not.toContain("1-100");
+    });
+  }
+
+  it("get_post_analytics derives its scan depth rather than restating 500", async () => {
+    const client = await connect();
+    const { tools } = await client.listTools();
+    const tool = tools.find((t) => t.name === "get_post_analytics");
+    expect(tool?.description).toContain(
+      `${ANALYTICS_SCAN_DEPTH} most recent published posts`,
+    );
+  });
+
+  it("get_post_analytics reports the same depth in its not-found note", async () => {
+    stubFetch(); // empty feed: the id is never found
+    const client = await connect();
+
+    const result = await client.callTool({
+      name: "get_post_analytics",
+      arguments: { post_id: 12345 },
+    });
+    const payload = JSON.parse((result.content as any[])[0].text);
+    expect(payload.found).toBe(false);
+    expect(payload.note).toContain(
+      `${ANALYTICS_SCAN_DEPTH} most recent published posts`,
+    );
+  });
+});

--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -15,6 +15,28 @@ import {
 import { mapHttpStatusToError, extractErrorDetail } from "../utils/errors.js";
 
 /**
+ * Largest `limit` Substack's post_management endpoints will accept.
+ *
+ * Probed directly against `/api/v1/post_management/published` (2026-08-02):
+ * `limit=50` → HTTP 200, `limit=51` → HTTP 400
+ * `{"errors":[{"location":"query","param":"limit","value":51,"msg":"Invalid value"}]}`,
+ * `limit=100` → 400. So 51 is the exact boundary and 50 is the largest page the
+ * API will serve. Never send a `limit` above this — the request fails outright
+ * rather than returning a truncated page.
+ */
+export const MAX_PAGE_SIZE = 50;
+
+/** Pages `getPostAnalytics` will scan before giving up. */
+export const ANALYTICS_MAX_PAGES = 10;
+
+/**
+ * How many of the most recent published posts `getPostAnalytics` searches.
+ * Derived, not stated: tool descriptions that quote this bound must interpolate
+ * it so they can't rot when either factor changes.
+ */
+export const ANALYTICS_SCAN_DEPTH = MAX_PAGE_SIZE * ANALYTICS_MAX_PAGES;
+
+/**
  * Parse Substack's order-of-magnitude subscriber bucket into a number.
  *
  * Values look like "1K+", "2.5K+", "750+", "1M+". Exported for tests.
@@ -340,9 +362,13 @@ export class SubstackClient {
     // Substack has no per-post stats endpoint. Each row of the published
     // feed already carries a `stats` object, so page through the feed
     // (newest first) until the matching id turns up. Bounded so a bad id
-    // can't scan forever: up to 500 of the most recent published posts.
-    const pageSize = 100;
-    const maxPages = 5;
+    // can't scan forever: ANALYTICS_SCAN_DEPTH most recent published posts.
+    //
+    // Pages are awaited one at a time, so the worst case is ANALYTICS_MAX_PAGES
+    // *sequential* requests, not a parallel burst — and that worst case only
+    // occurs when the id isn't in the feed at all. A found post short-circuits.
+    const pageSize = MAX_PAGE_SIZE;
+    const maxPages = ANALYTICS_MAX_PAGES;
     for (let page = 0; page < maxPages; page++) {
       const { posts } = await this.getPublishedPosts(page * pageSize, pageSize);
       const found = posts.find((p) => p.id === postId);

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,6 +1,10 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
-import { SubstackClient } from "./api/client.js";
+import {
+  SubstackClient,
+  MAX_PAGE_SIZE,
+  ANALYTICS_SCAN_DEPTH,
+} from "./api/client.js";
 import { buildAnnotations } from "./annotations.js";
 import { markdownToProseMirror, markdownToProseMirrorContent } from "./utils/markdown-to-prosemirror.js";
 import { fileToDataUri } from "./utils/image.js";
@@ -8,7 +12,7 @@ import { fileToDataUri } from "./utils/image.js";
 export function createServer(client: SubstackClient): McpServer {
   const server = new McpServer({
     name: "substack-mcp",
-    version: "0.6.0",
+    version: "0.6.1",
   });
 
   // Every tool is registered with MCP annotations derived from its declared
@@ -45,12 +49,18 @@ export function createServer(client: SubstackClient): McpServer {
       description: "List published posts with pagination. Returns title, date, slug, and URL for each post.",
       inputSchema: {
         offset: z.number().optional().default(0).describe("Number of posts to skip"),
-        limit: z.number().optional().default(25).describe("Max posts to return (1-100)"),
+        limit: z
+          .number()
+          .optional()
+          .default(25)
+          .describe(
+            `Max posts to return (1-${MAX_PAGE_SIZE}; Substack rejects anything higher, so larger values are clamped)`,
+          ),
       },
       annotations: buildAnnotations("list_published_posts"),
     },
     async ({ offset, limit }) => {
-      const { posts, total } = await client.getPublishedPosts(offset, Math.min(limit, 100));
+      const { posts, total } = await client.getPublishedPosts(offset, Math.min(limit, MAX_PAGE_SIZE));
       const summary = posts.map((p) => ({
         id: p.id,
         title: p.title,
@@ -73,12 +83,18 @@ export function createServer(client: SubstackClient): McpServer {
       description: "List draft posts. Returns title, creation date, and audience for each draft.",
       inputSchema: {
         offset: z.number().optional().default(0).describe("Number of drafts to skip"),
-        limit: z.number().optional().default(25).describe("Max drafts to return (1-100)"),
+        limit: z
+          .number()
+          .optional()
+          .default(25)
+          .describe(
+            `Max drafts to return (1-${MAX_PAGE_SIZE}; Substack rejects anything higher, so larger values are clamped)`,
+          ),
       },
       annotations: buildAnnotations("list_drafts"),
     },
     async ({ offset, limit }) => {
-      const drafts = await client.getDrafts(offset, Math.min(limit, 100));
+      const drafts = await client.getDrafts(offset, Math.min(limit, MAX_PAGE_SIZE));
       const summary = drafts.map((d) => ({
         id: d.id,
         title: d.draft_title,
@@ -212,7 +228,8 @@ export function createServer(client: SubstackClient): McpServer {
     "get_post_analytics",
     {
       description:
-        "Get performance stats (views, emails sent/delivered/opened, signups, subscribes, estimated value, comments, reactions) for a published post by ID. Substack has no per-post stats endpoint, so this searches your 500 most recent published posts for the ID; returns a not-found note if it isn't among them.",
+        "Get performance stats (views, emails sent/delivered/opened, signups, subscribes, estimated value, comments, reactions) for a published post by ID. " +
+        `Substack has no per-post stats endpoint, so this searches your ${ANALYTICS_SCAN_DEPTH} most recent published posts for the ID; returns a not-found note if it isn't among them.`,
       inputSchema: {
         post_id: z.number().describe("The published post ID to get stats for"),
       },
@@ -229,7 +246,7 @@ export function createServer(client: SubstackClient): McpServer {
                 {
                   found: false,
                   post_id,
-                  note: "Post not found among the 500 most recent published posts. Check the ID with list_published_posts.",
+                  note: `Post not found among the ${ANALYTICS_SCAN_DEPTH} most recent published posts. Check the ID with list_published_posts.`,
                 },
                 null,
                 2,
@@ -275,12 +292,18 @@ export function createServer(client: SubstackClient): McpServer {
         "List posts scheduled for future publication, soonest first. Read-only visibility into what's queued — scheduling itself is done in Substack's editor (this server does not schedule, publish, or delete long-form posts). Returns id, title, audience, and scheduled time (`trigger_at`).",
       inputSchema: {
         offset: z.number().optional().default(0).describe("Number of posts to skip"),
-        limit: z.number().optional().default(25).describe("Max posts to return (1-100)"),
+        limit: z
+          .number()
+          .optional()
+          .default(25)
+          .describe(
+            `Max posts to return (1-${MAX_PAGE_SIZE}; Substack rejects anything higher, so larger values are clamped)`,
+          ),
       },
       annotations: buildAnnotations("list_scheduled_posts"),
     },
     async ({ offset, limit }) => {
-      const posts = await client.getScheduledPosts(offset, Math.min(limit, 100));
+      const posts = await client.getScheduledPosts(offset, Math.min(limit, MAX_PAGE_SIZE));
       const summary = posts.map((p) => ({
         id: p.id,
         title: p.draft_title ?? p.title ?? null,


### PR DESCRIPTION
## What & why

Closes #28. `get_post_analytics` failed on every call. It pages the published feed looking for the requested post ID, with a hardcoded `pageSize = 100` — and Substack's `post_management` endpoints reject any `limit` above 50, so the first page request 400'd regardless of which ID was passed. The tool was unconditionally broken, not broken at the margin.

I probed the boundary directly against `/api/v1/post_management/published`:

| `limit` | Result |
|---|---|
| 50 | HTTP 200 |
| 51 | HTTP 400 `{"errors":[{"location":"query","param":"limit","value":51,"msg":"Invalid value"}]}` |
| 100 | HTTP 400 |

51 is the exact boundary, so 50 is the largest page the API will serve. That is now an exported `MAX_PAGE_SIZE`, with the probe recorded in its doc comment.

**Scan depth is preserved.** Page bound goes 5 → 10, so `MAX_PAGE_SIZE * ANALYTICS_MAX_PAGES` is still 500. Worth being explicit about the request-count read, because 10 pages sounds worse than it is: the loop `await`s each page in sequence, so this is **10 sequential requests worst case, not a parallel burst** — and that worst case only occurs when the post ID isn't in the feed at all. A found post short-circuits on the page it lands on. The rate-limit exposure is much lower than the number suggests.

**The list tools had the same cap wrong in two places.** `list_published_posts`, `list_drafts`, and `list_scheduled_posts` clamped with `Math.min(limit, 100)` and described their `limit` as `(1-100)`. The clamp only bites when a caller passes >50, which the default of 25 hid. The description is the worse half: it is what tells a model that 100 is a legal argument, so the wrong number there was actively generating the failing calls. Both now derive from `MAX_PAGE_SIZE`.

Kept clamping rather than switching to a zod `.max(50)`, so any caller already passing 100 gets a smaller page instead of a brand-new validation error.

**Derived, not restated.** `get_post_analytics` stated "500 most recent posts" as a literal in two places (its description and its not-found note). That number is `MAX_PAGE_SIZE * ANALYTICS_MAX_PAGES`, so it is now interpolated from `ANALYTICS_SCAN_DEPTH` and can't rot the next time either constant moves.

## About the tests

The existing suite passed 134/134 **with the bug present**. `client.test.ts` asserted only that the request URL *contained* `/api/v1/post_management/published` — a shape assertion, which cannot see a wrong value inside the shape it matched.

The new tests read the `limit` and `offset` values back off the URLs the client actually built, and drive the real registered tools over an in-memory MCP transport so the server-side clamp and the advertised cap are covered too (`src/__tests__/server.test.ts` is new — the clamp and the `describe` strings live in `server.ts`, out of reach of a client-only test).

I mutation-checked both before trusting them:

**Revert `pageSize` to 100** → 3 failures, first one:

```
FAIL src/__tests__/client.test.ts > pagination limit cap (regression: #28)
     > getPostAnalytics sends a limit value within the cap on every page
AssertionError: expected 100 to be less than or equal to 50
```

The other two catch the knock-on effects: offsets tile at 100 instead of 50 (`expected [0, 100, 200, …] to deeply equal [0, 50, 100, …]`), and the short-circuit test drops from 2 requests to 1.

**Revert the clamps and descriptions to 100** → 6 more failures:

```
AssertionError: expected 100 to be 50 // Object.is equality
AssertionError: expected 'Max posts to return (1-100; Substack …' to contain '1-50'
```

There are must-still-fire cases beside the must-not-fire ones: an under-cap `limit: 7` must still pass through unchanged, and an over-cap `limit: 100` must return a clamped result rather than an error.

## How verified

- [x] `npm run lint` clean (`tsc --noEmit`, exit 0)
- [x] `npm test` passing — 150/150 across 8 files, up from 134 (+16)
- [x] `npm run build` clean
- [x] Mutation-tested: reverting either fix turns the new tests red, with the messages above

## Safe-by-design checklist

- [x] No new publish / delete / schedule capability for long-form posts
- [x] Any immediate-publish behavior (Notes) stays loudly documented in the tool description

Version bumped to 0.6.1 in `package.json` and `src/server.ts` per the existing release convention (`server.json` is derived from `package.json` at publish time by #27's workflow), with a dated CHANGELOG entry. Note that merging this to `main` will trigger the trusted-publishing workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
