### PR TITLE
feat: sync Calendar newsletter opt-ins through MCP

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,11 @@ repositories, prompts to unapproved public services, and routine logs.
 
 Implementation and live verification notes: [subscriber API](docs/subscribers.md).
 
+For Google Calendar booking opt-ins, the [calendar sync helper](docs/calendar-sync.md)
+provides a bounded Gmail scan, latest-answer selection, a private durable attempt
+ledger, and read-only reconciliation after uncertain writes. Scheduling is an
+explicit local setup step; installing the MCP does not start a background job.
+
 ### Intentionally excluded
 
 - **Publish posts** — Publishing long-form posts should be a deliberate human action (Notes are the documented exception above)

--- a/docs/calendar-sync.md
+++ b/docs/calendar-sync.md
@@ -1,0 +1,71 @@
+# Calendar booking consent sync
+
+`node dist/calendar-sync.js CONFIG.json` runs a dry-run. Add `--write` only after
+reviewing the dry-run and explicitly authorizing the recurring newsletter adds.
+The helper uses Gmail's read-only CLI operations and calls the actual registered
+MCP tools through an in-memory MCP connection. No Gmail labels or read states are
+modified. Archived booking notices remain eligible for scanning.
+
+Prerequisites: build this repository, install/authenticate `gws`, and configure
+Substack credentials as for the MCP server. For a scheduled process, use the
+existing encrypted session store from `substack-mcp-login` or an appropriate
+secret provider; do not put session tokens in task arguments or this config.
+
+Keep config, state, locks, and output logs outside any shared repository:
+
+```json
+{
+  "organizer_email": "host@example.org",
+  "publication_url": "https://example.substack.com",
+  "publication_key": "default",
+  "state_path": "/private/calendar-sync-state.json",
+  "gws_command": "/path/to/gws",
+  "days": 180,
+  "max_messages": 200,
+  "max_adds": 5
+}
+```
+
+On Windows point `gws_command` to the installed native `gws.exe`, not a `.ps1`
+or `.cmd` shim. Execution uses an argument array and no shell, preserving Gmail's
+JSON query parameters. `publication_key` must match a configured MCP publication
+and its URL must match `publication_url`. Each publication/organizer pair needs
+one canonical state file and one scheduler; do not run multiple state files for
+the same audience. The state contains private email addresses, signup answers,
+source message IDs, and timestamps. File modes are best effort on Windows; keep
+the parent directory protected by the user's account ACL.
+
+## Processing and recovery
+
+The entire bounded Gmail scan finishes before any add is attempted. It accepts
+original `Appointment booked:` notices whose From is the configured organizer
+and Sender is Google's Calendar notification address. It reads nested plain-text
+MIME, normalizes CRLF, and associates the answer with `Booked by`, not the guest
+in the subject. These are structural sender checks, not independent signature
+verification; use the organizer's authenticated Gmail account and preserve its
+normal spam protections.
+
+Only exact affirmative answers enter the add queue. The latest received answer
+wins per email. Negative, ambiguous, duplicate-question, and already-subscribed
+answers never trigger an add. A booking No does not remove an existing reader.
+
+An exclusive lock prevents two runs using the same state. Every live attempt is
+saved and fsynced before the MCP write. State is then replaced atomically.
+Existing, verified, and blocked outcomes are terminal: the helper never re-adds
+those addresses even if they later leave the newsletter. Unknown, interrupted,
+busy, and retryable outcomes are **read-only reconciliation** on later runs.
+The scheduled helper deliberately does not automatically retry even a retryable
+MCP result. An operator can investigate and reset an individual attempt only
+after establishing that retry is appropriate and no membership was created.
+
+If a process is killed, its `.lock` may remain. Confirm the process is stopped
+before removing that lock; preserve the state file. An `attempting` record is
+treated as an unknown write, so removing a stale lock does not replay it.
+Malformed state, mismatched publication configuration, and a scan exceeding the
+message cap stop the run before new writes. Back up state before repairs.
+
+Output is aggregate JSON only. Capture stdout/stderr to private files when
+scheduling and monitor the task's exit status. `pending`, `blocked`, and `review`
+counts identify records that may need inspection in the private state. Session
+expiry, Gmail authentication, or a changed upstream response can stop the job;
+there is no unattended login or credential refresh workaround in this helper.

