### PR TITLE
Support multiple Substack publications behind one server

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,8 +4,10 @@ MCP server for Substack — read posts, manage drafts, create notes. Cannot publ
 
 ## Architecture
 - `src/index.ts` — MCP server bootstrap and entry point
-- `src/server.ts` — Tool registration, request handlers, Zod schema generation
+- `src/server.ts` — Tool registration, request handlers, Zod schema generation; `createServer(publications: PublicationConfig[])` takes one client per configured publication
 - `src/annotations.ts` — Tool side-effect classification (read / draft-write / public-upload / publish) → MCP annotations (hints set explicitly; MCP defaults omitted hints to the unsafe direction)
+- `src/auth/resolve-credentials.ts` — Single-publication env-var + stored-session credential resolution (the original, still-supported contract)
+- `src/auth/resolve-publications.ts` — Multi-publication credential resolution (`SUBSTACK_PUB_<KEY>_*` env vars), falling back to `resolve-credentials.ts` when none are set
 - `src/api/client.ts` — HTTP client for Substack API (session cookie auth)
 - `src/api/types.ts` — TypeScript interfaces for API responses
 - `src/utils/errors.ts` — Error handling utilities
@@ -17,6 +19,7 @@ MCP server for Substack — read posts, manage drafts, create notes. Cannot publ
 - Notes publish immediately via `create_note` / `create_note_with_link` — Substack has no note-draft state, so there is no preview step
 - Auth sends both `connect.sid` and `substack.sid` cookies set to the same session token (custom domains use `connect.sid`, substack.com uses `substack.sid`)
 - Markdown must be converted to ProseMirror format for Substack's editor
