### PR TITLE
Pin the Node container base with weekly updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+version: 2
+updates:
+  - package-ecosystem: docker
+    directory: "/"
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 1

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,13 +6,15 @@
 #           -e SUBSTACK_USER_ID=... \
 #           substack-mcp
 
-FROM node:22-alpine AS builder
+# Pin the multi-architecture base for reproducible MCP Catalog builds.
+# Dependabot checks the Node 22 / Alpine 3.24 tag weekly for a new digest.
+FROM node:22-alpine3.24@sha256:c610fcdfb1d5b4740dd70c284ed3cb16bb857e0f7166196e36a5501df7a3aa32 AS builder
 WORKDIR /app
 COPY package.json package-lock.json tsconfig.json ./
 COPY src ./src
 RUN npm ci --ignore-scripts && npm run build
 
-FROM node:22-alpine
+FROM node:22-alpine3.24@sha256:c610fcdfb1d5b4740dd70c284ed3cb16bb857e0f7166196e36a5501df7a3aa32
 WORKDIR /app
 ENV NODE_ENV=production
 COPY package.json package-lock.json ./


### PR DESCRIPTION
Pins Node 22 / Alpine 3.24 by multi-architecture digest and adds weekly Docker Dependabot updates so security refreshes arrive as auditable PRs.

Verification:
- lint, 165 tests, and build pass
- pin-count and no-floating-base controls pass
- hosted CI passes
- Docker Hub confirms `22-alpine3.24` resolves to the pinned OCI multi-architecture index
- `git diff --check` passes

Exact head: `5742fae8fada6fa192e3e73d0a2f30476e785179`.

Independent exact-SHA reviews:
- `claude-sonnet-5`: clean; no blocking findings
- `thinkingmachines/inkling:free`: clean; no blocking findings

Advances conorbronsdon/personal-context#194.
