### PR TITLE
Fix and gate release metadata drift

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,5 +19,6 @@ jobs:
           node-version: ${{ matrix.node-version }}
           cache: npm
       - run: npm ci
+      - run: npm run check:release
       - run: npm run build
       - run: npm test

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -27,6 +27,12 @@ jobs:
           node-version: 24
           registry-url: https://registry.npmjs.org
 
+      # Release commits must carry aligned package, lockfile, and registry
+      # metadata. `npm version` synchronizes and stages server.json before the
+      # release commit is created.
+      - name: Verify release metadata
+        run: npm run check:release
+
       - name: Check if package.json version is already published
         id: version
         run: |
@@ -62,21 +68,6 @@ jobs:
       - name: Publish to npm
         if: steps.version.outputs.changed == 'true'
         run: npm publish --provenance --access public
-
-      # server.json is derived from package.json at publish time so the two can
-      # never drift again — the registry stayed pinned at the June 2026 versions
-      # because server.json was hand-maintained and nobody re-published it.
-      - name: Sync server.json version from package.json
-        run: |
-          node -e '
-            const fs = require("fs");
-            const pkg = JSON.parse(fs.readFileSync("package.json", "utf8"));
-            const server = JSON.parse(fs.readFileSync("server.json", "utf8"));
-            server.version = pkg.version;
-            for (const p of server.packages || []) p.version = pkg.version;
-            fs.writeFileSync("server.json", JSON.stringify(server, null, 2) + "\n");
-          '
-          node -p "\"server.json is now at \" + require('./server.json').version"
 
       # Checked independently of the npm gate above: npm and the registry can be
       # out of sync on their own, so a workflow_dispatch has to be able to push a

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@conorbronsdon/substack-mcp",
-  "version": "0.4.0",
+  "version": "0.6.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@conorbronsdon/substack-mcp",
-      "version": "0.4.0",
+      "version": "0.6.2",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.12.0",