+- With 2+ publications configured (`SUBSTACK_PUB_<KEY>_*`), every tool gains a *required* `publication` enum parameter — no default, no guessing. With exactly one publication configured, no `publication` parameter is added at all (schema-identical to single-publication mode)
 
 ## Development
 ```bash

--- a/README.md
+++ b/README.md
@@ -167,6 +167,8 @@ Each triplet is independent, and setting *any* `SUBSTACK_PUB_<KEY>_*` variable d
 
 Keys are compared case-insensitively, with `_` folded to `-`. Two names that resolve to the same key (`SUBSTACK_PUB_ALPHA_*` and `SUBSTACK_PUB_Alpha_*`) are a startup error too — merging them silently would let one publication's URL pair with another's session token.
 
+`<KEY>` accepts ASCII letters, digits, and underscores; the three suffixes must be uppercase and the whole name must have no stray whitespace. Anything that begins with `SUBSTACK_PUB_` but does not fit that shape — a hyphen in the key, a lowercase suffix, an accented character, a trailing space — is a startup error naming the variable, not a variable that gets quietly ignored. For the same reason as above: an ignored publication is not one fewer publication, it is a silent reroute to a different one.
+
 With two or more publications configured, every tool gains a **required** `publication` parameter — one of your configured keys (e.g. `kevin-muldoon`, `sapere` above). The calling model must specify one on every call; an unrecognized value is rejected before any Substack API call is made, so a stray write can't land on the wrong publication. **With exactly one publication configured** — the common case, whether via plain `SUBSTACK_*` vars or a single `SUBSTACK_PUB_<KEY>_*` triplet — **no `publication` parameter is added at all**; every tool's schema is unchanged from single-publication mode.
 
 Don't mix the two styles: if any `SUBSTACK_PUB_<KEY>_*` var is set, the plain `SUBSTACK_*` vars are ignored (with a startup warning) rather than treated as an unnamed extra publication.

--- a/README.md
+++ b/README.md
@@ -148,6 +148,29 @@ Add to your `.mcp.json`:
 
 Ask your AI assistant: "How many Substack subscribers do I have?"
 
+## Multiple publications
+
+Running more than one publication behind a single server? Set a `SUBSTACK_PUB_<KEY>_*` triplet per publication instead of the plain `SUBSTACK_*` vars. `<KEY>` is any name you choose (letters, digits, underscores) — it becomes the publication's lowercase, hyphenated key, e.g. `KEVIN_MULDOON` → `kevin-muldoon`.
+
+```json
+"env": {
+  "SUBSTACK_PUB_KEVIN_MULDOON_PUBLICATION_URL": "https://kevinmuldoon.substack.com",
+  "SUBSTACK_PUB_KEVIN_MULDOON_SESSION_TOKEN": "token-1",
+  "SUBSTACK_PUB_KEVIN_MULDOON_USER_ID": "111",
+  "SUBSTACK_PUB_SAPERE_PUBLICATION_URL": "https://sapere.substack.com",
+  "SUBSTACK_PUB_SAPERE_SESSION_TOKEN": "token-2",
+  "SUBSTACK_PUB_SAPERE_USER_ID": "222"
+}
+```
+
+Each triplet is independent — an incomplete one (e.g. missing `_USER_ID`) fails startup with a clear error rather than silently dropping that publication.
+
+With two or more publications configured, every tool gains a **required** `publication` parameter — one of your configured keys (e.g. `kevin-muldoon`, `sapere` above). The calling model must specify one on every call; an unrecognized value is rejected before any Substack API call is made, so a stray write can't land on the wrong publication. **With exactly one publication configured** — the common case, whether via plain `SUBSTACK_*` vars or a single `SUBSTACK_PUB_<KEY>_*` triplet — **no `publication` parameter is added at all**; every tool's schema is unchanged from single-publication mode.
+
+Don't mix the two styles: if any `SUBSTACK_PUB_<KEY>_*` var is set, the plain `SUBSTACK_*` vars are ignored (with a startup warning) rather than treated as an unnamed extra publication.
+
+`SUBSTACK_USER_AGENT` and `SUBSTACK_REQUEST_TIMEOUT_MS` apply to every configured publication — they are not per-publication. The browser-login flow (`substack-mcp-login`) is single-publication only; multiple publications require the env-var scheme above.
+
 ## Token expiration
 
 Substack session tokens expire periodically (typically ~90 days). If you get authentication errors, grab a fresh `connect.sid` cookie from your browser and update the env var (make sure ad blockers are disabled when copying the cookie) — or, if you used the browser login, just re-run `substack-mcp-login` to refresh the stored session.

--- a/README.md
+++ b/README.md
@@ -163,7 +163,9 @@ Running more than one publication behind a single server? Set a `SUBSTACK_PUB_<K
 }
 ```
 
-Each triplet is independent — an incomplete one (e.g. missing `_USER_ID`) fails startup with a clear error rather than silently dropping that publication.
+Each triplet is independent, and setting *any* `SUBSTACK_PUB_<KEY>_*` variable declares that publication. An incomplete triplet — a missing variable, an empty value, or a whitespace-only value — fails startup with an error naming the key, rather than silently dropping that publication. That matters because a dropped publication is not "one fewer publication": drop the only one and the server falls back to your stored browser-login session; drop one of two and every tool loses its `publication` parameter, so a call meant for the dropped publication routes silently to the surviving one.
+
+Keys are compared case-insensitively, with `_` folded to `-`. Two names that resolve to the same key (`SUBSTACK_PUB_ALPHA_*` and `SUBSTACK_PUB_Alpha_*`) are a startup error too — merging them silently would let one publication's URL pair with another's session token.
 
 With two or more publications configured, every tool gains a **required** `publication` parameter — one of your configured keys (e.g. `kevin-muldoon`, `sapere` above). The calling model must specify one on every call; an unrecognized value is rejected before any Substack API call is made, so a stray write can't land on the wrong publication. **With exactly one publication configured** — the common case, whether via plain `SUBSTACK_*` vars or a single `SUBSTACK_PUB_<KEY>_*` triplet — **no `publication` parameter is added at all**; every tool's schema is unchanged from single-publication mode.
 

--- a/src/__tests__/annotations.test.ts
+++ b/src/__tests__/annotations.test.ts
@@ -4,8 +4,10 @@ import { createServer } from "../server.js";
 import type { SubstackClient } from "../api/client.js";
 
 // The server only touches the client inside tool handlers, which these tests
-// never invoke — a bare object is enough to register everything.
-const server = createServer({} as SubstackClient);
+// never invoke — a bare object is enough to register everything. A single
+// publication keeps every tool's schema unchanged (see server.ts), which is
+// what this file's name-only completeness check assumes.
+const server = createServer([{ key: "default", label: "Default", client: {} as SubstackClient }]);
 
 interface RegisteredToolShape {
   description?: string;

--- a/src/__tests__/resolve-publications.test.ts
+++ b/src/__tests__/resolve-publications.test.ts
@@ -98,3 +98,87 @@ describe("resolvePublications", () => {
     expect(warn).toHaveBeenCalledWith(expect.stringMatching(/legacy/i));
   });
 });
+
+/**
+ * A named publication's variable *name* is what declares intent, so an empty
+ * value has to be an error. If empty values are skipped instead, the group
+ * disappears — and a disappeared group is not "no configuration", it is a
+ * different, more dangerous configuration. Both cases below were reachable at
+ * eaa84bb.
+ */
+describe("resolvePublications: an empty named publication must not disappear", () => {
+  it("does not fall back to a stored session when a named publication is present but empty", () => {
+    const loader = vi.fn(() => stored);
+    const env = {
+      SUBSTACK_PUB_SAPERE_PUBLICATION_URL: "",
+      SUBSTACK_PUB_SAPERE_SESSION_TOKEN: "",
+      SUBSTACK_PUB_SAPERE_USER_ID: "",
+    } as NodeJS.ProcessEnv;
+
+    expect(() => resolvePublications(env, loader)).toThrow(/sapere/i);
+    expect(loader).not.toHaveBeenCalled();
+  });
+
+  it("does not collapse to single-publication routing when one valid triplet sits beside an all-empty one", () => {
+    const loader = vi.fn(() => stored);
+    const env = {
+      SUBSTACK_PUB_SAPERE_PUBLICATION_URL: "https://sapere.substack.com",
+      SUBSTACK_PUB_SAPERE_SESSION_TOKEN: "tok-2",
+      SUBSTACK_PUB_SAPERE_USER_ID: "222",
+      SUBSTACK_PUB_OTHER_PUBLICATION_URL: "",
+      SUBSTACK_PUB_OTHER_SESSION_TOKEN: "",
+      SUBSTACK_PUB_OTHER_USER_ID: "",
+    } as NodeJS.ProcessEnv;
+
+    // Must throw naming `other` — not return the single valid publication,
+    // which would drop the `publication` parameter from every tool and route
+    // a call meant for `other` silently to `sapere`.
+    expect(() => resolvePublications(env, loader)).toThrow(/other/i);
+    expect(loader).not.toHaveBeenCalled();
+  });
+
+  it("reports a whitespace-only value the same way as an empty one", () => {
+    const env = {
+      SUBSTACK_PUB_SAPERE_PUBLICATION_URL: "https://sapere.substack.com",
+      SUBSTACK_PUB_SAPERE_SESSION_TOKEN: "   ",
+      SUBSTACK_PUB_SAPERE_USER_ID: "222",
+    } as NodeJS.ProcessEnv;
+    expect(() => resolvePublications(env, () => null)).toThrow(/sapere.*SESSION_TOKEN/is);
+  });
+
+  it("distinguishes an absent variable from an empty one in the error", () => {
+    const env = {
+      SUBSTACK_PUB_SAPERE_PUBLICATION_URL: "https://sapere.substack.com",
+      SUBSTACK_PUB_SAPERE_SESSION_TOKEN: "",
+      // SUBSTACK_PUB_SAPERE_USER_ID absent entirely
+    } as NodeJS.ProcessEnv;
+    expect(() => resolvePublications(env, () => null)).toThrow(/_SESSION_TOKEN \(empty\)/);
+    expect(() => resolvePublications(env, () => null)).toThrow(/_USER_ID(?! \(empty\))/);
+  });
+});
+
+describe("resolvePublications: key collisions", () => {
+  it("rejects two distinct env names that slugify to the same key", () => {
+    // Distinct variables on any POSIX host; one slug. Last-writer-wins would
+    // merge them, and can pair one publication's URL with the other's cookie.
+    const env = {
+      SUBSTACK_PUB_ALPHA_PUBLICATION_URL: "https://alpha.substack.com",
+      SUBSTACK_PUB_ALPHA_SESSION_TOKEN: "tok-alpha",
+      SUBSTACK_PUB_ALPHA_USER_ID: "1",
+      SUBSTACK_PUB_Alpha_PUBLICATION_URL: "https://beta.substack.com",
+      SUBSTACK_PUB_Alpha_SESSION_TOKEN: "tok-beta",
+      SUBSTACK_PUB_Alpha_USER_ID: "2",
+    } as NodeJS.ProcessEnv;
+    expect(() => resolvePublications(env, () => null)).toThrow(/same publication key/i);
+    expect(() => resolvePublications(env, () => null)).toThrow(/ALPHA, Alpha/);
+  });
+
+  it("does not fire on a single key used across all three of its variables", () => {
+    const env = {
+      SUBSTACK_PUB_ALPHA_PUBLICATION_URL: "https://alpha.substack.com",
+      SUBSTACK_PUB_ALPHA_SESSION_TOKEN: "tok-alpha",
+      SUBSTACK_PUB_ALPHA_USER_ID: "1",
+    } as NodeJS.ProcessEnv;
+    expect(resolvePublications(env, () => null).map((p) => p.key)).toEqual(["alpha"]);
+  });
+});

--- a/src/__tests__/resolve-publications.test.ts
+++ b/src/__tests__/resolve-publications.test.ts
@@ -152,8 +152,103 @@ describe("resolvePublications: an empty named publication must not disappear", (
       SUBSTACK_PUB_SAPERE_SESSION_TOKEN: "",
       // SUBSTACK_PUB_SAPERE_USER_ID absent entirely
     } as NodeJS.ProcessEnv;
-    expect(() => resolvePublications(env, () => null)).toThrow(/_SESSION_TOKEN \(empty\)/);
-    expect(() => resolvePublications(env, () => null)).toThrow(/_USER_ID(?! \(empty\))/);
+    // Asserted as the whole message on purpose. The previous version of this
+    // test used /_USER_ID(?! \(empty\))/, which could never fail: the
+    // unconditional tail "…and _USER_ID with a non-empty value" satisfies the
+    // negative lookahead no matter what the per-key detail says.
+    expect(() => resolvePublications(env, () => null)).toThrow(
+      "Incomplete SUBSTACK_PUB_<KEY>_* configuration for: " +
+        "sapere (_SESSION_TOKEN (empty), _USER_ID). " +
+        "Each publication needs all three of _PUBLICATION_URL, _SESSION_TOKEN, and _USER_ID with a non-empty value.",
+    );
+  });
+});
+
+/**
+ * The same lesson as the empty-value bug, one gate earlier: a name that
+ * announces itself as a publication variable but does not match the grammar is
+ * still intent, and dropping it silently changes the configuration rather than
+ * reducing it.
+ */
+describe("resolvePublications: names that do not match the grammar", () => {
+  const validA = {
+    SUBSTACK_PUB_A_PUBLICATION_URL: "https://a.substack.com",
+    SUBSTACK_PUB_A_SESSION_TOKEN: "FAKE-A",
+    SUBSTACK_PUB_A_USER_ID: "1",
+  };
+
+  const malformedGroups: Array<[string, NodeJS.ProcessEnv, RegExp]> = [
+    [
+      "a hyphen in the key",
+      {
+        "SUBSTACK_PUB_B-PUB_PUBLICATION_URL": "https://b.substack.com",
+        "SUBSTACK_PUB_B-PUB_SESSION_TOKEN": "FAKE-B",
+        "SUBSTACK_PUB_B-PUB_USER_ID": "2",
+      } as NodeJS.ProcessEnv,
+      /B-PUB_PUBLICATION_URL/,
+    ],
+    [
+      "trailing whitespace in the name",
+      {
+        "SUBSTACK_PUB_B_PUBLICATION_URL ": "https://b.substack.com",
+        "SUBSTACK_PUB_B_SESSION_TOKEN ": "FAKE-B",
+        "SUBSTACK_PUB_B_USER_ID ": "2",
+      } as NodeJS.ProcessEnv,
+      /SUBSTACK_PUB_B_USER_ID /,
+    ],
+    [
+      "a lowercase suffix",
+      {
+        SUBSTACK_PUB_B_publication_url: "https://b.substack.com",
+        SUBSTACK_PUB_B_session_token: "FAKE-B",
+        SUBSTACK_PUB_B_user_id: "2",
+      } as NodeJS.ProcessEnv,
+      /SUBSTACK_PUB_B_publication_url/,
+    ],
+    [
+      "a non-ASCII key",
+      {
+        "SUBSTACK_PUB_CAFÉ_PUBLICATION_URL": "https://c.substack.com",
+        "SUBSTACK_PUB_CAFÉ_SESSION_TOKEN": "FAKE-C",
+        "SUBSTACK_PUB_CAFÉ_USER_ID": "3",
+      } as NodeJS.ProcessEnv,
+      /CAFÉ_SESSION_TOKEN/,
+    ],
+  ];
+
+  for (const [label, malformed, named] of malformedGroups) {
+    it(`throws naming the variable, beside a valid publication — ${label}`, () => {
+      const loader = vi.fn(() => stored);
+      // Without this, the malformed group vanishes, one publication remains,
+      // single-publication mode is selected, and a call meant for it lands on A.
+      expect(() => resolvePublications({ ...validA, ...malformed }, loader)).toThrow(named);
+      expect(loader).not.toHaveBeenCalled();
+    });
+
+    it(`throws rather than falling back to a stored session — ${label} alone`, () => {
+      const loader = vi.fn(() => stored);
+      expect(() => resolvePublications({ ...malformed }, loader)).toThrow(named);
+      expect(loader).not.toHaveBeenCalled();
+    });
+  }
+
+  it("control: well-formed names beside each other still resolve", () => {
+    const env = {
+      ...validA,
+      SUBSTACK_PUB_B_PUB_PUBLICATION_URL: "https://b.substack.com",
+      SUBSTACK_PUB_B_PUB_SESSION_TOKEN: "FAKE-B",
+      SUBSTACK_PUB_B_PUB_USER_ID: "2",
+    } as NodeJS.ProcessEnv;
+    expect(resolvePublications(env, () => null).map((p) => p.key).sort()).toEqual(["a", "b-pub"]);
+  });
+
+  it("control: the legacy SUBSTACK_PUBLICATION_URL is not mistaken for a malformed prefixed name", () => {
+    const env = {
+      SUBSTACK_PUBLICATION_URL: "https://legacy.substack.com",
+      SUBSTACK_SESSION_TOKEN: "FAKE-LEGACY",
+      SUBSTACK_USER_ID: "1",
+    } as NodeJS.ProcessEnv;
+    expect(resolvePublications(env, () => null)[0].key).toBe("default");
   });
 });
 

--- a/src/__tests__/resolve-publications.test.ts
+++ b/src/__tests__/resolve-publications.test.ts
@@ -1,0 +1,100 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { resolvePublications } from "../auth/resolve-publications.js";
+import type { StoredSession } from "../auth/session-store.js";
+
+const stored: StoredSession = {
+  publicationUrl: "https://stored.substack.com",
+  sessionToken: "stored-tok",
+  userId: "99",
+  savedAt: "2026-01-01T00:00:00Z",
+};
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("resolvePublications", () => {
+  it("falls back to resolveCredentials (single 'default' entry) when no prefixed vars are set", () => {
+    const env = {
+      SUBSTACK_PUBLICATION_URL: "https://env.substack.com",
+      SUBSTACK_SESSION_TOKEN: "env-tok",
+      SUBSTACK_USER_ID: "1",
+    } as NodeJS.ProcessEnv;
+    const pubs = resolvePublications(env, () => stored);
+    expect(pubs).toHaveLength(1);
+    expect(pubs[0]).toMatchObject({
+      key: "default",
+      publicationUrl: "https://env.substack.com",
+      sessionToken: "env-tok",
+      userId: "1",
+      source: "env",
+      missing: [],
+    });
+  });
+
+  it("falls back to the stored-session path with nothing set at all", () => {
+    const pubs = resolvePublications({} as NodeJS.ProcessEnv, () => stored);
+    expect(pubs).toHaveLength(1);
+    expect(pubs[0].publicationUrl).toBe("https://stored.substack.com");
+    expect(pubs[0].source).toBe("stored");
+  });
+
+  it("resolves a single complete prefixed triplet, slugging the key and deriving a label", () => {
+    const env = {
+      SUBSTACK_PUB_KEVIN_MULDOON_PUBLICATION_URL: "https://kevinmuldoon.substack.com",
+      SUBSTACK_PUB_KEVIN_MULDOON_SESSION_TOKEN: "tok-1",
+      SUBSTACK_PUB_KEVIN_MULDOON_USER_ID: "111",
+    } as NodeJS.ProcessEnv;
+    const pubs = resolvePublications(env, () => null);
+    expect(pubs).toEqual([
+      {
+        key: "kevin-muldoon",
+        label: "Kevin Muldoon",
+        publicationUrl: "https://kevinmuldoon.substack.com",
+        sessionToken: "tok-1",
+        userId: "111",
+        source: "env",
+        missing: [],
+      },
+    ]);
+  });
+
+  it("resolves multiple complete prefixed triplets", () => {
+    const env = {
+      SUBSTACK_PUB_KEVIN_MULDOON_PUBLICATION_URL: "https://kevinmuldoon.substack.com",
+      SUBSTACK_PUB_KEVIN_MULDOON_SESSION_TOKEN: "tok-1",
+      SUBSTACK_PUB_KEVIN_MULDOON_USER_ID: "111",
+      SUBSTACK_PUB_SAPERE_PUBLICATION_URL: "https://sapere.substack.com",
+      SUBSTACK_PUB_SAPERE_SESSION_TOKEN: "tok-2",
+      SUBSTACK_PUB_SAPERE_USER_ID: "222",
+    } as NodeJS.ProcessEnv;
+    const pubs = resolvePublications(env, () => null);
+    expect(pubs.map((p) => p.key).sort()).toEqual(["kevin-muldoon", "sapere"]);
+    expect(pubs.every((p) => p.source === "env" && p.missing.length === 0)).toBe(true);
+  });
+
+  it("throws naming the offending key when a triplet is incomplete", () => {
+    const env = {
+      SUBSTACK_PUB_SAPERE_PUBLICATION_URL: "https://sapere.substack.com",
+      SUBSTACK_PUB_SAPERE_SESSION_TOKEN: "tok-2",
+      // SUBSTACK_PUB_SAPERE_USER_ID missing
+    } as NodeJS.ProcessEnv;
+    expect(() => resolvePublications(env, () => null)).toThrow(/sapere/);
+  });
+
+  it("ignores legacy vars (with a warning) when prefixed vars are also present", () => {
+    const warn = vi.spyOn(console, "error").mockImplementation(() => {});
+    const env = {
+      SUBSTACK_PUBLICATION_URL: "https://legacy.substack.com",
+      SUBSTACK_SESSION_TOKEN: "legacy-tok",
+      SUBSTACK_USER_ID: "1",
+      SUBSTACK_PUB_SAPERE_PUBLICATION_URL: "https://sapere.substack.com",
+      SUBSTACK_PUB_SAPERE_SESSION_TOKEN: "tok-2",
+      SUBSTACK_PUB_SAPERE_USER_ID: "222",
+    } as NodeJS.ProcessEnv;
+    const pubs = resolvePublications(env, () => null);
+    expect(pubs).toHaveLength(1);
+    expect(pubs[0].key).toBe("sapere");
+    expect(warn).toHaveBeenCalledWith(expect.stringMatching(/legacy/i));
+  });
+});

--- a/src/__tests__/server-publications.test.ts
+++ b/src/__tests__/server-publications.test.ts
@@ -1,0 +1,90 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+import { createServer, type PublicationConfig } from "../server.js";
+import { SubstackClient } from "../api/client.js";
+
+/**
+ * Multi-publication routing and schema behavior. Separate from server.ts's
+ * #28 pagination-clamp suite — different concern, same in-memory-transport
+ * pattern.
+ */
+describe("multi-publication support", () => {
+  afterEach(() => vi.unstubAllGlobals());
+
+  function stubFetch() {
+    const body = { sections: [] };
+    const fetchMock = vi.fn(async (..._args: any[]) => ({
+      ok: true,
+      status: 200,
+      json: async () => body,
+      text: async () => JSON.stringify(body),
+    }));
+    vi.stubGlobal("fetch", fetchMock);
+    return fetchMock;
+  }
+
+  async function connect(publications: PublicationConfig[]) {
+    const server = createServer(publications);
+    const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+    const client = new Client({ name: "test", version: "0.0.0" });
+    await Promise.all([client.connect(clientTransport), server.connect(serverTransport)]);
+    return client;
+  }
+
+  it("adds no `publication` field to any tool when only one publication is configured", async () => {
+    const client = await connect([
+      { key: "default", label: "Default", client: new SubstackClient("https://a.substack.com", "tok", "1") },
+    ]);
+    const { tools } = await client.listTools();
+    const tool = tools.find((t) => t.name === "get_sections");
+    const schema = tool!.inputSchema as any;
+    expect(schema.properties?.publication).toBeUndefined();
+    expect(schema.required ?? []).not.toContain("publication");
+  });
+
+  it("requires `publication` (enum of configured keys) once 2+ publications are configured", async () => {
+    const client = await connect([
+      { key: "kevin-muldoon", label: "Kevin Muldoon", client: new SubstackClient("https://a.substack.com", "tok", "1") },
+      { key: "sapere", label: "Sapere", client: new SubstackClient("https://b.substack.com", "tok", "2") },
+    ]);
+    const { tools } = await client.listTools();
+    const tool = tools.find((t) => t.name === "get_sections");
+    const schema = tool!.inputSchema as any;
+    expect(schema.required).toContain("publication");
+    expect(schema.properties.publication.enum?.sort()).toEqual(["kevin-muldoon", "sapere"]);
+  });
+
+  it("rejects an unconfigured publication value before any network call", async () => {
+    const fetchMock = stubFetch();
+    const client = await connect([
+      { key: "kevin-muldoon", label: "Kevin Muldoon", client: new SubstackClient("https://a.substack.com", "tok", "1") },
+      { key: "sapere", label: "Sapere", client: new SubstackClient("https://b.substack.com", "tok", "2") },
+    ]);
+
+    const result = await client.callTool({
+      name: "get_sections",
+      arguments: { publication: "not-a-real-publication" },
+    });
+
+    expect(result.isError).toBe(true);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("routes a call to the client matching the given publication key", async () => {
+    const fetchMock = stubFetch();
+    const client = await connect([
+      { key: "kevin-muldoon", label: "Kevin Muldoon", client: new SubstackClient("https://a.substack.com", "tok", "1") },
+      { key: "sapere", label: "Sapere", client: new SubstackClient("https://b.substack.com", "tok", "2") },
+    ]);
+
+    const result = await client.callTool({
+      name: "get_sections",
+      arguments: { publication: "sapere" },
+    });
+
+    expect(result.isError).toBeFalsy();
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(String(fetchMock.mock.calls[0][0])).toContain("b.substack.com");
+  });
+});

--- a/src/__tests__/server.test.ts
+++ b/src/__tests__/server.test.ts
@@ -33,9 +33,9 @@ describe("tool pagination limits (regression: #28)", () => {
   }
 
   async function connect() {
-    const server = createServer(
-      new SubstackClient("https://example.substack.com", "tok", "1"),
-    );
+    const server = createServer([
+      { key: "default", label: "Default", client: new SubstackClient("https://example.substack.com", "tok", "1") },
+    ]);
     const [clientTransport, serverTransport] =
       InMemoryTransport.createLinkedPair();
     const client = new Client({ name: "test", version: "0.0.0" });

--- a/src/auth/resolve-publications.ts
+++ b/src/auth/resolve-publications.ts
@@ -7,13 +7,37 @@
  *   This is the zero-touch path every existing single-publication deployment
  *   stays on — no `publication` field is ever added to a tool's schema in
  *   this case (see server.ts).
- * - One or more complete `SUBSTACK_PUB_<KEY>_*` triplets present: one entry
- *   per triplet, keyed by a slugified `<KEY>` (e.g. `KEVIN_MULDOON` becomes
- *   `kevin-muldoon`). A triplet missing 1-2 of its 3 vars throws at startup —
- *   this is new, explicitly opt-in config, so a partial triplet is almost
- *   certainly a typo, not something to silently drop. Legacy unprefixed vars
- *   are ignored (with a warning) in this mode, rather than treated as an
- *   implicit unnamed extra publication.
+ * - One or more `SUBSTACK_PUB_<KEY>_*` vars present: one entry per triplet,
+ *   keyed by a slugified `<KEY>` (e.g. `KEVIN_MULDOON` becomes
+ *   `kevin-muldoon`). An incomplete triplet throws at startup — this is new,
+ *   explicitly opt-in config, so a partial triplet is almost certainly a typo,
+ *   not something to silently drop. Legacy unprefixed vars are ignored (with a
+ *   warning) in this mode, rather than treated as an implicit unnamed extra
+ *   publication.
+ *
+ * ## Why a variable's *name* is what establishes intent
+ *
+ * The rule here is that a matching variable name creates the group, before its
+ * value is looked at. Skipping empty values instead — `if (!value) continue` —
+ * makes an all-empty triplet vanish, and a vanished group is not an error, it
+ * is a different configuration:
+ *
+ * - All-empty triplet on its own: no groups remain, so resolution falls back to
+ *   the legacy path and can pick up a *stored browser-login session* the
+ *   operator never intended this process to use.
+ * - Valid A plus an all-empty B: one group remains, the server decides it is in
+ *   single-publication mode, every tool loses its `publication` parameter, and
+ *   a call meant for B routes silently to A. `create_note` publishes
+ *   immediately and cannot be undone, so that is an uncorrectable mistake.
+ *
+ * Both were reachable at eaa84bb. Creating the group first turns each into a
+ * startup error naming the offending key.
+ *
+ * Slug collisions are an error for the same reason: `SUBSTACK_PUB_ALPHA_*` and
+ * `SUBSTACK_PUB_Alpha_*` are two distinct variables on a POSIX host but one
+ * slug, so last-writer-wins would silently merge two publications — and can
+ * pair one publication's URL with another's session cookie, per field, in
+ * whatever order the environment happens to enumerate.
  *
  * Browser-login sessions stay out of scope for named publications: only the
  * single-publication fallback above can ever pull from a stored session.
@@ -37,6 +61,20 @@ type Field = "publicationUrl" | "sessionToken" | "userId";
 
 const PREFIXED_VAR_RE = /^SUBSTACK_PUB_([A-Za-z0-9_]+)_(PUBLICATION_URL|SESSION_TOKEN|USER_ID)$/;
 
+/** One publication under construction: its fields, plus every raw `<KEY>` that mapped to it. */
+interface Group {
+  fields: Partial<Record<Field, string>>;
+  rawKeys: Set<string>;
+}
+
+const ALL_FIELDS: Field[] = ["publicationUrl", "sessionToken", "userId"];
+
+const SUFFIX_BY_FIELD: Record<Field, string> = {
+  publicationUrl: "PUBLICATION_URL",
+  sessionToken: "SESSION_TOKEN",
+  userId: "USER_ID",
+};
+
 const FIELD_BY_SUFFIX: Record<string, Field> = {
   PUBLICATION_URL: "publicationUrl",
   SESSION_TOKEN: "sessionToken",
@@ -59,17 +97,18 @@ export function resolvePublications(
   env: NodeJS.ProcessEnv = process.env,
   loader: () => StoredSession | null = loadSession,
 ): PublicationCredentials[] {
-  const groups = new Map<string, Partial<Record<Field, string>>>();
+  const groups = new Map<string, Group>();
 
   for (const envName of Object.keys(env)) {
     const match = PREFIXED_VAR_RE.exec(envName);
     if (!match) continue;
-    const value = env[envName];
-    if (!value) continue;
     const [, rawKey, suffix] = match;
     const slug = slugify(rawKey);
-    const group = groups.get(slug) ?? {};
-    group[FIELD_BY_SUFFIX[suffix]] = value;
+    // The name creates the group; the value is judged afterwards. See the
+    // module comment for what skipping empty values here used to allow.
+    const group = groups.get(slug) ?? { fields: {}, rawKeys: new Set<string>() };
+    group.rawKeys.add(rawKey);
+    group.fields[FIELD_BY_SUFFIX[suffix]] = env[envName] ?? "";
     groups.set(slug, group);
   }
 
@@ -95,12 +134,29 @@ export function resolvePublications(
     );
   }
 
+  // Two env-var names that slugify to the same key are two publications the
+  // operator meant to keep apart. Merging them is silent and can cross
+  // credentials, so it is fatal rather than a warning.
+  const collisions = [...groups]
+    .filter(([, group]) => group.rawKeys.size > 1)
+    .map(([slug, group]) => `${slug} (from ${[...group.rawKeys].sort().join(", ")})`);
+  if (collisions.length > 0) {
+    throw new Error(
+      `Conflicting SUBSTACK_PUB_<KEY>_* names resolve to the same publication key: ${collisions.join("; ")}. ` +
+        "Keys are compared case-insensitively with _ as -; give each publication a distinct key.",
+    );
+  }
+
   const incomplete: string[] = [];
   const result: PublicationCredentials[] = [];
-  for (const [slug, fields] of groups) {
-    const missingFields = (["publicationUrl", "sessionToken", "userId"] as Field[]).filter((f) => !fields[f]);
-    if (missingFields.length > 0) {
-      incomplete.push(`${slug} (missing ${missingFields.length} of 3 vars)`);
+  for (const [slug, { fields }] of groups) {
+    // `undefined` (name never seen) and `""` (name seen, value empty) are both
+    // unusable, and both are reported — an empty value is a typo, not a
+    // decision to disable that publication.
+    const badFields = ALL_FIELDS.filter((f) => !fields[f]?.trim());
+    if (badFields.length > 0) {
+      const detail = badFields.map((f) => `_${SUFFIX_BY_FIELD[f]}${fields[f] === undefined ? "" : " (empty)"}`);
+      incomplete.push(`${slug} (${detail.join(", ")})`);
       continue;
     }
     result.push({
@@ -117,7 +173,7 @@ export function resolvePublications(
   if (incomplete.length > 0) {
     throw new Error(
       `Incomplete SUBSTACK_PUB_<KEY>_* configuration for: ${incomplete.join(", ")}. ` +
-        "Each publication needs all three of _PUBLICATION_URL, _SESSION_TOKEN, and _USER_ID.",
+        "Each publication needs all three of _PUBLICATION_URL, _SESSION_TOKEN, and _USER_ID with a non-empty value.",
     );
   }
 

--- a/src/auth/resolve-publications.ts
+++ b/src/auth/resolve-publications.ts
@@ -61,6 +61,16 @@ type Field = "publicationUrl" | "sessionToken" | "userId";
 
 const PREFIXED_VAR_RE = /^SUBSTACK_PUB_([A-Za-z0-9_]+)_(PUBLICATION_URL|SESSION_TOKEN|USER_ID)$/;
 
+/**
+ * "This name is trying to be a publication variable."
+ *
+ * Leading whitespace is tolerated and the prefix matched case-insensitively so
+ * that a typo is *caught* rather than skipped. The trailing underscore is what
+ * keeps the legacy `SUBSTACK_PUBLICATION_URL` out — `SUBSTACK_PUBL…` does not
+ * start with `SUBSTACK_PUB_`.
+ */
+const PUB_PREFIX_RE = /^\s*SUBSTACK_PUB_/i;
+
 /** One publication under construction: its fields, plus every raw `<KEY>` that mapped to it. */
 interface Group {
   fields: Partial<Record<Field, string>>;
@@ -98,10 +108,21 @@ export function resolvePublications(
   loader: () => StoredSession | null = loadSession,
 ): PublicationCredentials[] {
   const groups = new Map<string, Group>();
+  const malformed: string[] = [];
 
   for (const envName of Object.keys(env)) {
     const match = PREFIXED_VAR_RE.exec(envName);
-    if (!match) continue;
+    if (!match) {
+      // A name that announces itself as a publication variable but does not
+      // match the grammar is intent too, and silently skipping it is the same
+      // failure as skipping an empty value: `SUBSTACK_PUB_B-PUB_*` (a hyphen
+      // in the key) used to vanish entirely, so a valid A plus a complete
+      // hyphenated B resolved to A alone, in single-publication mode, and a
+      // call meant for B landed on A. A lone malformed group fell all the way
+      // back to the stored browser-login session.
+      if (PUB_PREFIX_RE.test(envName)) malformed.push(envName);
+      continue;
+    }
     const [, rawKey, suffix] = match;
     const slug = slugify(rawKey);
     // The name creates the group; the value is judged afterwards. See the
@@ -110,6 +131,17 @@ export function resolvePublications(
     group.rawKeys.add(rawKey);
     group.fields[FIELD_BY_SUFFIX[suffix]] = env[envName] ?? "";
     groups.set(slug, group);
+  }
+
+  // Before the fallback, so a process configured only with malformed names can
+  // never reach `resolveCredentials()` and its stored-session path.
+  if (malformed.length > 0) {
+    throw new Error(
+      `Unrecognized SUBSTACK_PUB_<KEY>_* variable name(s): ${malformed.map((n) => JSON.stringify(n)).join(", ")}. ` +
+        "Each must be exactly SUBSTACK_PUB_<KEY>_PUBLICATION_URL, _SESSION_TOKEN, or _USER_ID, " +
+        "where <KEY> is ASCII letters, digits, and underscores only — no hyphens, no surrounding whitespace, " +
+        "and the suffix uppercase.",
+    );
   }
 
   if (groups.size === 0) {

--- a/src/auth/resolve-publications.ts
+++ b/src/auth/resolve-publications.ts
@@ -1,0 +1,125 @@
+/**
+ * Resolve credentials for one or more Substack publications.
+ *
+ * - No `SUBSTACK_PUB_<KEY>_*` vars present: falls back to the existing
+ *   single-publication `resolveCredentials()` (plain `SUBSTACK_*` env vars,
+ *   with the stored-session fallback), wrapped as a single internal entry.
+ *   This is the zero-touch path every existing single-publication deployment
+ *   stays on — no `publication` field is ever added to a tool's schema in
+ *   this case (see server.ts).
+ * - One or more complete `SUBSTACK_PUB_<KEY>_*` triplets present: one entry
+ *   per triplet, keyed by a slugified `<KEY>` (e.g. `KEVIN_MULDOON` becomes
+ *   `kevin-muldoon`). A triplet missing 1-2 of its 3 vars throws at startup —
+ *   this is new, explicitly opt-in config, so a partial triplet is almost
+ *   certainly a typo, not something to silently drop. Legacy unprefixed vars
+ *   are ignored (with a warning) in this mode, rather than treated as an
+ *   implicit unnamed extra publication.
+ *
+ * Browser-login sessions stay out of scope for named publications: only the
+ * single-publication fallback above can ever pull from a stored session.
+ */
+import { resolveCredentials, type ResolvedCredentials } from "./resolve-credentials.js";
+import { loadSession, type StoredSession } from "./session-store.js";
+
+export interface PublicationCredentials {
+  /** Tool-facing `publication` enum value, e.g. "kevin-muldoon". Never surfaced when only one publication is configured. */
+  key: string;
+  /** Human-readable label derived from `key`, e.g. "Kevin Muldoon". Used only in startup logs and the `publication` field's description. */
+  label: string;
+  publicationUrl: string;
+  sessionToken: string;
+  userId: string;
+  source: ResolvedCredentials["source"];
+  missing: string[];
+}
+
+type Field = "publicationUrl" | "sessionToken" | "userId";
+
+const PREFIXED_VAR_RE = /^SUBSTACK_PUB_([A-Za-z0-9_]+)_(PUBLICATION_URL|SESSION_TOKEN|USER_ID)$/;
+
+const FIELD_BY_SUFFIX: Record<string, Field> = {
+  PUBLICATION_URL: "publicationUrl",
+  SESSION_TOKEN: "sessionToken",
+  USER_ID: "userId",
+};
+
+function slugify(rawKey: string): string {
+  return rawKey.toLowerCase().replace(/_/g, "-");
+}
+
+function labelFromKey(key: string): string {
+  return key
+    .split("-")
+    .filter(Boolean)
+    .map((word) => word[0].toUpperCase() + word.slice(1))
+    .join(" ");
+}
+
+export function resolvePublications(
+  env: NodeJS.ProcessEnv = process.env,
+  loader: () => StoredSession | null = loadSession,
+): PublicationCredentials[] {
+  const groups = new Map<string, Partial<Record<Field, string>>>();
+
+  for (const envName of Object.keys(env)) {
+    const match = PREFIXED_VAR_RE.exec(envName);
+    if (!match) continue;
+    const value = env[envName];
+    if (!value) continue;
+    const [, rawKey, suffix] = match;
+    const slug = slugify(rawKey);
+    const group = groups.get(slug) ?? {};
+    group[FIELD_BY_SUFFIX[suffix]] = value;
+    groups.set(slug, group);
+  }
+
+  if (groups.size === 0) {
+    const creds = resolveCredentials(env, loader);
+    return [
+      {
+        key: "default",
+        label: "default",
+        publicationUrl: creds.publicationUrl,
+        sessionToken: creds.sessionToken,
+        userId: creds.userId,
+        source: creds.source,
+        missing: creds.missing,
+      },
+    ];
+  }
+
+  if (env.SUBSTACK_PUBLICATION_URL || env.SUBSTACK_SESSION_TOKEN || env.SUBSTACK_USER_ID) {
+    console.error(
+      "Warning: both SUBSTACK_PUB_<KEY>_* and legacy SUBSTACK_* env vars are set. " +
+        "The legacy vars are ignored — remove them, or fold that publication into a SUBSTACK_PUB_<KEY>_* triplet.",
+    );
+  }
+
+  const incomplete: string[] = [];
+  const result: PublicationCredentials[] = [];
+  for (const [slug, fields] of groups) {
+    const missingFields = (["publicationUrl", "sessionToken", "userId"] as Field[]).filter((f) => !fields[f]);
+    if (missingFields.length > 0) {
+      incomplete.push(`${slug} (missing ${missingFields.length} of 3 vars)`);
+      continue;
+    }
+    result.push({
+      key: slug,
+      label: labelFromKey(slug),
+      publicationUrl: fields.publicationUrl!,
+      sessionToken: fields.sessionToken!,
+      userId: fields.userId!,
+      source: "env",
+      missing: [],
+    });
+  }
+
+  if (incomplete.length > 0) {
+    throw new Error(
+      `Incomplete SUBSTACK_PUB_<KEY>_* configuration for: ${incomplete.join(", ")}. ` +
+        "Each publication needs all three of _PUBLICATION_URL, _SESSION_TOKEN, and _USER_ID.",
+    );
+  }
+
+  return result;
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,8 +2,8 @@
 
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import { SubstackClient } from "./api/client.js";
-import { createServer } from "./server.js";
-import { resolveCredentials } from "./auth/resolve-credentials.js";
+import { createServer, type PublicationConfig } from "./server.js";
+import { resolvePublications } from "./auth/resolve-publications.js";
 
 /**
  * Wire every way this process can be asked to stop to one clean transport close.
@@ -60,27 +60,35 @@ function resolveTimeoutMs(raw: string | undefined): number | undefined {
 
 async function main() {
   // Env vars take precedence; a stored session (from `substack-mcp-login`)
-  // fills any gaps.
-  const creds = resolveCredentials();
-  const { publicationUrl, sessionToken, userId } = creds;
-
-  if (creds.missing.length > 0) {
-    console.error(`Warning: Missing credentials: ${creds.missing.join(", ")}`);
-    console.error(
-      "Set them as SUBSTACK_* env vars, or run `substack-mcp-login` to sign in via browser. See README.md.",
-    );
-  } else if (creds.source !== "env") {
-    console.error(`Using stored credentials (source: ${creds.source}).`);
-  }
-
+  // fills any gaps. See resolve-publications.ts for the multi-publication
+  // SUBSTACK_PUB_<KEY>_* scheme this falls back from.
+  const pubCreds = resolvePublications();
+  const multi = pubCreds.length > 1;
   const userAgent = process.env.SUBSTACK_USER_AGENT;
   const timeoutMs = resolveTimeoutMs(process.env.SUBSTACK_REQUEST_TIMEOUT_MS);
-  // The client constructor rejects a non-numeric user id; fall back to "0" so
-  // startup surfaces the friendly missing-credentials warning above instead of
-  // throwing when nothing is configured yet.
-  const client = new SubstackClient(publicationUrl, sessionToken, userId || "0", userAgent, timeoutMs);
 
-  const server = createServer(client);
+  // Only appended once 2+ publications are configured, so single-publication
+  // log output stays byte-identical to what it was before this existed.
+  const pubSuffix = (label: string): string => (multi ? ` for publication "${label}"` : "");
+
+  const publications: PublicationConfig[] = pubCreds.map((p) => {
+    if (p.missing.length > 0) {
+      console.error(`Warning: Missing credentials${pubSuffix(p.label)}: ${p.missing.join(", ")}`);
+      console.error(
+        "Set them as SUBSTACK_* env vars, or run `substack-mcp-login` to sign in via browser. See README.md.",
+      );
+    } else if (p.source !== "env") {
+      console.error(`Using stored credentials${pubSuffix(p.label)} (source: ${p.source}).`);
+    }
+
+    // The client constructor rejects a non-numeric user id; fall back to "0"
+    // so startup surfaces the friendly missing-credentials warning above
+    // instead of throwing when nothing is configured yet.
+    const client = new SubstackClient(p.publicationUrl, p.sessionToken, p.userId || "0", userAgent, timeoutMs);
+    return { key: p.key, label: p.label, client };
+  });
+
+  const server = createServer(publications);
   const transport = new StdioServerTransport();
   // Registered before connect so a signal arriving during startup is still
   // handled; McpServer.close() is safe on a server that never connected.
@@ -94,13 +102,19 @@ async function main() {
   // `initialize` for undici's full connect timeout with no output at all.
   // Tools still error individually on a bad token, which is where the failure
   // is actionable anyway.
-  try {
-    const user = await client.validateAuth();
-    console.error(`Authenticated as user ${user.id}`);
-  } catch (err) {
-    console.error("Warning: Authentication failed. Tools will error until a valid session token is provided.");
-    console.error(err instanceof Error ? err.message : String(err));
-  }
+  await Promise.all(
+    publications.map(async (p) => {
+      try {
+        const user = await p.client.validateAuth();
+        console.error(`Authenticated as user ${user.id}${pubSuffix(p.label)}`);
+      } catch (err) {
+        console.error(
+          `Warning: Authentication failed${pubSuffix(p.label)}. Tools will error until a valid session token is provided.`,
+        );
+        console.error(err instanceof Error ? err.message : String(err));
+      }
+    }),
+  );
 }
 
 main().catch((err) => {

--- a/src/server.ts
+++ b/src/server.ts
@@ -9,11 +9,51 @@ import { buildAnnotations } from "./annotations.js";
 import { markdownToProseMirror, markdownToProseMirrorContent } from "./utils/markdown-to-prosemirror.js";
 import { fileToDataUri } from "./utils/image.js";
 
-export function createServer(client: SubstackClient): McpServer {
+export interface PublicationConfig {
+  /** Tool-facing `publication` enum value, e.g. "kevin-muldoon". */
+  key: string;
+  /** Human-readable label, e.g. "Kevin Muldoon" — used in descriptions/errors only. */
+  label: string;
+  client: SubstackClient;
+}
+
+export function createServer(publications: PublicationConfig[]): McpServer {
+  if (publications.length === 0) {
+    throw new Error("createServer requires at least one publication configuration.");
+  }
+
   const server = new McpServer({
     name: "substack-mcp",
     version: "0.6.1",
   });
+
+  const multi = publications.length > 1;
+  const pubKeys = publications.map((p) => p.key) as [string, ...string[]];
+
+  // With exactly one publication configured, every tool's schema is left
+  // untouched — no `publication` field at all — so single-publication
+  // deployments (the common case) see zero change. With 2+, every tool gains
+  // a *required* enum field: Zod itself then rejects an unconfigured or
+  // missing value before any handler (and therefore any Substack API call)
+  // runs, so a write tool can never silently land on the wrong publication.
+  function publicationField(): Record<string, z.ZodTypeAny> {
+    if (!multi) return {};
+    const options = publications.map((p) => `${p.key} (${p.label})`).join(", ");
+    return {
+      publication: z.enum(pubKeys).describe(`Which publication to operate on. One of: ${options}.`),
+    };
+  }
+
+  // Unreachable in practice when multi (see publicationField above) — this
+  // is a defensive fallback, not the primary validation path.
+  function clientFor(publication?: string): SubstackClient {
+    if (!multi) return publications[0].client;
+    const found = publications.find((p) => p.key === publication);
+    if (!found) {
+      throw new Error(`Unknown publication "${publication}". Configured: ${pubKeys.join(", ")}.`);
+    }
+    return found.client;
+  }
 
   // Every tool is registered with MCP annotations derived from its declared
   // side-effect class (see annotations.ts) so clients can render accurate
@@ -30,11 +70,11 @@ export function createServer(client: SubstackClient): McpServer {
         "'exact' when the API reports a true count, 'approximate' when only Substack's rounded " +
         "value is available (the real number is that or higher — render it hedged, e.g. '1,000+'), " +
         "or 'unavailable' with count -1. Never treat an approximate value as exact.",
-      inputSchema: {},
+      inputSchema: { ...publicationField() },
       annotations: buildAnnotations("get_subscriber_count"),
     },
-    async () => {
-      const result = await client.getSubscriberCount();
+    async ({ publication }: { publication?: string }) => {
+      const result = await clientFor(publication).getSubscriberCount();
       return {
         content: [
           { type: "text", text: JSON.stringify(result, null, 2) },
@@ -56,11 +96,12 @@ export function createServer(client: SubstackClient): McpServer {
           .describe(
             `Max posts to return (1-${MAX_PAGE_SIZE}; Substack rejects anything higher, so larger values are clamped)`,
           ),
+        ...publicationField(),
       },
       annotations: buildAnnotations("list_published_posts"),
     },
-    async ({ offset, limit }) => {
-      const { posts, total } = await client.getPublishedPosts(offset, Math.min(limit, MAX_PAGE_SIZE));
+    async ({ offset, limit, publication }: { offset: number; limit: number; publication?: string }) => {
+      const { posts, total } = await clientFor(publication).getPublishedPosts(offset, Math.min(limit, MAX_PAGE_SIZE));
       const summary = posts.map((p) => ({
         id: p.id,
         title: p.title,
@@ -90,11 +131,12 @@ export function createServer(client: SubstackClient): McpServer {
           .describe(
             `Max drafts to return (1-${MAX_PAGE_SIZE}; Substack rejects anything higher, so larger values are clamped)`,
           ),
+        ...publicationField(),
       },
       annotations: buildAnnotations("list_drafts"),
     },
-    async ({ offset, limit }) => {
-      const drafts = await client.getDrafts(offset, Math.min(limit, MAX_PAGE_SIZE));
+    async ({ offset, limit, publication }: { offset: number; limit: number; publication?: string }) => {
+      const drafts = await clientFor(publication).getDrafts(offset, Math.min(limit, MAX_PAGE_SIZE));
       const summary = drafts.map((d) => ({
         id: d.id,
         title: d.draft_title,
@@ -116,11 +158,12 @@ export function createServer(client: SubstackClient): McpServer {
       description: "Get the full content of a published post by ID. Returns title, body HTML, metadata.",
       inputSchema: {
         post_id: z.number().describe("The post ID to retrieve"),
+        ...publicationField(),
       },
       annotations: buildAnnotations("get_post"),
     },
-    async ({ post_id }) => {
-      const post = await client.getPost(post_id);
+    async ({ post_id, publication }: { post_id: number; publication?: string }) => {
+      const post = await clientFor(publication).getPost(post_id);
       return {
         content: [
           {
@@ -152,11 +195,12 @@ export function createServer(client: SubstackClient): McpServer {
       description: "Get the full content of a draft post by ID. Returns title, body, metadata.",
       inputSchema: {
         draft_id: z.number().describe("The draft ID to retrieve"),
+        ...publicationField(),
       },
       annotations: buildAnnotations("get_draft"),
     },
-    async ({ draft_id }) => {
-      const draft = await client.getDraft(draft_id);
+    async ({ draft_id, publication }: { draft_id: number; publication?: string }) => {
+      const draft = await clientFor(publication).getDraft(draft_id);
       return {
         content: [
           {
@@ -188,11 +232,12 @@ export function createServer(client: SubstackClient): McpServer {
       inputSchema: {
         post_id: z.number().describe("The post ID to get comments for"),
         limit: z.number().optional().default(20).describe("Max comments to return (default 20)"),
+        ...publicationField(),
       },
       annotations: buildAnnotations("get_post_comments"),
     },
-    async ({ post_id, limit }) => {
-      const comments = await client.getPostComments(post_id, limit);
+    async ({ post_id, limit, publication }: { post_id: number; limit: number; publication?: string }) => {
+      const comments = await clientFor(publication).getPostComments(post_id, limit);
       const summary = comments.map((c) => ({
         id: c.id,
         name: c.name,
@@ -212,11 +257,11 @@ export function createServer(client: SubstackClient): McpServer {
     {
       description:
         "List your publication's sections (categories). Returns each section's id and name. Use a section id as `section_id` when creating or updating a draft to file it under that section.",
-      inputSchema: {},
+      inputSchema: { ...publicationField() },
       annotations: buildAnnotations("get_sections"),
     },
-    async () => {
-      const sections = await client.getSections();
+    async ({ publication }: { publication?: string }) => {
+      const sections = await clientFor(publication).getSections();
       const summary = sections.map((s) => ({ id: s.id, name: s.name }));
       return {
         content: [{ type: "text", text: JSON.stringify(summary, null, 2) }],
@@ -232,11 +277,12 @@ export function createServer(client: SubstackClient): McpServer {
         `Substack has no per-post stats endpoint, so this searches your ${ANALYTICS_SCAN_DEPTH} most recent published posts for the ID; returns a not-found note if it isn't among them.`,
       inputSchema: {
         post_id: z.number().describe("The published post ID to get stats for"),
+        ...publicationField(),
       },
       annotations: buildAnnotations("get_post_analytics"),
     },
