### PR TITLE
Select the latest MCP registry record

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -78,7 +78,7 @@ jobs:
           SERVER_NAME="$(node -p "require('./package.json').mcpName")"
           LOCAL_VERSION="${{ steps.version.outputs.local }}"
           if curl -fsSL "https://registry.modelcontextprotocol.io/v0.1/servers?search=$SERVER_NAME" -o registry.json; then
-            REGISTRY_VERSION="$(SERVER_NAME="$SERVER_NAME" node -p "const r = JSON.parse(require('fs').readFileSync('registry.json', 'utf8')).servers || []; const m = r.find(s => s.server && s.server.name === process.env.SERVER_NAME); m ? m.server.version : 'none'")"
+            REGISTRY_VERSION="$(SERVER_NAME="$SERVER_NAME" node -p "const r = JSON.parse(require('fs').readFileSync('registry.json', 'utf8')).servers || []; const exact = r.filter(s => s.server && s.server.name === process.env.SERVER_NAME); const key = 'io.modelcontextprotocol.registry/official'; const latest = exact.find(s => s._meta && s._meta[key] && s._meta[key].isLatest) || exact.sort((a, b) => ((b._meta && b._meta[key] && b._meta[key].publishedAt) || '').localeCompare((a._meta && a._meta[key] && a._meta[key].publishedAt) || ''))[0]; latest ? latest.server.version : 'none'")"
           else
             REGISTRY_VERSION=unknown
             echo "Registry lookup failed — will attempt the publish and let it decide."


### PR DESCRIPTION
## Summary
The MCP registry search endpoint returns every historical version for an exact server name. The publish workflow used the first matching record, read `0.3.0` instead of the `0.6.2` record marked `isLatest`, and attempted a duplicate publish after #37 merged.

This selects the official `isLatest` record and falls back to the newest `publishedAt` record when that flag is absent.

## Verification
- live registry selector returns `0.6.2`
- `npm run check:release`
- `npm test`: 165/165
- `git diff --check`

## Exact-SHA review
Head `be7ab20b96a15525d02959176b6d8f634df3d4bc`:
- authenticated `claude-sonnet-5`: clean
- free `thinkingmachines/inkling:free`: clean