--- a/package.json
+++ b/package.json
@@ -10,11 +10,13 @@
   "scripts": {
     "build": "tsc",
     "check:release": "node scripts/check-release-metadata.mjs",
+    "sync:release": "node scripts/sync-release-metadata.mjs",
     "lint": "tsc --noEmit -p tsconfig.lint.json",
     "test": "vitest run",
     "start": "node dist/index.js",
     "dev": "tsx src/index.ts",
-    "prepublishOnly": "npm run check:release && npm run build && npm test"
+    "prepublishOnly": "npm run check:release && npm run build && npm test",
+    "version": "npm run sync:release && git add package-lock.json server.json"
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.12.0",

--- a/package.json
+++ b/package.json
@@ -9,10 +9,12 @@
   },
   "scripts": {
     "build": "tsc",
+    "check:release": "node scripts/check-release-metadata.mjs",
     "lint": "tsc --noEmit -p tsconfig.lint.json",
     "test": "vitest run",
     "start": "node dist/index.js",
-    "dev": "tsx src/index.ts"
+    "dev": "tsx src/index.ts",
+    "prepublishOnly": "npm run check:release && npm run build && npm test"
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.12.0",

--- a/scripts/check-release-metadata.mjs
+++ b/scripts/check-release-metadata.mjs
@@ -34,7 +34,9 @@ if (!Array.isArray(server.packages) || server.packages.length === 0) {
 } else {
   server.packages.forEach((entry, index) => {
     requireEqual(`server.json packages[${index}] version`, entry.version, pkg.version);
-    requireEqual(`server.json packages[${index}] identifier`, entry.identifier, pkg.name);
+    if (entry.registryType === 'npm') {
+      requireEqual(`server.json packages[${index}] identifier`, entry.identifier, pkg.name);
+    }
   });
 }
 

--- a/scripts/check-release-metadata.mjs
+++ b/scripts/check-release-metadata.mjs
@@ -5,24 +5,43 @@ const pkg = readJson('package.json');
 const lock = readJson('package-lock.json');
 const server = readJson('server.json');
 
-const versions = [
-  ['package-lock.json', lock.version],
-  ['package-lock.json root package', lock.packages?.['']?.version],
-  ['server.json', server.version],
-  ...((server.packages ?? []).map((entry, index) => [
-    `server.json packages[${index}]`,
-    entry.version,
-  ])),
-];
-
-const mismatches = versions.filter(([, version]) => version !== pkg.version);
-
-if (mismatches.length > 0) {
-  console.error(`Release metadata must match package.json version ${pkg.version}:`);
-  for (const [source, version] of mismatches) {
-    console.error(`- ${source}: ${version ?? '<missing>'}`);
+const errors = [];
+const requireEqual = (source, actual, expected) => {
+  if (actual !== expected) {
+    errors.push(`${source}: ${actual ?? '<missing>'} (expected ${expected})`);
   }
+};
+
+if (typeof pkg.version !== 'string' || pkg.version.length === 0) {
+  errors.push('package.json version is missing');
+}
+if (typeof pkg.name !== 'string' || pkg.name.length === 0) {
+  errors.push('package.json name is missing');
+}
+if (typeof pkg.mcpName !== 'string' || pkg.mcpName.length === 0) {
+  errors.push('package.json mcpName is missing');
+}
+
+requireEqual('package-lock.json version', lock.version, pkg.version);
+requireEqual('package-lock.json name', lock.name, pkg.name);
+requireEqual('package-lock.json root version', lock.packages?.['']?.version, pkg.version);
+requireEqual('package-lock.json root name', lock.packages?.['']?.name, pkg.name);
+requireEqual('server.json version', server.version, pkg.version);
+requireEqual('server.json name', server.name, pkg.mcpName);
+
+if (!Array.isArray(server.packages) || server.packages.length === 0) {
+  errors.push('server.json packages must contain at least one package');
+} else {
+  server.packages.forEach((entry, index) => {
+    requireEqual(`server.json packages[${index}] version`, entry.version, pkg.version);
+    requireEqual(`server.json packages[${index}] identifier`, entry.identifier, pkg.name);
+  });
+}
+
+if (errors.length > 0) {
+  console.error('Release metadata is inconsistent:');
+  for (const error of errors) console.error(`- ${error}`);
   process.exit(1);
 }
 
-console.log(`Release metadata agrees at ${pkg.version}.`);
+console.log(`Release metadata agrees for ${pkg.name}@${pkg.version}.`);

--- a/scripts/check-release-metadata.mjs
+++ b/scripts/check-release-metadata.mjs
@@ -1,0 +1,28 @@
+import { readFileSync } from 'node:fs';
+
+const readJson = (path) => JSON.parse(readFileSync(path, 'utf8'));
+const pkg = readJson('package.json');
+const lock = readJson('package-lock.json');
+const server = readJson('server.json');
+
+const versions = [
+  ['package-lock.json', lock.version],
+  ['package-lock.json root package', lock.packages?.['']?.version],
+  ['server.json', server.version],
+  ...((server.packages ?? []).map((entry, index) => [
+    `server.json packages[${index}]`,
+    entry.version,
+  ])),
+];
+
+const mismatches = versions.filter(([, version]) => version !== pkg.version);
+
+if (mismatches.length > 0) {
+  console.error(`Release metadata must match package.json version ${pkg.version}:`);
+  for (const [source, version] of mismatches) {
+    console.error(`- ${source}: ${version ?? '<missing>'}`);
+  }
+  process.exit(1);
+}
+
+console.log(`Release metadata agrees at ${pkg.version}.`);

--- a/scripts/sync-release-metadata.mjs
+++ b/scripts/sync-release-metadata.mjs
@@ -1,0 +1,14 @@
+import { readFileSync, writeFileSync } from 'node:fs';
+
+const pkg = JSON.parse(readFileSync('package.json', 'utf8'));
+const server = JSON.parse(readFileSync('server.json', 'utf8'));
+
+server.name = pkg.mcpName;
+server.version = pkg.version;
+for (const entry of server.packages ?? []) {
+  entry.identifier = pkg.name;
+  entry.version = pkg.version;
+}
+
+writeFileSync('server.json', `${JSON.stringify(server, null, 2)}\n`);
+console.log(`Synchronized server.json for ${pkg.name}@${pkg.version}.`);

--- a/scripts/sync-release-metadata.mjs
+++ b/scripts/sync-release-metadata.mjs
@@ -6,8 +6,8 @@ const server = JSON.parse(readFileSync('server.json', 'utf8'));
 server.name = pkg.mcpName;
 server.version = pkg.version;
 for (const entry of server.packages ?? []) {
-  entry.identifier = pkg.name;
   entry.version = pkg.version;
+  if (entry.registryType === 'npm') entry.identifier = pkg.name;
 }
 
 writeFileSync('server.json', `${JSON.stringify(server, null, 2)}\n`);

--- a/server.json
+++ b/server.json
@@ -7,12 +7,12 @@
     "url": "https://github.com/conorbronsdon/substack-mcp",
     "source": "github"
   },
-  "version": "0.6.0",
+  "version": "0.6.2",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "@conorbronsdon/substack-mcp",
-      "version": "0.6.0",
+      "version": "0.6.2",
       "runtimeHint": "npx",
       "transport": {
         "type": "stdio"


### PR DESCRIPTION
## Summary
- align `package-lock.json` and `server.json` with the published/package/tag version `0.6.2`
- add a fail-closed release metadata check for package names, MCP names, package identifiers, and versions
- make `npm version` synchronize and stage `server.json`
- make CI and publishing verify committed metadata instead of rewriting it after npm publish
- preserve identifiers for future non-npm registry entries

Tracks the Substack drift in conorbronsdon/personal-context#250.

## Verification
- `npm run check:release`
- `npm run lint`
- `npm run build`
- `npm test`: 165/165
- mutation controls: version/name mismatch fails; sync restores it; OCI identifier survives sync and passes the scoped check
- `git diff --check`

## Exact-SHA review
Final head `897036ae46b5ce8591dd89789eb18a70f5d6eec9`:
- authenticated `claude-sonnet-5`: clean
- free `thinkingmachines/inkling:free`: clean for scope

Two repair cycles resolved the original publish-order contradiction and the non-npm identifier assumption.