-    async ({ post_id }) => {
-      const post = await client.getPostAnalytics(post_id);
+    async ({ post_id, publication }: { post_id: number; publication?: string }) => {
+      const post = await clientFor(publication).getPostAnalytics(post_id);
       if (!post) {
         return {
           content: [
@@ -299,11 +345,12 @@ export function createServer(client: SubstackClient): McpServer {
           .describe(
             `Max posts to return (1-${MAX_PAGE_SIZE}; Substack rejects anything higher, so larger values are clamped)`,
           ),
+        ...publicationField(),
       },
       annotations: buildAnnotations("list_scheduled_posts"),
     },
-    async ({ offset, limit }) => {
-      const posts = await client.getScheduledPosts(offset, Math.min(limit, MAX_PAGE_SIZE));
+    async ({ offset, limit, publication }: { offset: number; limit: number; publication?: string }) => {
+      const posts = await clientFor(publication).getScheduledPosts(offset, Math.min(limit, MAX_PAGE_SIZE));
       const summary = posts.map((p) => ({
         id: p.id,
         title: p.draft_title ?? p.title ?? null,
@@ -331,12 +378,25 @@ export function createServer(client: SubstackClient): McpServer {
           .optional()
           .default("everyone")
           .describe("Who can see this post"),
+        ...publicationField(),
       },
       annotations: buildAnnotations("create_draft"),
     },
-    async ({ title, body, subtitle, audience }) => {
+    async ({
+      title,
+      body,
+      subtitle,
+      audience,
+      publication,
+    }: {
+      title: string;
+      body?: string;
+      subtitle?: string;
+      audience: "everyone" | "only_paid" | "founding" | "only_free";
+      publication?: string;
+    }) => {
       const prosemirrorBody = body ? markdownToProseMirror(body) : undefined;
-      const draft = await client.createDraft(
+      const draft = await clientFor(publication).createDraft(
         title,
         prosemirrorBody,
         subtitle,
@@ -374,17 +434,32 @@ export function createServer(client: SubstackClient): McpServer {
           .enum(["everyone", "only_paid", "founding", "only_free"])
           .optional()
           .describe("Who can see this post"),
+        ...publicationField(),
       },
       annotations: buildAnnotations("update_draft"),
     },
-    async ({ draft_id, title, subtitle, body, audience }) => {
+    async ({
+      draft_id,
+      title,
+      subtitle,
+      body,
+      audience,
+      publication,
+    }: {
+      draft_id: number;
+      title?: string;
+      subtitle?: string;
+      body?: string;
+      audience?: "everyone" | "only_paid" | "founding" | "only_free";
+      publication?: string;
+    }) => {
       const updates: Record<string, unknown> = {};
       if (title !== undefined) updates.draft_title = title;
       if (subtitle !== undefined) updates.draft_subtitle = subtitle;
       if (body !== undefined) updates.draft_body = markdownToProseMirror(body);
       if (audience !== undefined) updates.audience = audience;
 
-      const draft = await client.updateDraft(draft_id, updates);
+      const draft = await clientFor(publication).updateDraft(draft_id, updates);
       return {
         content: [
           {
@@ -422,10 +497,19 @@ export function createServer(client: SubstackClient): McpServer {
           .describe(
             'Absolute path to a local image file (e.g., "/Users/me/pic.png"). Read and encoded automatically; MIME type inferred from the extension. Mutually exclusive with image_base64.',
           ),
+        ...publicationField(),
       },
       annotations: buildAnnotations("upload_image"),
     },
-    async ({ image_base64, image_path }) => {
+    async ({
+      image_base64,
+      image_path,
+      publication,
+    }: {
+      image_base64?: string;
+      image_path?: string;
+      publication?: string;
+    }) => {
       if (!image_base64 === !image_path) {
         throw new Error(
           "Provide exactly one of `image_base64` or `image_path`.",
@@ -434,7 +518,7 @@ export function createServer(client: SubstackClient): McpServer {
       const dataUri = image_path
         ? await fileToDataUri(image_path)
         : (image_base64 as string);
-      const result = await client.uploadImage(dataUri);
+      const result = await clientFor(publication).uploadImage(dataUri);
       return {
         content: [
           { type: "text", text: JSON.stringify({ image_url: result.url }) },
@@ -451,16 +535,17 @@ export function createServer(client: SubstackClient): McpServer {
       description: "Create a Substack Note (short-form content). Accepts markdown text. PUBLISHES IMMEDIATELY to your public Notes feed — Notes have no draft state on Substack, and this server has no delete tools, so there is no undo from here.",
       inputSchema: {
         body: z.string().describe("Note content in markdown format"),
+        ...publicationField(),
       },
       annotations: buildAnnotations("create_note"),
     },
-    async ({ body }) => {
+    async ({ body, publication }: { body: string; publication?: string }) => {
       const bodyJson = {
         type: "doc" as const,
         attrs: { schemaVersion: "v1" as const },
         content: markdownToProseMirrorContent(body),
       };
-      const note = await client.createNote(bodyJson);
+      const note = await clientFor(publication).createNote(bodyJson);
       return {
         content: [
           {
@@ -488,10 +573,12 @@ export function createServer(client: SubstackClient): McpServer {
       inputSchema: {
         body: z.string().describe("Note content in markdown format"),
         url: z.string().url().describe("URL to attach as a link card"),
+        ...publicationField(),
       },
       annotations: buildAnnotations("create_note_with_link"),
     },
-    async ({ body, url }) => {
+    async ({ body, url, publication }: { body: string; url: string; publication?: string }) => {
+      const client = clientFor(publication);
       const attachment = await client.createNoteAttachment(url);
       const bodyJson = {
         type: "doc" as const,


### PR DESCRIPTION
## Summary
- Adds an opt-in `SUBSTACK_PUB_<KEY>_*` env var scheme so one server instance can hold credentials for several publications at once (e.g. `SUBSTACK_PUB_KEVIN_MULDOON_PUBLICATION_URL` / `_SESSION_TOKEN` / `_USER_ID`).
- **Single-publication mode is unchanged.** With only the existing `SUBSTACK_PUBLICATION_URL`/`SUBSTACK_SESSION_TOKEN`/`SUBSTACK_USER_ID` set (or a single prefixed triplet), every tool's schema is byte-identical to before — no new parameter appears anywhere.
- **With 2+ publications configured**, every tool gains a *required* `publication` parameter (a Zod enum of the configured keys). No silent default: two tools (`create_note`, `create_note_with_link`) publish immediately and irreversibly, so a design that guessed the wrong publication on those calls would be a real, uncorrectable mistake rather than an inconvenience. An unconfigured/missing value is rejected by the MCP SDK's own input validation before the handler — and therefore before any Substack API call — ever runs.
- A malformed triplet (missing one of the three vars) fails fast at startup with a clear error naming the offending key, rather than silently dropping that publication. If legacy unprefixed vars are set alongside prefixed ones, they're ignored with a startup warning rather than treated as an implicit unnamed extra publication.
- New `src/auth/resolve-publications.ts` reuses the existing `resolveCredentials()` (untouched) for the single-publication fallback path, rather than duplicating its logic.
- The browser-login flow (`substack-mcp-login`, `~/.substack-mcp/session.json`) is intentionally untouched — it stays single-session; multiple publications are env-var only for now.

## Test plan
- [x] `npm run lint` — clean
- [x] `npm run build` — clean
- [x] `npm test` — 175/175 passing, including two new suites: `resolve-publications.test.ts` (env var parsing/fallback/incomplete-triplet/legacy-conflict behavior) and `server-publications.test.ts` (schema shape with 1 vs 2+ publications configured, invalid-value rejection before any network call, and correct client routing by key)
- [x] Manual smoke test against the built server: with only legacy vars set, confirmed `tools/list` shows no `publication` field anywhere and startup log lines match pre-change wording exactly; with three `SUBSTACK_PUB_<KEY>_*` triplets set, confirmed `tools/list` shows `publication` as required with the right 3-member enum and an unconfigured value is rejected before any network call

🤖 Generated with [Claude Code](https://claude.com/claude-code)