### PR TITLE
feat: add consent-based free subscriber management

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,8 @@ Every tool declares MCP [tool annotations](https://modelcontextprotocol.io/docs/
 | Tool | Description |
 |------|-------------|
 | `get_subscriber_count` | Get your publication's current subscriber count |
+| `list_subscribers` | Read a bounded page of private subscriber records |
+| `get_subscriber` | Look up membership by exact email; reconcile pending additions |
 | `list_published_posts` | List published posts with pagination |
 | `list_drafts` | List draft posts |
 | `get_post` | Get full content of a published post by ID |
@@ -59,6 +61,37 @@ Every tool declares MCP [tool annotations](https://modelcontextprotocol.io/docs/
 | `create_note_with_link` | Publish a Note with a link card attachment (**publishes immediately**) |
 
 Notes have no draft state on Substack, so there is no draft-first option for these two tools.
+
+### Subscriber management
+
+`add_free_subscriber` adds one consenting reader to the free newsletter. It is
+a distribution change: that reader may receive future newsletter emails. It
+does not send a welcome email, grant paid access, or override Substack's
+suppression of previously unsubscribed addresses. Its MCP annotations identify
+it as an external write (`readOnlyHint: false`, `openWorldHint: true`).
+
+```json
+{"email":"reader@example.org","consent_confirmed":true,"dry_run":true}
+```
+
+Dry-run is the default. After checking actual newsletter consent, set
+`dry_run: false` to execute. Multi-publication configurations also require the
+`publication` selector, just like every other tool.
+
+Results distinguish `existing`, `dry_run`, `verified`, `blocked`, and
+`unverified`. An empty API acknowledgement is **not** proof of addition.
+`verified` means an exact membership lookup succeeded after the request; it
+does not prove that this request originally created the membership. Dashboard
+data can lag. A missing reader may also have previously unsubscribed.
+
+For `unverified`, recheck with `get_subscriber`; never automatically repeat the
+add. For `blocked`, review in Substack without bypassing suppression. Automated
+callers must persist an attempt ledger **before** sending each live request.
+The client's in-memory duplicate guard does not survive restarts or separate
+HTTP sessions. Keep subscriber identities and consent evidence out of shared
+repositories, prompts to public services, and routine logs.
+
+Implementation and live verification notes: [subscriber API](docs/subscribers.md).
 
 ### Intentionally excluded
 

--- a/README.md
+++ b/README.md
@@ -79,7 +79,9 @@ Dry-run is the default. After checking actual newsletter consent, set
 `publication` selector, just like every other tool.
 
 Results distinguish `existing`, `dry_run`, `verified`, `blocked`, and
-`unverified`. An empty API acknowledgement is **not** proof of addition.
+`unverified`, `busy`, and `retryable`. `busy` performs no write; wait for the
+other operation. `retryable` means authentication or rate limiting refused the
+request; resolve that condition before explicitly retrying. An empty API acknowledgement is **not** proof of addition.
 `verified` means an exact membership lookup succeeded after the request; it
 does not prove that this request originally created the membership. Dashboard
 data can lag. A missing reader may also have previously unsubscribed.

--- a/README.md
+++ b/README.md
@@ -71,11 +71,14 @@ suppression of previously unsubscribed addresses. Its MCP annotations identify
 it as an external write (`readOnlyHint: false`, `openWorldHint: true`).
 
 ```json
-{"email":"reader@example.org","consent_confirmed":true,"dry_run":true}
+{"email":"reader@example.org","consent_confirmed":true,"consent_evidence":{"source":"booking:message-id","recorded_at":"2026-09-01T00:00:00Z"},"dry_run":true}
 ```
 
 Dry-run is the default. After checking actual newsletter consent, set
-`dry_run: false` to execute. Multi-publication configurations also require the
+`dry_run: false` to execute. Live adds require the source reference and timestamp
+in `consent_evidence`; this attestation is echoed with the publication key for
+auditing and does not replace checking the underlying consent record.
+Multi-publication configurations also require the
 `publication` selector, just like every other tool.
 
 Results distinguish `existing`, `dry_run`, `verified`, `blocked`, and
@@ -91,7 +94,7 @@ add. For `blocked`, review in Substack without bypassing suppression. Automated
 callers must persist an attempt ledger **before** sending each live request.
 The client's in-memory duplicate guard does not survive restarts or separate
 HTTP sessions. Keep subscriber identities and consent evidence out of shared
-repositories, prompts to public services, and routine logs.
+repositories, prompts to unapproved public services, and routine logs.
 
 Implementation and live verification notes: [subscriber API](docs/subscribers.md).
 

--- a/docs/subscribers.md
+++ b/docs/subscribers.md
@@ -13,6 +13,10 @@ over a thousand subscribers returned filtered `count: 1` for a listed address
 and `count: 0` for an absent one. Both paths were exercised through the built
 MCP tools. Pages are bounded to 50 records and default to 10.
 
+Case behavior was also checked live: a mixed-case stored address matched both
+its original spelling and a lower-case query, and an upper-case query matched
+another existing member. The exact filter is case-insensitive in these checks.
+
 The response includes `subscribers`, `count`, and a potentially stale
 `lastSync`. Membership is established by an exact row with a subscription ID.
 The field `is_subscribed` represents paid-content access, **not** free newsletter
@@ -48,6 +52,11 @@ address by itself does not. For calendar integrations, bind the answer to the
 `Booked by` email, use the latest answer per address, and exclude negative,
 ambiguous, or already-subscribed answers. A later booking No blocks a new add;
 it is not an instruction to remove an existing subscriber.
+
+Live adds require `consent_evidence` containing a nonempty `source` reference
+and an ISO `recorded_at` timestamp. The tool echoes this attestation and the
+publication key for caller audit logs; it cannot independently authenticate a
+caller's evidence. Retain the underlying record privately.
 
 Persist an attempt before calling a live add, keyed by publication and email.
 Unknown outcomes require read-only reconciliation, including after a process

--- a/docs/subscribers.md
+++ b/docs/subscribers.md
@@ -8,7 +8,10 @@ existing session-cookie client. These are unofficial endpoints and can change.
 `POST /api/v1/subscriber-stats` accepts `{filters, limit, offset}`. Exact email
 lookup uses `filters.user_email_address_string_is`; a top-level search is not
 equivalent. The MCP checks returned addresses and counts, failing closed if a
-filter appears ignored. Pages are bounded to 50 records and default to 10.
+filter appears ignored. Live exact-email queries against a publication with
+over a thousand subscribers returned filtered `count: 1` for a listed address
+and `count: 0` for an absent one. Both paths were exercised through the built
+MCP tools. Pages are bounded to 50 records and default to 10.
 
 The response includes `subscribers`, `count`, and a potentially stale
 `lastSync`. Membership is established by an exact row with a subscription ID.

--- a/docs/subscribers.md
+++ b/docs/subscribers.md
@@ -1,0 +1,52 @@
+# Subscriber API contract
+
+Validated September 2026 against a publication with a custom domain using the
+existing session-cookie client. These are unofficial endpoints and can change.
+
+## Read
+
+`POST /api/v1/subscriber-stats` accepts `{filters, limit, offset}`. Exact email
+lookup uses `filters.user_email_address_string_is`; a top-level search is not
+equivalent. The MCP checks returned addresses and counts, failing closed if a
+filter appears ignored. Pages are bounded to 50 records and default to 10.
+
+The response includes `subscribers`, `count`, and a potentially stale
+`lastSync`. Membership is established by an exact row with a subscription ID.
+The field `is_subscribed` represents paid-content access, **not** free newsletter
+membership, and is intentionally omitted from tool output.
+
+## Write
+
+`POST /api/v1/subscriber/add` uses:
+
+```json
+{"email":"reader@example.org","subscription":false,"sendEmail":false}
+```
+
+The field names are shown in the publisher's [working request screenshots](https://substack.com/@huryn/note/c-181571328).
+The [subscriber-query implementation](https://github.com/marcomoauro/substack-mcp/blob/main/src/api/substack/SubscriberQuery.js)
+documents the exact filter encoding and paid-access field semantics.
+
+A real opted-in address absent from the membership query received HTTP 400:
+`No valid emails found. This could be because an email previously unsubscribed.`
+The tool reports `blocked`; it does not infer that an unsubscribe definitely
+occurred, attempt another endpoint, or offer a force-resubscribe option.
+
+Three earlier UI additions were reconciled through exact API lookups. The
+dashboard had initially not shown them. This establishes why immediate absence
+is not a failed-write signal. The new add tool's successful-write sequence is
+covered with mocked API responses; production verification must state separately
+which paths were exercised live. No invented subscriber is added as a test.
+
+## Automation contract
+
+Only an explicit newsletter opt-in authorizes an addition. A booking or contact
+address by itself does not. For calendar integrations, bind the answer to the
+`Booked by` email, use the latest answer per address, and exclude negative,
+ambiguous, or already-subscribed answers. A later booking No blocks a new add;
+it is not an instruction to remove an existing subscriber.
+
+Persist an attempt before calling a live add, keyed by publication and email.
+Unknown outcomes require read-only reconciliation, including after a process
+crash. Do not use inbox/unread status as processing state: booking notices may
+already be archived. Never use approximate audience counts to verify an add.

--- a/src/__tests__/annotations.test.ts
+++ b/src/__tests__/annotations.test.ts
@@ -21,6 +21,8 @@ const registered = (
 
 const READ_TOOLS: ToolName[] = [
   "get_subscriber_count",
+  "list_subscribers",
+  "get_subscriber",
   "list_published_posts",
   "list_drafts",
   "get_post",
@@ -34,6 +36,7 @@ const READ_TOOLS: ToolName[] = [
 const DRAFT_WRITE_TOOLS: ToolName[] = ["create_draft", "update_draft"];
 
 const PUBLIC_UPLOAD_TOOLS: ToolName[] = ["upload_image"];
+const SUBSCRIBER_WRITE_TOOLS: ToolName[] = ["add_free_subscriber"];
 
 const PUBLISH_TOOLS: ToolName[] = ["create_note", "create_note_with_link"];
 
@@ -127,6 +130,7 @@ describe("tool annotation classifications", () => {
     // unsafe default of true. Reads omit it (not meaningful for a read).
     for (const name of [
       ...DRAFT_WRITE_TOOLS,
+      ...SUBSCRIBER_WRITE_TOOLS,
       ...PUBLIC_UPLOAD_TOOLS,
       ...PUBLISH_TOOLS,
     ]) {
@@ -146,6 +150,7 @@ describe("tool annotation classifications", () => {
     const grouped = [
       ...READ_TOOLS,
       ...DRAFT_WRITE_TOOLS,
+      ...SUBSCRIBER_WRITE_TOOLS,
       ...PUBLIC_UPLOAD_TOOLS,
       ...PUBLISH_TOOLS,
     ];

--- a/src/__tests__/subscribers.test.ts
+++ b/src/__tests__/subscribers.test.ts
@@ -7,6 +7,7 @@ import { ValidationError, SubstackAPIError } from "../utils/errors.js";
 import { createServer } from "../server.js";
 
 const email = "reader@example.org";
+const evidence = { source: "booking:test-message-id", recorded_at: "2026-09-01T00:00:00Z" };
 const row = { user_email_address: email, subscription_id: 42, subscription_interval: "free", is_subscribed: false };
 const empty = { count: 0, subscribers: [], lastSync: "2026-09-01T00:00:00Z" };
 const found = { count: 1, subscribers: [row] };
@@ -14,9 +15,10 @@ const found = { count: 1, subscribers: [row] };
 describe("subscriber management", () => {
   it("uses the exact-email filter and does not mistake free membership for unsubscribed", async () => {
     const request = vi.fn().mockResolvedValue(found);
-    const result = await new SubscriberService(request).add(" Reader@Example.org ", true, false);
+    const result = await new SubscriberService(request).add(" Reader@Example.org ", true, false, evidence);
     expect(result.status).toBe("existing");
     expect(result.subscriber?.subscription_id).toBe(42);
+    expect(result.subscriber).not.toHaveProperty("is_subscribed");
     expect(request).toHaveBeenCalledTimes(1);
     expect(JSON.parse(request.mock.calls[0][1].body)).toEqual({ filters: { user_email_address_string_is: email }, limit: 2, offset: 0 });
   });
@@ -29,7 +31,7 @@ describe("subscriber management", () => {
 
   it("sends the free/no-welcome contract and verifies membership", async () => {
     const request = vi.fn().mockResolvedValueOnce(empty).mockResolvedValueOnce({}).mockResolvedValueOnce(found);
-    expect((await new SubscriberService(request).add(email, true, false)).status).toBe("verified");
+    expect((await new SubscriberService(request).add(email, true, false, evidence)).status).toBe("verified");
     expect(request.mock.calls[1]).toEqual(["/api/v1/subscriber/add", { method: "POST", body: JSON.stringify({ email, subscription: false, sendEmail: false }) }]);
   });
 
@@ -37,22 +39,22 @@ describe("subscriber management", () => {
     const request = vi.fn().mockResolvedValue(empty);
     request.mockResolvedValueOnce(empty).mockResolvedValueOnce({});
     const service = new SubscriberService(request);
-    expect((await service.add(email, true, false)).status).toBe("unverified");
-    expect((await service.add(email, true, false)).status).toBe("unverified");
+    expect((await service.add(email, true, false, evidence)).status).toBe("unverified");
+    expect((await service.add(email, true, false, evidence)).status).toBe("unverified");
     expect(request.mock.calls.filter(c => c[0].endsWith("/add"))).toHaveLength(1);
   });
 
   it("can reconcile a prior uncertain write without a second add", async () => {
     const request = vi.fn().mockResolvedValueOnce(empty).mockResolvedValueOnce({}).mockResolvedValueOnce(empty).mockResolvedValueOnce(found);
     const service = new SubscriberService(request);
-    await service.add(email, true, false);
-    expect((await service.add(email, true, false)).status).toBe("existing");
+    await service.add(email, true, false, evidence);
+    expect((await service.add(email, true, false, evidence)).status).toBe("existing");
     expect(request.mock.calls.filter(c => c[0].endsWith("/add"))).toHaveLength(1);
   });
 
   it("respects Substack rejection without a suppression override", async () => {
     const request = vi.fn().mockResolvedValueOnce(empty).mockRejectedValueOnce(new ValidationError("/add", "No valid emails found. This could be because an email previously unsubscribed."));
-    const result = await new SubscriberService(request).add(email, true, false);
+    const result = await new SubscriberService(request).add(email, true, false, evidence);
     expect(result.status).toBe("blocked");
     expect(request).toHaveBeenCalledTimes(2);
   });
@@ -60,32 +62,34 @@ describe("subscriber management", () => {
   it.each([new Error("network failure"), new SyntaxError("invalid JSON")])("retains unknown outcomes after a write failure", async error => {
     const request = vi.fn().mockResolvedValue(empty).mockResolvedValueOnce(empty).mockRejectedValueOnce(error);
     const service = new SubscriberService(request);
-    expect((await service.add(email, true, false)).status).toBe("unverified");
-    await service.add(email, true, false);
+    expect((await service.add(email, true, false, evidence)).status).toBe("unverified");
+    await service.add(email, true, false, evidence);
     expect(request.mock.calls.filter(c => c[0].endsWith("/add"))).toHaveLength(1);
   });
 
   it("reports verification failure separately from write acceptance", async () => {
     const request = vi.fn().mockResolvedValueOnce(empty).mockResolvedValueOnce({}).mockRejectedValueOnce(new Error("read failed"));
-    expect((await new SubscriberService(request).add(email, true, false)).status).toBe("unverified");
+    expect((await new SubscriberService(request).add(email, true, false, evidence)).status).toBe("unverified");
   });
 
   it.each([{}, { count: 0, subscribers: [row] }, { count: 1, subscribers: [] }, { count: 1, subscribers: [{ ...row, user_email_address: "different@example.org" }] }])("fails closed on malformed or ignored lookup filters", async page => {
     const request = vi.fn().mockResolvedValue(page);
-    await expect(new SubscriberService(request).add(email, true, false)).rejects.toThrow();
+    await expect(new SubscriberService(request).add(email, true, false, evidence)).rejects.toThrow();
     expect(request).toHaveBeenCalledTimes(1);
   });
 
   it.each([null, [], { error: "blocked" }])("does not call an unexpected add response verified", async reply => {
     const request = vi.fn().mockResolvedValueOnce(empty).mockResolvedValueOnce(reply);
-    expect((await new SubscriberService(request).add(email, true, false)).status).toBe("unverified");
+    expect((await new SubscriberService(request).add(email, true, false, evidence)).status).toBe("unverified");
   });
 
   it("requires valid consent and a single email before touching the API", async () => {
     const request = vi.fn();
     const service = new SubscriberService(request);
+    await expect(service.add(email, true, false)).rejects.toThrow();
+    await expect(service.add(email, true, false, { source: " ", recorded_at: "invalid" })).rejects.toThrow();
     await expect(service.add(email, false, false)).rejects.toThrow(/opt-in/);
-    await expect(service.add("a@example.org,b@example.org", true, false)).rejects.toThrow();
+    await expect(service.add("a@example.org,b@example.org", true, false, evidence)).rejects.toThrow();
     expect(request).not.toHaveBeenCalled();
   });
 
@@ -94,7 +98,7 @@ describe("subscriber management", () => {
     const request = vi.fn().mockImplementationOnce(() => new Promise(resolve => { release = resolve; })).mockResolvedValue(empty);
     const service = new SubscriberService(request);
     const first = service.add(email, true);
-    expect((await service.add(email, true, false)).status).toBe("busy");
+    expect((await service.add(email, true, false, evidence)).status).toBe("busy");
     expect((await service.add("other@example.org", true)).status).toBe("dry_run");
     release(empty);
     await first;
@@ -113,24 +117,24 @@ describe("subscriber management", () => {
   it.each([401, 403, 429])("allows an explicit retry after a known %i rejection", async code => {
     const request = vi.fn().mockResolvedValueOnce(empty).mockRejectedValueOnce(new SubstackAPIError(code, "rejected", "/add")).mockResolvedValueOnce(empty).mockResolvedValueOnce({}).mockResolvedValueOnce(found);
     const service = new SubscriberService(request);
-    expect((await service.add(email, true, false)).status).toBe("retryable");
-    expect((await service.add(email, true, false)).status).toBe("verified");
+    expect((await service.add(email, true, false, evidence)).status).toBe("retryable");
+    expect((await service.add(email, true, false, evidence)).status).toBe("verified");
     expect(request.mock.calls.filter(c => c[0].endsWith("/add"))).toHaveLength(2);
   });
 
   it("keeps blocked terminal without misreporting it as an unknown write", async () => {
     const request = vi.fn().mockResolvedValueOnce(empty).mockRejectedValueOnce(new ValidationError("/add", "No valid emails")).mockResolvedValue(empty);
     const service = new SubscriberService(request);
-    expect((await service.add(email, true, false)).status).toBe("blocked");
-    expect((await service.add(email, true, false)).status).toBe("blocked");
+    expect((await service.add(email, true, false, evidence)).status).toBe("blocked");
+    expect((await service.add(email, true, false, evidence)).status).toBe("blocked");
     expect(request.mock.calls.filter(c => c[0].endsWith("/add"))).toHaveLength(1);
   });
 
   it("does not assume a 500 proves the write was rolled back", async () => {
     const request = vi.fn().mockResolvedValueOnce(empty).mockRejectedValueOnce(new SubstackAPIError(500, "server failed", "/add")).mockResolvedValue(empty);
     const service = new SubscriberService(request);
-    expect((await service.add(email, true, false)).status).toBe("unverified");
-    await service.add(email, true, false);
+    expect((await service.add(email, true, false, evidence)).status).toBe("unverified");
+    await service.add(email, true, false, evidence);
     expect(request.mock.calls.filter(c => c[0].endsWith("/add"))).toHaveLength(1);
   });
 });
@@ -153,7 +157,12 @@ describe("subscriber tools over MCP", () => {
       expect(missing.isError).toBe(true);
       const wrongPub = await client.callTool({ name: "get_subscriber", arguments: { email } });
       expect(wrongPub.isError).toBe(true);
+      const missingEvidence = await client.callTool({ name: "add_free_subscriber", arguments: { email, consent_confirmed: true, dry_run: false, publication: "two" } });
+      expect(missingEvidence.isError).toBe(true);
       expect(fetchMock).toHaveBeenCalledTimes(1);
+      fetchMock.mockResolvedValue({ ok: true, json: async () => found });
+      const audited = await client.callTool({ name: "add_free_subscriber", arguments: { email, consent_confirmed: true, consent_evidence: evidence, dry_run: false, publication: "one" } });
+      expect(JSON.parse((audited.content as Array<{text: string}>)[0].text)).toMatchObject({ status: "existing", publication: "one", consent_evidence: evidence });
       const tools = (await client.listTools()).tools;
       expect(tools.find(t => t.name === "add_free_subscriber")?.annotations).toMatchObject({ readOnlyHint: false, openWorldHint: true, destructiveHint: false });
     } finally { await client.close(); await server.close(); }

--- a/src/__tests__/subscribers.test.ts
+++ b/src/__tests__/subscribers.test.ts
@@ -1,0 +1,137 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+import { SubscriberService } from "../api/subscribers.js";
+import { SubstackClient } from "../api/client.js";
+import { ValidationError } from "../utils/errors.js";
+import { createServer } from "../server.js";
+
+const email = "reader@example.org";
+const row = { user_email_address: email, subscription_id: 42, subscription_interval: "free", is_subscribed: false };
+const empty = { count: 0, subscribers: [], lastSync: "2026-09-01T00:00:00Z" };
+const found = { count: 1, subscribers: [row] };
+
+describe("subscriber management", () => {
+  it("uses the exact-email filter and does not mistake free membership for unsubscribed", async () => {
+    const request = vi.fn().mockResolvedValue(found);
+    const result = await new SubscriberService(request).add(" Reader@Example.org ", true, false);
+    expect(result.status).toBe("existing");
+    expect(result.subscriber?.subscription_id).toBe(42);
+    expect(request).toHaveBeenCalledTimes(1);
+    expect(JSON.parse(request.mock.calls[0][1].body)).toEqual({ filters: { user_email_address_string_is: email }, limit: 2, offset: 0 });
+  });
+
+  it("defaults to dry run", async () => {
+    const request = vi.fn().mockResolvedValue(empty);
+    expect((await new SubscriberService(request).add(email, true)).status).toBe("dry_run");
+    expect(request).toHaveBeenCalledTimes(1);
+  });
+
+  it("sends the free/no-welcome contract and verifies membership", async () => {
+    const request = vi.fn().mockResolvedValueOnce(empty).mockResolvedValueOnce({}).mockResolvedValueOnce(found);
+    expect((await new SubscriberService(request).add(email, true, false)).status).toBe("verified");
+    expect(request.mock.calls[1]).toEqual(["/api/v1/subscriber/add", { method: "POST", body: JSON.stringify({ email, subscription: false, sendEmail: false }) }]);
+  });
+
+  it("does not treat an empty acknowledgement as success or repeat an uncertain write", async () => {
+    const request = vi.fn().mockResolvedValue(empty);
+    request.mockResolvedValueOnce(empty).mockResolvedValueOnce({});
+    const service = new SubscriberService(request);
+    expect((await service.add(email, true, false)).status).toBe("unverified");
+    expect((await service.add(email, true, false)).status).toBe("unverified");
+    expect(request.mock.calls.filter(c => c[0].endsWith("/add"))).toHaveLength(1);
+  });
+
+  it("can reconcile a prior uncertain write without a second add", async () => {
+    const request = vi.fn().mockResolvedValueOnce(empty).mockResolvedValueOnce({}).mockResolvedValueOnce(empty).mockResolvedValueOnce(found);
+    const service = new SubscriberService(request);
+    await service.add(email, true, false);
+    expect((await service.add(email, true, false)).status).toBe("existing");
+    expect(request.mock.calls.filter(c => c[0].endsWith("/add"))).toHaveLength(1);
+  });
+
+  it("respects Substack rejection without a suppression override", async () => {
+    const request = vi.fn().mockResolvedValueOnce(empty).mockRejectedValueOnce(new ValidationError("/add", "No valid emails found. This could be because an email previously unsubscribed."));
+    const result = await new SubscriberService(request).add(email, true, false);
+    expect(result.status).toBe("blocked");
+    expect(request).toHaveBeenCalledTimes(2);
+  });
+
+  it.each([new Error("network failure"), new SyntaxError("invalid JSON")])("retains unknown outcomes after a write failure", async error => {
+    const request = vi.fn().mockResolvedValue(empty).mockResolvedValueOnce(empty).mockRejectedValueOnce(error);
+    const service = new SubscriberService(request);
+    expect((await service.add(email, true, false)).status).toBe("unverified");
+    await service.add(email, true, false);
+    expect(request.mock.calls.filter(c => c[0].endsWith("/add"))).toHaveLength(1);
+  });
+
+  it("reports verification failure separately from write acceptance", async () => {
+    const request = vi.fn().mockResolvedValueOnce(empty).mockResolvedValueOnce({}).mockRejectedValueOnce(new Error("read failed"));
+    expect((await new SubscriberService(request).add(email, true, false)).status).toBe("unverified");
+  });
+
+  it.each([{}, { count: 0, subscribers: [row] }, { count: 1, subscribers: [] }, { count: 1, subscribers: [{ ...row, user_email_address: "different@example.org" }] }])("fails closed on malformed or ignored lookup filters", async page => {
+    const request = vi.fn().mockResolvedValue(page);
+    await expect(new SubscriberService(request).add(email, true, false)).rejects.toThrow();
+    expect(request).toHaveBeenCalledTimes(1);
+  });
+
+  it.each([null, [], { error: "blocked" }])("does not call an unexpected add response verified", async reply => {
+    const request = vi.fn().mockResolvedValueOnce(empty).mockResolvedValueOnce(reply);
+    expect((await new SubscriberService(request).add(email, true, false)).status).toBe("unverified");
+  });
+
+  it("requires valid consent and a single email before touching the API", async () => {
+    const request = vi.fn();
+    const service = new SubscriberService(request);
+    await expect(service.add(email, false, false)).rejects.toThrow(/opt-in/);
+    await expect(service.add("a@example.org,b@example.org", true, false)).rejects.toThrow();
+    expect(request).not.toHaveBeenCalled();
+  });
+
+  it("blocks concurrent writes for one email but permits another email", async () => {
+    let release!: (value: unknown) => void;
+    const request = vi.fn().mockImplementationOnce(() => new Promise(resolve => { release = resolve; })).mockResolvedValue(empty);
+    const service = new SubscriberService(request);
+    const first = service.add(email, true);
+    expect((await service.add(email, true, false)).status).toBe("unverified");
+    expect((await service.add("other@example.org", true)).status).toBe("dry_run");
+    release(empty);
+    await first;
+    expect(request).toHaveBeenCalledTimes(2);
+  });
+
+  it("bounds pagination before an API call", async () => {
+    const request = vi.fn().mockResolvedValue(empty);
+    const service = new SubscriberService(request);
+    for (const [offset, limit] of [[-1, 10], [0, 51], [0, 0], [0.5, 10]]) await expect(service.list(offset, limit)).rejects.toThrow();
+    await service.list(50, 10);
+    expect(request).toHaveBeenCalledTimes(1);
+    expect(JSON.parse(request.mock.calls[0][1].body)).toEqual({ filters: { order_by_desc_nulls_last: "subscription_created_at" }, offset: 50, limit: 10 });
+  });
+});
+
+describe("subscriber tools over MCP", () => {
+  afterEach(() => vi.unstubAllGlobals());
+  it("routes to the selected publication and rejects missing consent/publication without requests", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({ ok: true, json: async () => empty });
+    vi.stubGlobal("fetch", fetchMock);
+    const server = createServer(["one", "two"].map(key => ({ key, label: key, client: new SubstackClient(`https://${key}.substack.com`, "token", "1") })));
+    const client = new Client({ name: "test", version: "1" });
+    const [ct, st] = InMemoryTransport.createLinkedPair();
+    await Promise.all([client.connect(ct), server.connect(st)]);
+    try {
+      const result = await client.callTool({ name: "add_free_subscriber", arguments: { email, consent_confirmed: true, publication: "two" } });
+      expect(result.isError).toBeFalsy();
+      expect(JSON.parse((result.content as Array<{text: string}>)[0].text).status).toBe("dry_run");
+      expect(fetchMock.mock.calls[0][0]).toBe("https://two.substack.com/api/v1/subscriber-stats");
+      const missing = await client.callTool({ name: "add_free_subscriber", arguments: { email, publication: "two" } });
+      expect(missing.isError).toBe(true);
+      const wrongPub = await client.callTool({ name: "get_subscriber", arguments: { email } });
+      expect(wrongPub.isError).toBe(true);
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+      const tools = (await client.listTools()).tools;
+      expect(tools.find(t => t.name === "add_free_subscriber")?.annotations).toMatchObject({ readOnlyHint: false, openWorldHint: true, destructiveHint: false });
+    } finally { await client.close(); await server.close(); }
+  });
+});

--- a/src/__tests__/subscribers.test.ts
+++ b/src/__tests__/subscribers.test.ts
@@ -3,7 +3,7 @@ import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
 import { SubscriberService } from "../api/subscribers.js";
 import { SubstackClient } from "../api/client.js";
-import { ValidationError } from "../utils/errors.js";
+import { ValidationError, SubstackAPIError } from "../utils/errors.js";
 import { createServer } from "../server.js";
 
 const email = "reader@example.org";
@@ -94,7 +94,7 @@ describe("subscriber management", () => {
     const request = vi.fn().mockImplementationOnce(() => new Promise(resolve => { release = resolve; })).mockResolvedValue(empty);
     const service = new SubscriberService(request);
     const first = service.add(email, true);
-    expect((await service.add(email, true, false)).status).toBe("unverified");
+    expect((await service.add(email, true, false)).status).toBe("busy");
     expect((await service.add("other@example.org", true)).status).toBe("dry_run");
     release(empty);
     await first;
@@ -108,6 +108,30 @@ describe("subscriber management", () => {
     await service.list(50, 10);
     expect(request).toHaveBeenCalledTimes(1);
     expect(JSON.parse(request.mock.calls[0][1].body)).toEqual({ filters: { order_by_desc_nulls_last: "subscription_created_at" }, offset: 50, limit: 10 });
+  });
+
+  it.each([401, 403, 429])("allows an explicit retry after a known %i rejection", async code => {
+    const request = vi.fn().mockResolvedValueOnce(empty).mockRejectedValueOnce(new SubstackAPIError(code, "rejected", "/add")).mockResolvedValueOnce(empty).mockResolvedValueOnce({}).mockResolvedValueOnce(found);
+    const service = new SubscriberService(request);
+    expect((await service.add(email, true, false)).status).toBe("retryable");
+    expect((await service.add(email, true, false)).status).toBe("verified");
+    expect(request.mock.calls.filter(c => c[0].endsWith("/add"))).toHaveLength(2);
+  });
+
+  it("keeps blocked terminal without misreporting it as an unknown write", async () => {
+    const request = vi.fn().mockResolvedValueOnce(empty).mockRejectedValueOnce(new ValidationError("/add", "No valid emails")).mockResolvedValue(empty);
+    const service = new SubscriberService(request);
+    expect((await service.add(email, true, false)).status).toBe("blocked");
+    expect((await service.add(email, true, false)).status).toBe("blocked");
+    expect(request.mock.calls.filter(c => c[0].endsWith("/add"))).toHaveLength(1);
+  });
+
+  it("does not assume a 500 proves the write was rolled back", async () => {
+    const request = vi.fn().mockResolvedValueOnce(empty).mockRejectedValueOnce(new SubstackAPIError(500, "server failed", "/add")).mockResolvedValue(empty);
+    const service = new SubscriberService(request);
+    expect((await service.add(email, true, false)).status).toBe("unverified");
+    await service.add(email, true, false);
+    expect(request.mock.calls.filter(c => c[0].endsWith("/add"))).toHaveLength(1);
   });
 });
 

--- a/src/annotations.ts
+++ b/src/annotations.ts
@@ -19,7 +19,8 @@
  *
  * `openWorldHint` convention used here: `true` means the tool's output enters
  * an open world of external entities — a public Substack Note, or a
- * publicly-fetchable CDN image URL. Private draft writes stay in your account
+ * publicly-fetchable CDN image URL, or a change to newsletter recipients.
+ * Private draft writes stay in your account
  * and are `false`.
  */
 
@@ -84,6 +85,7 @@ export type ToolName = keyof typeof TOOL_KINDS;
 /** MCP tool annotations derived from a tool's side-effect class. */
 export interface ToolAnnotationHints {
   readOnlyHint: boolean;
+  idempotentHint?: boolean;
   destructiveHint?: boolean;
   openWorldHint?: boolean;
 }
@@ -110,12 +112,13 @@ export function buildAnnotations(name: ToolName): ToolAnnotationHints {
         openWorldHint: false,
       };
     case "public-upload":
-    case "subscriber-write":
       return {
         readOnlyHint: false,
         destructiveHint: false,
         openWorldHint: true,
       };
+    case "subscriber-write":
+      return { readOnlyHint: false, destructiveHint: false, openWorldHint: true, idempotentHint: false };
     case "publish":
       return {
         readOnlyHint: false,

--- a/src/annotations.ts
+++ b/src/annotations.ts
@@ -3,14 +3,14 @@
  *
  * Mirrors the gws-mcp-server pattern: every tool declares exactly one
  * side-effect class in an exhaustive registry, and `buildAnnotations` maps
- * that class to MCP annotation hints so clients can reason about side
+ * that class to MCP side-effect hints so clients can reason about side
  * effects and render accurate consent UI. A completeness test asserts the
  * registry matches the set of tools actually registered on the server, so
  * new tools cannot ship unclassified.
  *
  * IMPORTANT — MCP hints default to the UNSAFE direction. Per the spec
  * (schema 2025-06-18), an omitted `destructiveHint` defaults to `true` and an
- * omitted `openWorldHint` defaults to `true`. So we set EVERY relevant hint
+ * omitted `openWorldHint` defaults to `true`. So we set readOnlyHint, destructiveHint, and openWorldHint
  * explicitly on writes; leaving one off would make a reversible private draft
  * edit read to a conformant client as destructive and open-world. Annotations
  * are also untrusted hints — the authoritative consent surface is the tool
@@ -91,8 +91,8 @@ export interface ToolAnnotationHints {
 }
 
 /**
- * Map a tool's declared kind into MCP `annotations`, setting every relevant
- * hint EXPLICITLY (never relying on MCP's unsafe-by-default omission).
+ * Map a tool's declared kind into MCP `annotations`, setting the read/destructive/open-world
+ * hints EXPLICITLY (never relying on MCP's unsafe-by-default omission).
  *
  * - Reads: `readOnlyHint: true` (destructive/open-world hints are not
  *   meaningful for a read).

--- a/src/annotations.ts
+++ b/src/annotations.ts
@@ -38,6 +38,8 @@ export type ToolKind =
    * URL, though the asset is not attributed or added to your feed.
    */
   | "public-upload"
+  /** Changes who receives future newsletter emails. */
+  | "subscriber-write"
   /**
    * Write with IMMEDIATE PUBLIC effect: Substack Notes publish the moment
    * the tool runs. Notes have no draft state on Substack, and this server
@@ -56,6 +58,9 @@ export type ToolKind =
 export const TOOL_KINDS = {
   // Reads
   get_subscriber_count: "read",
+  list_subscribers: "read",
+  get_subscriber: "read",
+  add_free_subscriber: "subscriber-write",
   list_published_posts: "read",
   list_drafts: "read",
   get_post: "read",
@@ -105,6 +110,7 @@ export function buildAnnotations(name: ToolName): ToolAnnotationHints {
         openWorldHint: false,
       };
     case "public-upload":
+    case "subscriber-write":
       return {
         readOnlyHint: false,
         destructiveHint: false,

--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -13,6 +13,7 @@ import {
   SubstackScheduledPost,
 } from "./types.js";
 import { mapHttpStatusToError, extractErrorDetail, TimeoutError, isAbortError } from "../utils/errors.js";
+import { SubscriberService } from "./subscribers.js";
 
 /**
  * Per-request deadline applied to every outbound fetch.
@@ -68,6 +69,8 @@ export function parseMagnitude(raw: string): number | null {
 }
 
 export class SubstackClient {
+  readonly subscribers = new SubscriberService((path, options) =>
+    this.request(`${this.publicationUrl}${path}`, options));
   private publicationUrl: string;
   private cookie: string;
   private userId: number;

--- a/src/api/subscribers.ts
+++ b/src/api/subscribers.ts
@@ -2,6 +2,11 @@ import { z } from "zod";
 import { SubstackAPIError } from "../utils/errors.js";
 
 const emailSchema = z.string().trim().email().max(254).transform(s => s.toLowerCase());
+export const consentEvidenceSchema = z.object({
+  source: z.string().trim().min(1).max(500),
+  recorded_at: z.string().datetime({ offset: true }),
+});
+export type ConsentEvidence = z.infer<typeof consentEvidenceSchema>;
 const rowSchema = z.object({
   user_email_address: emailSchema,
   subscription_id: z.number().int().positive(),
@@ -64,10 +69,11 @@ export class SubscriberService {
     };
   }
 
-  async add(email: string, consentConfirmed: boolean, dryRun = true): Promise<SubscriberResult> {
+  async add(email: string, consentConfirmed: boolean, dryRun = true, evidence?: ConsentEvidence): Promise<SubscriberResult> {
     const normalized = emailSchema.parse(email);
     if (consentConfirmed !== true) throw new Error("Explicit newsletter opt-in is required.");
     if (typeof dryRun !== "boolean") throw new Error("dryRun must be a boolean.");
+    if (!dryRun) consentEvidenceSchema.parse(evidence);
     if (this.busy.has(normalized)) return { status: "busy", email: normalized, note: "Another operation is in progress for this email. This call performed no write; wait for that operation to finish." };
     this.busy.add(normalized);
     try {
@@ -89,7 +95,7 @@ export class SubscriberService {
         if (error instanceof SubstackAPIError && error.statusCode === 400) {
           this.attempted.delete(normalized);
           this.blocked.add(normalized);
-          return { status: "blocked", email: normalized, note: "Substack rejected the address. It may be invalid or previously unsubscribed. Do not bypass suppression or automatically retry." };
+          return { status: "blocked", email: normalized, note: "Substack rejected the request (HTTP 400). The address may be invalid or suppressed, or the request format may have changed. Review without bypassing suppression or automatically retrying." };
         }
         if (error instanceof SubstackAPIError && [401, 403, 429].includes(error.statusCode)) {
           this.attempted.delete(normalized);

--- a/src/api/subscribers.ts
+++ b/src/api/subscribers.ts
@@ -1,0 +1,99 @@
+import { z } from "zod";
+import { SubstackAPIError } from "../utils/errors.js";
+
+const emailSchema = z.string().trim().email().max(254).transform(s => s.toLowerCase());
+const rowSchema = z.object({
+  user_email_address: emailSchema,
+  subscription_id: z.number().int().positive(),
+  subscription_interval: z.string().nullable(),
+});
+const pageSchema = z.object({
+  count: z.number().int().nonnegative(),
+  subscribers: z.array(rowSchema),
+  lastSync: z.string().optional(),
+});
+
+export type Subscriber = z.infer<typeof rowSchema>;
+export interface SubscriberResult {
+  status: "existing" | "verified" | "dry_run" | "blocked" | "unverified";
+  email: string;
+  subscriber?: Subscriber;
+  note: string;
+}
+
+type Request = (path: string, options?: RequestInit) => Promise<unknown>;
+
+/** Unofficial admin API. Never interpret is_subscribed as free membership:
+ * that field indicates paid-content access. Never expose a resubscribe override.
+ */
+export class SubscriberService {
+  // Prevent a second write after an unknown outcome during this client lifetime.
+  // Durable callers must also persist their own attempt ledger before calling.
+  private attempted = new Set<string>();
+  private busy = new Set<string>();
+  constructor(private request: Request) {}
+
+  async list(offset = 0, limit = 10, email?: string) {
+    z.number().int().min(0).parse(offset);
+    z.number().int().min(1).max(50).parse(limit);
+    const normalized = email === undefined ? undefined : emailSchema.parse(email);
+    const filters = normalized
+      ? { user_email_address_string_is: normalized }
+      : { order_by_desc_nulls_last: "subscription_created_at" };
+    const result = pageSchema.parse(await this.request("/api/v1/subscriber-stats", {
+      method: "POST", body: JSON.stringify({ filters, limit, offset }),
+    }));
+    // Fail closed if the upstream stops honoring the exact-email filter.
+    if (normalized && (result.count > 1 || result.count !== result.subscribers.length || result.subscribers.some(s => s.user_email_address !== normalized))) {
+      throw new Error("Substack returned an unexpected exact-email lookup result; no write is safe.");
+    }
+    if (result.count > 0 && offset === 0 && result.subscribers.length === 0) {
+      throw new Error("Substack returned an incomplete subscriber page.");
+    }
+    return result;
+  }
+
+  async get(email: string) {
+    const normalized = emailSchema.parse(email);
+    const page = await this.list(0, 2, normalized);
+    return {
+      email: normalized, subscriber: page.subscribers[0] ?? null,
+      last_sync: page.lastSync ?? null,
+      note: "Absence does not establish eligibility: former subscribers may be suppressed. Dashboard data can lag writes.",
+    };
+  }
+
+  async add(email: string, consentConfirmed: boolean, dryRun = true): Promise<SubscriberResult> {
+    const normalized = emailSchema.parse(email);
+    if (consentConfirmed !== true) throw new Error("Explicit newsletter opt-in is required.");
+    if (typeof dryRun !== "boolean") throw new Error("dryRun must be a boolean.");
+    if (this.busy.has(normalized)) return { status: "unverified", email: normalized, note: "Another operation is in progress for this email. Reconcile before retrying." };
+    this.busy.add(normalized);
+    try {
+      const before = await this.get(normalized);
+      if (before.subscriber) return { status: "existing", email: normalized, subscriber: before.subscriber, note: "Already listed; no write performed." };
+      if (this.attempted.has(normalized)) return { status: "unverified", email: normalized, note: "A previous write has an unknown outcome. No second write performed. Reconcile through Substack before retrying." };
+      if (dryRun) return { status: "dry_run", email: normalized, note: "Not currently listed. A live add may still be blocked by Substack suppression. No write performed." };
+      this.attempted.add(normalized);
+      try {
+        const reply = await this.request("/api/v1/subscriber/add", {
+          method: "POST", body: JSON.stringify({ email: normalized, subscription: false, sendEmail: false }),
+        });
+        // {} is normal. It is an acknowledgement, not proof of membership.
+        if (!reply || typeof reply !== "object" || Array.isArray(reply) || "error" in reply || "errors" in reply) {
+          return { status: "unverified", email: normalized, note: "Unexpected add response. Reconcile membership; do not automatically retry." };
+        }
+      } catch (error) {
+        if (error instanceof SubstackAPIError && error.statusCode === 400) {
+          return { status: "blocked", email: normalized, note: "Substack rejected the address. It may be invalid or previously unsubscribed. Do not bypass suppression or automatically retry." };
+        }
+        return { status: "unverified", email: normalized, note: "The add request failed or timed out; its outcome is unknown. Reconcile membership before retrying." };
+      }
+      try {
+        const after = await this.get(normalized);
+        if (after.subscriber) return { status: "verified", email: normalized, subscriber: after.subscriber, note: "Membership verified after the request. No welcome email requested." };
+      } catch { /* The write may have succeeded despite failed verification. */ }
+      return { status: "unverified", email: normalized, note: "Request accepted but membership is not yet verified. Dashboard data may lag. Recheck with get_subscriber; do not automatically retry the add." };
+    } finally { this.busy.delete(normalized); }
+  }
+}

--- a/src/api/subscribers.ts
+++ b/src/api/subscribers.ts
@@ -15,7 +15,7 @@ const pageSchema = z.object({
 
 export type Subscriber = z.infer<typeof rowSchema>;
 export interface SubscriberResult {
-  status: "existing" | "verified" | "dry_run" | "blocked" | "unverified";
+  status: "existing" | "verified" | "dry_run" | "blocked" | "unverified" | "busy" | "retryable";
   email: string;
   subscriber?: Subscriber;
   note: string;
@@ -30,6 +30,7 @@ export class SubscriberService {
   // Prevent a second write after an unknown outcome during this client lifetime.
   // Durable callers must also persist their own attempt ledger before calling.
   private attempted = new Set<string>();
+  private blocked = new Set<string>();
   private busy = new Set<string>();
   constructor(private request: Request) {}
 
@@ -67,11 +68,12 @@ export class SubscriberService {
     const normalized = emailSchema.parse(email);
     if (consentConfirmed !== true) throw new Error("Explicit newsletter opt-in is required.");
     if (typeof dryRun !== "boolean") throw new Error("dryRun must be a boolean.");
-    if (this.busy.has(normalized)) return { status: "unverified", email: normalized, note: "Another operation is in progress for this email. Reconcile before retrying." };
+    if (this.busy.has(normalized)) return { status: "busy", email: normalized, note: "Another operation is in progress for this email. This call performed no write; wait for that operation to finish." };
     this.busy.add(normalized);
     try {
       const before = await this.get(normalized);
       if (before.subscriber) return { status: "existing", email: normalized, subscriber: before.subscriber, note: "Already listed; no write performed." };
+      if (this.blocked.has(normalized)) return { status: "blocked", email: normalized, note: "Substack previously rejected this address. No write performed; review without bypassing suppression." };
       if (this.attempted.has(normalized)) return { status: "unverified", email: normalized, note: "A previous write has an unknown outcome. No second write performed. Reconcile through Substack before retrying." };
       if (dryRun) return { status: "dry_run", email: normalized, note: "Not currently listed. A live add may still be blocked by Substack suppression. No write performed." };
       this.attempted.add(normalized);
@@ -85,7 +87,13 @@ export class SubscriberService {
         }
       } catch (error) {
         if (error instanceof SubstackAPIError && error.statusCode === 400) {
+          this.attempted.delete(normalized);
+          this.blocked.add(normalized);
           return { status: "blocked", email: normalized, note: "Substack rejected the address. It may be invalid or previously unsubscribed. Do not bypass suppression or automatically retry." };
+        }
+        if (error instanceof SubstackAPIError && [401, 403, 429].includes(error.statusCode)) {
+          this.attempted.delete(normalized);
+          return { status: "retryable", email: normalized, note: "Substack refused the request due to authentication or rate limiting. Resolve authentication or back off before an explicit retry; no retry was performed." };
         }
         return { status: "unverified", email: normalized, note: "The add request failed or timed out; its outcome is unknown. Reconcile membership before retrying." };
       }

--- a/src/server.ts
+++ b/src/server.ts
@@ -62,6 +62,30 @@ export function createServer(publications: PublicationConfig[]): McpServer {
 
   // --- Read tools ---
 
+  server.registerTool("list_subscribers", {
+    description: "Read a page of private subscriber email addresses and subscription IDs. Dashboard data may lag recent changes. Use get_subscriber for exact membership checks.",
+    inputSchema: { offset: z.number().int().min(0).default(0), limit: z.number().int().min(1).max(50).default(10), ...publicationField() },
+    annotations: buildAnnotations("list_subscribers"),
+  }, async ({ offset, limit, publication }: { offset: number; limit: number; publication?: string }) => ({
+    content: [{ type: "text", text: JSON.stringify(await clientFor(publication).subscribers.list(offset, limit)) }],
+  }));
+
+  server.registerTool("get_subscriber", {
+    description: "Look up a subscriber by exact email address. A listed free subscriber is a member even without paid access. Absence does not prove the address is eligible: Substack may suppress previous unsubscribes, and dashboard data can lag. Read-only; use to reconcile uncertain adds.",
+    inputSchema: { email: z.string().trim().email().max(254), ...publicationField() },
+    annotations: buildAnnotations("get_subscriber"),
+  }, async ({ email, publication }: { email: string; publication?: string }) => ({
+    content: [{ type: "text", text: JSON.stringify(await clientFor(publication).subscribers.get(email)) }],
+  }));
+
+  server.registerTool("add_free_subscriber", {
+    description: "Add one explicitly opted-in reader to this publication's free newsletter. Changes email distribution: future newsletter emails may be delivered. Requires verified newsletter consent; never infer consent from a meeting alone. Dry-run by default; set dry_run=false to write. Never sends a welcome email, grants paid access, or overrides suppression. Existing members are skipped. An unverified result MUST be reconciled using get_subscriber, not automatically retried. Automated callers must persist an attempt ledger BEFORE invoking this tool; in-memory duplicate protection does not survive restarts or separate HTTP sessions.",
+    inputSchema: { email: z.string().trim().email().max(254), consent_confirmed: z.literal(true), dry_run: z.boolean().default(true), ...publicationField() },
+    annotations: buildAnnotations("add_free_subscriber"),
+  }, async ({ email, consent_confirmed, dry_run, publication }: { email: string; consent_confirmed: true; dry_run: boolean; publication?: string }) => ({
+    content: [{ type: "text", text: JSON.stringify(await clientFor(publication).subscribers.add(email, consent_confirmed, dry_run)) }],
+  }));
+
   server.registerTool(
     "get_subscriber_count",
     {

--- a/src/server.ts
+++ b/src/server.ts
@@ -6,6 +6,7 @@ import {
   ANALYTICS_SCAN_DEPTH,
 } from "./api/client.js";
 import { buildAnnotations } from "./annotations.js";
+import { consentEvidenceSchema, type ConsentEvidence } from "./api/subscribers.js";
 import { markdownToProseMirror, markdownToProseMirrorContent } from "./utils/markdown-to-prosemirror.js";
 import { fileToDataUri } from "./utils/image.js";
 
@@ -80,10 +81,10 @@ export function createServer(publications: PublicationConfig[]): McpServer {
 
   server.registerTool("add_free_subscriber", {
     description: "Add one explicitly opted-in reader to this publication's free newsletter. Changes email distribution: future newsletter emails may be delivered. Requires verified newsletter consent; never infer consent from a meeting alone. Dry-run by default; set dry_run=false to write. Never sends a welcome email, grants paid access, or overrides suppression. Existing members are skipped. An unverified result MUST be reconciled using get_subscriber, not automatically retried. Automated callers must persist an attempt ledger BEFORE invoking this tool; in-memory duplicate protection does not survive restarts or separate HTTP sessions.",
-    inputSchema: { email: z.string().trim().email().max(254), consent_confirmed: z.literal(true), dry_run: z.boolean().default(true), ...publicationField() },
+    inputSchema: { email: z.string().trim().email().max(254), consent_confirmed: z.literal(true), consent_evidence: consentEvidenceSchema.optional().describe("Required for a live add: the source reference and timestamp of this email address's explicit newsletter opt-in. Retain the underlying evidence privately; this field records caller attestation, not independent proof."), dry_run: z.boolean().default(true), ...publicationField() },
     annotations: buildAnnotations("add_free_subscriber"),
-  }, async ({ email, consent_confirmed, dry_run, publication }: { email: string; consent_confirmed: true; dry_run: boolean; publication?: string }) => ({
-    content: [{ type: "text", text: JSON.stringify(await clientFor(publication).subscribers.add(email, consent_confirmed, dry_run)) }],
+  }, async ({ email, consent_confirmed, consent_evidence, dry_run, publication }: { email: string; consent_confirmed: true; consent_evidence?: ConsentEvidence; dry_run: boolean; publication?: string }) => ({
+    content: [{ type: "text", text: JSON.stringify({ ...await clientFor(publication).subscribers.add(email, consent_confirmed, dry_run, consent_evidence), publication: multi ? publication : pubKeys[0], consent_evidence }) }],
   }));
 
   server.registerTool(


### PR DESCRIPTION
﻿Adds `list_subscribers`, `get_subscriber`, and `add_free_subscriber` so an opt-in workflow can manage free newsletter membership through the MCP. Adds default to dry-run and require explicit consent plus its source and timestamp for live calls. Existing members are skipped; welcome emails and paid grants are disabled. Substack rejections, concurrent calls, and uncertain outcomes stay distinct. No force-resubscribe path is exposed.

Validation: lint, build, all 250 tests, and CI on Node 20/22 pass. A mutation changing the free flag to paid fails its regression test. Live MCP calls verified exact lookup, case-insensitive matching, duplicate skipping, consent evidence, and dry-run. A direct live add validated Substack's invalid/previously-unsubscribed rejection. The new tool's successful-new-add path is covered with mocked responses, not claimed as live-tested.

Independent reviews passed at `252c991603e1ac2610e1750db402ddc208c4b605`: authenticated `claude-opus-5` and zero-priced `opencode/muse-spark-1.3-contributor-free`. Review fixes distinguish recoverable refusals from uncertain writes, retain blocked outcomes, expose busy status, and require auditable consent evidence. A suggested retry after HTTP 5xx was rejected: a server error cannot prove rollback. Live tests disproved concerns about filtered counts and case matching. Supplemental Nemotron operational review confirmed the documented caller-ledger boundary on the preceding revision. Initial free-lane approval setup was resolved by verifying public repository visibility and auditing the packet; no private subscriber records were sent to reviewers.

Automated callers must persist an attempt ledger before writes and reconcile unknown results instead of retrying. The in-memory guard does not span restarts or separate HTTP sessions. This supplies the MCP capability for conorbronsdon/cot-production#117; scheduling the calendar workflow is separate. Read-side validation of uncommon email formats is a possible fail-closed availability edge, not an unsafe add path.
