### PR TITLE
Reject non-monotonic automated releases

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,5 +20,6 @@ jobs:
           cache: npm
       - run: npm ci
       - run: npm run check:release
+      - run: npm run test:release
       - run: npm run build
       - run: npm test

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -33,6 +33,9 @@ jobs:
       - name: Verify release metadata
         run: npm run check:release
 
+      - name: Install dependencies
+        run: npm ci
+
       - name: Check if package.json version is already published
         id: version
         run: |
@@ -41,17 +44,14 @@ jobs:
           PUBLISHED_VERSION="$(npm view "$PKG_NAME" version 2>/dev/null || echo none)"
           echo "local=$LOCAL_VERSION" >> "$GITHUB_OUTPUT"
           echo "published=$PUBLISHED_VERSION" >> "$GITHUB_OUTPUT"
-          if [ "$LOCAL_VERSION" = "$PUBLISHED_VERSION" ]; then
+          RELEASE_STATE="$(node scripts/check-release-order.mjs "$LOCAL_VERSION" "$PUBLISHED_VERSION")"
+          if [ "$RELEASE_STATE" = "same" ]; then
             echo "changed=false" >> "$GITHUB_OUTPUT"
             echo "package.json version ($LOCAL_VERSION) is already published — nothing to do."
           else
             echo "changed=true" >> "$GITHUB_OUTPUT"
             echo "package.json version ($LOCAL_VERSION) differs from published ($PUBLISHED_VERSION) — publishing."
           fi
-
-      - name: Install dependencies
-        if: steps.version.outputs.changed == 'true'
-        run: npm ci
 
       - name: Build
         if: steps.version.outputs.changed == 'true'

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,10 +13,12 @@
         "zod": "^3.24.0"
       },
       "bin": {
-        "substack-mcp": "dist/index.js"
+        "substack-mcp": "dist/index.js",
+        "substack-mcp-login": "dist/login.js"
       },
       "devDependencies": {
         "@types/node": "^22.0.0",
+        "semver": "^7.8.5",
         "tsx": "^4.0.0",
         "typescript": "^5.7.0",
         "vitest": "^4.1.0"
@@ -2405,6 +2407,19 @@
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "license": "MIT"
+    },
+    "node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/send": {
       "version": "1.2.1",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "sync:release": "node scripts/sync-release-metadata.mjs",
     "lint": "tsc --noEmit -p tsconfig.lint.json",
     "test": "vitest run",
+    "test:release": "node --test scripts/check-release-order.controls.mjs",
     "start": "node dist/index.js",
     "dev": "tsx src/index.ts",
     "prepublishOnly": "npm run check:release && npm run build && npm test",
@@ -24,6 +25,7 @@
   },
   "devDependencies": {
     "@types/node": "^22.0.0",
+    "semver": "^7.8.5",
     "tsx": "^4.0.0",
     "typescript": "^5.7.0",
     "vitest": "^4.1.0"

--- a/scripts/check-release-order.controls.mjs
+++ b/scripts/check-release-order.controls.mjs
@@ -1,0 +1,22 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { classifyRelease } from './check-release-order.mjs';
+
+test('classifies equal and greater releases', () => {
+  assert.equal(classifyRelease('1.2.3', 'none'), 'first');
+  assert.equal(classifyRelease('1.2.3', '1.2.3'), 'same');
+  assert.equal(classifyRelease('1.2.4', '1.2.3'), 'upgrade');
+  assert.equal(classifyRelease('2.0.0', '1.99.99'), 'upgrade');
+});
+
+test('handles prerelease precedence', () => {
+  assert.equal(classifyRelease('1.2.3-beta.2', '1.2.3-beta.1'), 'upgrade');
+  assert.throws(() => classifyRelease('1.2.3-beta.1', '1.2.3'));
+});
+
+test('rejects lower and invalid versions', () => {
+  assert.throws(() => classifyRelease('1.2.2', '1.2.3'), /Refusing non-monotonic release/);
+  assert.throws(() => classifyRelease('not-semver', '1.2.3'), /Invalid local version/);
+  assert.throws(() => classifyRelease('1.2.3', 'not-semver'), /Invalid published version/);
+});

--- a/scripts/check-release-order.mjs
+++ b/scripts/check-release-order.mjs
@@ -1,0 +1,25 @@
+import semver from 'semver';
+
+export function classifyRelease(localVersion, publishedVersion) {
+  if (!semver.valid(localVersion)) {
+    throw new Error(`Invalid local version: ${localVersion}`);
+  }
+  if (publishedVersion === 'none') return 'first';
+  if (!semver.valid(publishedVersion)) {
+    throw new Error(`Invalid published version: ${publishedVersion}`);
+  }
+  if (semver.eq(localVersion, publishedVersion)) return 'same';
+  if (semver.gt(localVersion, publishedVersion)) return 'upgrade';
+  throw new Error(
+    `Refusing non-monotonic release: local ${localVersion} is older than published ${publishedVersion}`,
+  );
+}
+
+if (process.argv[1]?.endsWith('check-release-order.mjs')) {
+  try {
+    console.log(classifyRelease(process.argv[2], process.argv[3]));
+  } catch (error) {
+    console.error(error.message);
+    process.exit(1);
+  }
+}


### PR DESCRIPTION
## Summary
- compare the local package version to npm with standards-compliant SemVer ordering
- allow first publication, no-op on equal, publish only strictly greater versions
- fail the workflow before npm or MCP publication for lower or invalid versions
- cover first/equal/greater/lower/invalid/prerelease behavior with deterministic Node controls
- run the controls in CI and install dependencies before the publish-version decision

Closes #38.

## Verification
- `actionlint .github/workflows/ci.yml .github/workflows/publish.yml`
- `npm run test:release`: 3/3 controls
- `npm run check:release`
- `npm run lint`
- `npm run build`
- `npm test`: 165/165
- direct CLI: upgrade exits 0; downgrade exits 1
- `git diff --check`

## Exact-SHA review
Head `b66839b39d5bab657161df79ed570084026097b7`:
- authenticated `claude-sonnet-5`: scoped logic clean; one claimed MCP bypass was rejected because a failed version step terminates the job before later steps
- free `thinkingmachines/inkling:free`: no verified actionable finding