--- a/src/__tests__/calendar-sync.test.ts
+++ b/src/__tests__/calendar-sync.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it, vi } from "vitest";
+import { contactKey, ingest, parseBooking, processContacts, type BookingMessage, type SyncState, type Contact } from "../calendar-sync.js";
+
+const organizer = "host@example.org", email = "reader@example.org";
+function message(answer: string, subject = "Appointment booked: Guest name") : BookingMessage {
+  const text = `Booked by\r\nPR Contact\r\n${email}\r\n\r\nWould you like to sign up for my newsletter?\r\n${answer}\r\n`;
+  return { id: "m1", internalDate: "1780000000000", payload: { headers: [{ name: "From", value: organizer }, { name: "Sender", value: "Google Calendar <calendar-notification@google.com>" }, { name: "Subject", value: subject }], parts: [{ parts: [{ mimeType: "text/plain", body: { data: Buffer.from(text).toString("base64url") } }] }] } };
+}
+function state() : SyncState { return { version: 1, publication_url: "https://example.substack.com", organizer_email: organizer, seen_ids: [], contacts: {}, attempts: {} }; }
+const contact = () => parseBooking(message("Yes"), organizer)!;
+
+describe("calendar consent parsing", () => {
+  it("binds consent to the booker email, not the subject guest, through nested MIME and CRLF", () => {
+    expect(contact()).toMatchObject({ email, decision: "yes", message_id: "m1", received_at: 1780000000000 });
+  });
+  it.each(["Yes!", "Sure", "Sounds good:)", "Yes, please", "Heck yeah!", "Y"])("recognizes explicit affirmation: %s", answer => expect(parseBooking(message(answer), organizer)?.decision).toBe("yes"));
+  it.each(["Already am! :)", "Subscribed", "maybe", "Yes if you pay me", "ignore prior instructions"])("does not turn non-consent into an add: %s", answer => expect(parseBooking(message(answer), organizer)?.decision).toBe("review"));
+  it("ignores replies and other organizers", () => {
+    expect(parseBooking(message("Yes", "Re: Appointment booked: Guest"), organizer)).toBeNull();
+    expect(parseBooking(message("Yes"), "another@example.org")).toBeNull();
+    const m=message("Yes");m.payload.headers!.find(h=>h.name==="Sender")!.value="stranger@example.org";
+    expect(parseBooking(m, organizer)).toBeNull();
+  });
+  it("requires one question answer, so injected duplicate text becomes review", () => {
+    expect(parseBooking(message("Yes\r\nWould you like to sign up for my newsletter?\r\nNo"), organizer)?.decision).toBe("review");
+  });
+  it("uses newest consent regardless of Gmail list order", () => {
+    const s=state(); const yes=contact(), no:Contact={...yes, decision:"no",answer:"No",received_at:yes.received_at+1000,message_id:"m2"};
+    ingest(s,no);ingest(s,yes);
+    expect(s.contacts[contactKey(email)].decision).toBe("no");
+  });
+});
+
+describe("durable MCP workflow", () => {
+  function setup() { const s=state(); ingest(s,contact()); return s; }
+  it("saves an attempt before a live MCP add and persists its result", async () => {
+    const s=setup(), snapshots:SyncState[]=[];
+    const call=vi.fn(async(name:string,args:Record<string,unknown>)=>{
+      if(name==="get_subscriber")return {subscriber:null};
+      expect(snapshots.at(-1)?.attempts[contactKey(email)].status).toBe("attempting");
+      expect(args).toEqual({email,consent_confirmed:true,dry_run:false,consent_evidence:{source:"gmail:m1",recorded_at:new Date(1780000000000).toISOString()}});
+      return {email,status:"verified"};
+    });
+    const counts=await processContacts(s,call,()=>snapshots.push(structuredClone(s)),true);
+    expect(counts.verified).toBe(1);expect(counts.submitted).toBe(1);
+    expect(snapshots.at(-1)?.attempts[contactKey(email)].status).toBe("verified");
+  });
+  it("never adds when persistence fails before the request", async () => {
+    const call=vi.fn().mockResolvedValue({subscriber:null});
+    await expect(processContacts(setup(),call,()=>{throw new Error("disk full");},true)).rejects.toThrow("disk full");
+    expect(call).toHaveBeenCalledTimes(1);
+  });
+  it.each(["attempting","unverified","retryable","busy"] as const)("reconciles %s after restart without retrying an add", async status => {
+    const s=setup();s.attempts[contactKey(email)]={status,message_id:"m1",attempted_at:"2026-09-01T00:00:00Z"};
+    const call=vi.fn().mockResolvedValue({subscriber:null});
+    expect((await processContacts(s,call,vi.fn(),true)).pending).toBe(1);
+    expect(call).toHaveBeenCalledTimes(1);expect(call.mock.calls[0][0]).toBe("get_subscriber");
+  });
+  it("recognizes delayed membership without another write", async () => {
+    const s=setup();s.attempts[contactKey(email)]={status:"unverified",message_id:"m1",attempted_at:"2026-09-01T00:00:00Z"};
+    const call=vi.fn().mockResolvedValue({subscriber:{user_email_address:email,subscription_id:4}});
+    expect((await processContacts(s,call,vi.fn(),true)).existing).toBe(1);
+    expect(s.attempts[contactKey(email)].status).toBe("existing");expect(call).toHaveBeenCalledTimes(1);
+  });
+  it.each(["verified","existing","blocked"] as const)("never re-adds terminal %s, even if they later leave", async status => {
+    const s=setup();s.attempts[contactKey(email)]={status,message_id:"m1",attempted_at:"2026-09-01T00:00:00Z"};
+    const call=vi.fn();await processContacts(s,call,vi.fn(),true);expect(call).not.toHaveBeenCalled();
+  });
+  it("writes neither state nor Substack on dry-run", async () => {
+    const s=setup(), before=structuredClone(s), persist=vi.fn(),call=vi.fn().mockResolvedValue({subscriber:null});
+    await processContacts(s,call,persist,false);expect(s).toEqual(before);expect(persist).not.toHaveBeenCalled();expect(call).toHaveBeenCalledTimes(1);
+  });
+  it("negative and ambiguous latest answers never call MCP", async () => {
+    const s=setup();s.contacts[contactKey(email)].decision="no";
+    ingest(s,{...contact(),email:"other@example.org",decision:"review"});const call=vi.fn();
+    const counts=await processContacts(s,call,vi.fn(),true);expect(counts.no).toBe(1);expect(counts.review).toBe(1);expect(call).not.toHaveBeenCalled();
+  });
+  it("caps adds while retaining unsent contacts", async () => {
+    const s=setup();ingest(s,{...contact(),email:"other@example.org"});
+    const call=vi.fn(async(name:string,args:Record<string,unknown>)=>name==="get_subscriber"?{subscriber:null}:{email:args.email,status:"blocked"});
+    const counts=await processContacts(s,call,vi.fn(),true,1);expect(counts.submitted).toBe(1);expect(counts.capped).toBe(1);expect(Object.keys(s.attempts)).toHaveLength(1);
+  });
+  it("records an uncertain tool error instead of retrying it on the next run", async () => {
+    const s=setup();const call=vi.fn().mockResolvedValueOnce({subscriber:null}).mockRejectedValueOnce(new Error("transport failed")).mockResolvedValue({subscriber:null});
+    await processContacts(s,call,vi.fn(),true);await processContacts(s,call,vi.fn(),true);
+    expect(s.attempts[contactKey(email)].status).toBe("unverified");expect(call.mock.calls.filter(c=>c[0]==="add_free_subscriber")).toHaveLength(1);
+  });
+});

