### PR TITLE
readme: companion list covers the whole stack

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,9 +29,13 @@ An MCP server for Substack that lets AI assistants read your publication data an
 
 Built and maintained by [Conor Bronsdon](https://github.com/conorbronsdon) for the [Chain of Thought](https://chainofthought.show/?utm_source=github&utm_medium=referral&utm_campaign=repo-readme&utm_content=substack-mcp) podcast production workflow, where it drafts and reviews newsletter posts before a human hits publish. Conor hosts Chain of Thought, a show about AI infrastructure and how practitioners actually build with it. More tools for creators live in [ai-tools-for-creators](https://github.com/conorbronsdon/ai-tools-for-creators). Find Conor on X at [@ConorBronsdon](https://x.com/ConorBronsdon).
 
-**Sibling MCP servers:**
+**Companion tools:**
 - [Transistor-MCP](https://github.com/conorbronsdon/Transistor-MCP): manage podcast episodes, analytics, and transcripts on Transistor.fm
 - [podcastindex-mcp](https://github.com/conorbronsdon/podcastindex-mcp): search the Podcast Index and track guest appearances
+- [op3-mcp](https://github.com/conorbronsdon/op3-mcp): report downloads, listener geography, and apps from OP3
+- [apple-podcasts-mcp](https://github.com/conorbronsdon/apple-podcasts-mcp): pull plays, followers, and per-episode listening from Apple Podcasts Connect
+- [gsc-mcp](https://github.com/conorbronsdon/gsc-mcp): query search performance, keywords, and sitemaps in Google Search Console
+- [podcast-benchmark](https://github.com/conorbronsdon/podcast-benchmark): benchmark a show against its peers using only public data
 
 ## Tools
 


### PR DESCRIPTION
The companion list here predated op3-mcp, apple-podcasts-mcp, gsc-mcp, and podcast-benchmark, so it still pointed only at Transistor-MCP and podcastindex-mcp. This adds the four newer tools in the same one-line format and retitles the section to 'Companion tools' — podcast-benchmark is a CLI, not an MCP server, so 'Sibling MCP servers' no longer fit.