### PR TITLE
fix: keep Docker updates on the selected Node major

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,3 +5,9 @@ updates:
     schedule:
       interval: weekly
     open-pull-requests-limit: 1
+    # Production stays on the selected Node LTS line. Dependabot should refresh
+    # the pinned image digest without silently changing the runtime major.
+    ignore:
+      - dependency-name: node
+        update-types:
+          - version-update:semver-major


### PR DESCRIPTION
## What & why

Keep Docker image updates on the selected Node LTS major. Dependabot opened #42 to move the production image from Node 22 to pre-LTS Node 26 even though the pinned-image contract calls for Node 22 digest refreshes.

This ignores Docker semver-major updates for the `node` image while leaving same-major and digest updates enabled. It supersedes #42.

## How verified

- [x] `npm run lint` clean
- [x] `npm test` passing (165 tests)
- [x] Release metadata and release-order controls pass
- [x] TypeScript build passes
- [x] Dependabot YAML parses and the exact ignore rule is value-asserted

## Safe-by-design checklist

- [x] No new publish / delete / schedule capability for long-form posts
- [x] Immediate-publish Note behavior is unchanged