--- a/src/calendar-sync.ts
+++ b/src/calendar-sync.ts
@@ -1,0 +1,158 @@
+/** Google Calendar booking opt-ins -> the registered Substack MCP tools.
+ * No Gmail mutations. Private state and an exclusive lock live outside the repo.
+ */
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+import { createHash } from "node:crypto";
+import { readFileSync, writeFileSync, openSync, closeSync, fsyncSync, renameSync, unlinkSync, mkdirSync, existsSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { pathToFileURL } from "node:url";
+import { z } from "zod";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+import { SubstackClient } from "./api/client.js";
+import { createServer } from "./server.js";
+import { resolvePublications } from "./auth/resolve-publications.js";
+
+const exec = promisify(execFile);
+const emailSchema = z.string().email().max(254);
+const contactSchema = z.object({ email: emailSchema, answer: z.string(), message_id: z.string(), received_at: z.number().int().nonnegative(), decision: z.enum(["yes", "no", "review"]) });
+export type Contact = z.infer<typeof contactSchema>;
+const attemptSchema = z.object({ status: z.enum(["attempting", "existing", "verified", "blocked", "unverified", "retryable", "busy"]), message_id: z.string(), attempted_at: z.string() });
+const stateSchema = z.object({ version: z.literal(1), publication_url: z.string().url(), organizer_email: emailSchema, seen_ids: z.array(z.string()), contacts: z.record(contactSchema), attempts: z.record(attemptSchema) });
+export type SyncState = z.infer<typeof stateSchema>;
+export const contactKey = (email: string) => createHash("sha256").update(email.toLowerCase()).digest("hex");
+
+interface Part { mimeType?: string; body?: { data?: string }; parts?: Part[]; headers?: Array<{name: string; value: string}> }
+export interface BookingMessage { id: string; internalDate: string; payload: Part }
+function plainText(part: Part): string {
+  if (part.mimeType === "text/plain") return Buffer.from(part.body?.data ?? "", "base64url").toString("utf8");
+  return (part.parts ?? []).map(plainText).find(Boolean) ?? "";
+}
+function mailbox(value: string) { return (value.match(/<([^<>]+)>/)?.[1] ?? value).trim().toLowerCase(); }
+
+export function parseBooking(message: BookingMessage, organizer: string): Contact | null {
+  const headers = Object.fromEntries((message.payload.headers ?? []).map(h => [h.name.toLowerCase(), h.value]));
+  if (!headers.subject?.startsWith("Appointment booked:") || mailbox(headers.from ?? "") !== organizer.toLowerCase() || mailbox(headers.sender ?? "") !== "calendar-notification@google.com") return null;
+  const text = plainText(message.payload).replace(/\r\n?/g, "\n");
+  const bookers = [...text.matchAll(/^Booked by\n[^\n]+\n([^\s@]+@[^\s@]+)\s*\n/gm)];
+  if (bookers.length !== 1) return null;
+  const email = bookers[0][1].trim().toLowerCase();
+  const answers = [...text.matchAll(/^Would you like to sign up for my newsletter\?\n([^\n]+)/gm)];
+  const answer = answers.length === 1 ? answers[0][1].trim() : "";
+  const normalized = answer.toLowerCase().replace(/[.,!:)]+$/g, "").replace(/,/g, "").trim();
+  const yes = new Set(["yes", "y", "sure", "sounds good", "yes please", "yep", "absolutely", "yeah", "heck yeah", "yessir"]);
+  const no = new Set(["no", "no thanks", "no thank you", "nope", "not at this time"]);
+  const parsed = contactSchema.safeParse({ email, answer, message_id: message.id, received_at: Number(message.internalDate), decision: yes.has(normalized) ? "yes" : no.has(normalized) ? "no" : "review" });
+  return parsed.success ? parsed.data : null;
+}
+
+export function ingest(state: SyncState, contact: Contact) {
+  const key = contactKey(contact.email), previous = state.contacts[key];
+  if (!previous || contact.received_at > previous.received_at || (contact.received_at === previous.received_at && contact.message_id > previous.message_id)) state.contacts[key] = contact;
+}
+
+type Call = (name: string, args: Record<string, unknown>) => Promise<unknown>;
+export async function processContacts(state: SyncState, call: Call, persist: () => void, write: boolean, maxAdds = 5) {
+  const counts = { eligible: 0, existing: 0, verified: 0, blocked: 0, pending: 0, review: 0, no: 0, submitted: 0, capped: 0 };
+  for (const [key, contact] of Object.entries(state.contacts)) {
+    if (contact.decision !== "yes") { counts[contact.decision === "no" ? "no" : "review"]++; continue; }
+    counts.eligible++;
+    const prior = state.attempts[key];
+    if (prior && ["existing", "verified", "blocked"].includes(prior.status)) {
+      counts[prior.status as "existing" | "verified" | "blocked"]++; continue;
+    }
+    const lookup = z.object({ subscriber: z.object({ user_email_address: z.string(), subscription_id: z.number() }).passthrough().nullable() }).parse(await call("get_subscriber", { email: contact.email }));
+    if (lookup.subscriber) {
+      if (lookup.subscriber.user_email_address.toLowerCase() !== contact.email) throw new Error("Mismatched subscriber lookup.");
+      counts.existing++;
+      if (write) { state.attempts[key] = { status: "existing", message_id: contact.message_id, attempted_at: new Date().toISOString() }; persist(); }
+      continue;
+    }
+    // Any recorded live attempt is reconciliation-only, even after a crash.
+    // Retryable/busy are surfaced for an operator; the scheduler never retries.
+    if (prior) { counts.pending++; continue; }
+    if (!write) continue;
+    if (counts.submitted >= maxAdds) { counts.capped++; continue; }
+    state.attempts[key] = { status: "attempting", message_id: contact.message_id, attempted_at: new Date().toISOString() };
+    persist(); // Must succeed BEFORE sending an external write.
+    counts.submitted++;
+    try {
+      const result = z.object({ status: attemptSchema.shape.status, email: z.string() }).parse(await call("add_free_subscriber", {
+        email: contact.email, consent_confirmed: true, dry_run: false,
+        consent_evidence: { source: `gmail:${contact.message_id}`, recorded_at: new Date(contact.received_at).toISOString() },
+      }));
+      if (result.email !== contact.email) throw new Error("Mismatched add result.");
+      state.attempts[key].status = result.status;
+      if (result.status === "existing" || result.status === "verified" || result.status === "blocked") counts[result.status]++;
+      else counts.pending++;
+    } catch { state.attempts[key].status = "unverified"; counts.pending++; }
+    persist();
+  }
+  return counts;
+}
+
+function save(path: string, state: SyncState) {
+  const temporary = `${path}.new`, fd = openSync(temporary, "w", 0o600);
+  try { writeFileSync(fd, JSON.stringify(state)); fsyncSync(fd); } finally { closeSync(fd); }
+  renameSync(temporary, path);
+}
+
+async function main() {
+  const args = process.argv.slice(2);
+  if (args.length < 1 || args.length > 2 || (args[1] !== undefined && args[1] !== "--write")) throw new Error("Usage: node dist/calendar-sync.js CONFIG.json [--write]");
+  const config = z.object({ organizer_email: emailSchema, publication_url: z.string().url(), publication_key: z.string(), state_path: z.string().min(1), gws_command: z.string().default("gws"), days: z.number().int().min(1).max(365).default(180), max_messages: z.number().int().min(10).max(1000).default(200), max_adds: z.number().int().min(1).max(10).default(5) }).strict().parse(JSON.parse(readFileSync(args[0], "utf8")));
+  const statePath = resolve(config.state_path), write = args[1] === "--write";
+  mkdirSync(dirname(statePath), { recursive: true, mode: 0o700 });
+  // A stale lock after a crash is deliberately not automatically removed.
+  const lockPath = `${statePath}.lock`, lock = openSync(lockPath, "wx", 0o600);
+  let client: Client | undefined, server: ReturnType<typeof createServer> | undefined;
+  try {
+    const state = existsSync(statePath) ? stateSchema.parse(JSON.parse(readFileSync(statePath, "utf8"))) : stateSchema.parse({ version: 1, publication_url: config.publication_url, organizer_email: config.organizer_email, seen_ids: [], contacts: {}, attempts: {} });
+    if (state.publication_url !== config.publication_url || state.organizer_email !== config.organizer_email) throw new Error("State belongs to a different publication or organizer.");
+    const creds = resolvePublications();
+    const selected = creds.find(p => p.key === config.publication_key);
+    if (!selected || selected.missing.length || selected.publicationUrl.replace(/\/$/, "") !== config.publication_url.replace(/\/$/, "")) throw new Error("Missing or mismatched publication credentials.");
+    const gws = async (operation: "list" | "get", params: Record<string, unknown>) => {
+      const result = await exec(config.gws_command, ["gmail", "users", "messages", operation, "--params", JSON.stringify({ userId: "me", ...params })], { encoding: "utf8", timeout: 30000, maxBuffer: 4 * 1024 * 1024, windowsHide: true });
+      return JSON.parse(result.stdout || "{}");
+    };
+    const seen = new Set(state.seen_ids), ids: string[] = [];
+    let pageToken: string | undefined;
+    do {
+      const page = z.object({ resultSizeEstimate: z.number().int().nonnegative(), messages: z.array(z.object({ id: z.string() })).optional(), nextPageToken: z.string().optional() }).parse(await gws("list", { q: `from:${config.organizer_email} subject:"Appointment booked" newer_than:${config.days}d`, maxResults: 10, ...(pageToken ? { pageToken } : {}) }));
+      ids.push(...(page.messages ?? []).map(m => m.id)); pageToken = page.nextPageToken;
+      if (ids.length > config.max_messages || (pageToken && ids.length >= config.max_messages)) throw new Error("Booking scan exceeded its cap; no adds performed.");
+    } while (pageToken);
+    for (const id of new Set(ids)) {
+      if (seen.has(id)) continue;
+      const message = await gws("get", { id, format: "full" }) as BookingMessage;
+      if (message.id !== id) throw new Error("Mismatched Gmail message.");
+      const contact = parseBooking(message, config.organizer_email);
+      if (contact) ingest(state, contact);
+      seen.add(id);
+    }
+    state.seen_ids = [...seen];
+    if (write) save(statePath, state);
+    server = createServer([{ key: selected.key, label: selected.label, client: new SubstackClient(selected.publicationUrl, selected.sessionToken, selected.userId) }]);
+    client = new Client({ name: "calendar-consent-sync", version: "1" });
+    const [ct, st] = InMemoryTransport.createLinkedPair();
+    await Promise.all([client.connect(ct), server.connect(st)]);
+    const activeClient = client;
+    const call: Call = async (name, toolArgs) => {
+      const result = await activeClient.callTool({ name, arguments: toolArgs });
+      if (result.isError) throw new Error("MCP operation failed.");
+      const block = (result.content as Array<{type: string; text?: string}>).find(c => c.type === "text");
+      if (!block?.text) throw new Error("Missing MCP result.");
+      return JSON.parse(block.text);
+    };
+    const counts = await processContacts(state, call, () => save(statePath, state), write, config.max_adds);
+    console.log(JSON.stringify({ mode: write ? "write" : "dry_run", scanned: ids.length, ...counts }));
+  } finally {
+    try { await client?.close(); await server?.close(); } finally { closeSync(lock); unlinkSync(lockPath); }
+  }
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(resolve(process.argv[1])).href) {
+  main().catch(() => { console.error("Calendar newsletter sync failed; inspect credentials, state, scan cap, and lock. No automatic retry of recorded adds."); process.exitCode = 1; });
+}


### PR DESCRIPTION
Calendar booking opt-ins previously required manual subscriber additions. This helper scans original booking notices, keeps the latest answer per email, and submits only explicit affirmative answers through the registered Substack MCP tools.

It defaults to dry-run and stores a private durable ledger before each live request. Existing, verified, and blocked addresses are never automatically re-added; uncertain results are reconciliation-only. An exclusive lock, publication binding, bounded scans, and a per-run addition cap limit accidental repeats. Gmail filtering remains separate.

Validation: 279 tests, TypeScript lint/build, and a mutation check that catches removal of the pre-write persistence. An authenticated read-only mailbox run confirmed parsing and subscriber lookup; the authorized initial write-mode run persisted existing/blocked outcomes with zero additions. Recurring scheduling follows deployment.

Review target: `bbf4e2e40594da247674adfe9da08b7849b48088`. Muse Spark (`opencode/muse-spark-1.3-contributor-free`) passed. Paid `opencode-go/glm-5.3` also passed the exact-SHA packet. Claude hit its session limit and the first Go fallback (`opencode-go/grok-4.6`) timed out; both are recorded as `setup_failed`, not reviews. No structural fixes were needed. Node 20/22 CI passed.

Verified nonblocking review limitations: file fsync plus atomic rename protects process-crash recovery but does not guarantee directory-entry durability across power loss; consent is a scan snapshot; failed saves can leave a private `.new` file. These do not trigger automatic retries. State retention, template drift monitoring, and generic error diagnostics remain operational follow-ups. The free review found no blockers.

Supports conorbronsdon/cot-production#117. No subscriber addresses, credentials, or private state are included.
