### PR TITLE
fix: add Codex MCP packaging and pin CI actions

### DIFF
--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,0 +1,27 @@
+{
+  "name": "substack-mcp",
+  "version": "0.6.2",
+  "description": "Read Substack content and manage long-form drafts; Notes publish immediately.",
+  "author": {
+    "name": "Conor Bronsdon",
+    "url": "https://github.com/conorbronsdon"
+  },
+  "homepage": "https://github.com/conorbronsdon/substack-mcp",
+  "repository": "https://github.com/conorbronsdon/substack-mcp",
+  "license": "MIT",
+  "mcpServers": "./.mcp.json",
+  "interface": {
+    "displayName": "Substack MCP",
+    "shortDescription": "Read Substack content and manage long-form drafts; Notes publish immediately.",
+    "longDescription": "Runs the published Substack MCP server over stdio. Long-form posts have no publish, delete, or schedule tools. Notes publish immediately. Configure your own credentials outside the plugin.",
+    "developerName": "Conor Bronsdon",
+    "category": "Productivity",
+    "capabilities": [
+      "Read",
+      "Write"
+    ],
+    "defaultPrompt": [
+      "List my recent Substack posts."
+    ]
+  }
+}

--- a/.codexignore
+++ b/.codexignore
@@ -1,0 +1,6 @@
+.git/
+node_modules/
+__pycache__/
+.venv/
+.env
+.env.local

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,5 +1,9 @@
 version: 2
 updates:
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: weekly
   - package-ecosystem: docker
     directory: "/"
     schedule:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,8 +13,8 @@ jobs:
       matrix:
         node-version: [20, 22]
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-node@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+      - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
         with:
           node-version: ${{ matrix.node-version }}
           cache: npm

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,9 +15,9 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
 
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
         with:
           # Node 24 bundles npm >= 11.5.1 (required for trusted publishing) with
           # sigstore intact. Self-upgrading npm on the Node 22 runner

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,14 @@
+{
+  "mcpServers": {
+    "substack": {
+      "command": "npx",
+      "args": [
+        "-y",
+        "@conorbronsdon/substack-mcp@0.6.2"
+      ],
+      "env": {
+        "MCP_TRANSPORT": "stdio"
+      }
+    }
+  }
+}

--- a/README.md
+++ b/README.md
@@ -369,6 +369,18 @@ Built and maintained by [Conor Bronsdon](https://github.com/conorbronsdon) for t
 
 *This is an independent personal project, not affiliated with, sponsored by, or endorsed by any company. All views expressed are my own.*
 
+## Codex plugin
+
+The repository includes a Codex manifest at `.codex-plugin/plugin.json` and an
+MCP configuration at `.mcp.json`. It runs the published npm package over stdio
+using `npx`; Node.js and npm must be available. The package version is pinned
+in `.mcp.json`, so upgrading the plugin's server is an explicit change.
+
+Configure your Substack credentials outside the plugin using the environment
+variables or browser-login session described above. Never commit a session
+token. Installation does not authenticate an account or grant approval to post.
+Long-form posts remain drafts; Notes publish immediately.
+
 ## License
 
 MIT

--- a/cloud/test/fixtures.ts
+++ b/cloud/test/fixtures.ts
@@ -1,0 +1,2 @@
+// Synthetic test-only binding; never use it to configure a deployed worker.
+export const adminToken = 'example-test-token-with-more-than-thirty-two-characters';

--- a/cloud/vitest.config.ts
+++ b/cloud/vitest.config.ts
@@ -1,8 +1,9 @@
 import { cloudflareTest } from '@cloudflare/vitest-plugin';
 import { defineConfig } from 'vitest/config';
+import { adminToken } from './test/fixtures';
 export default defineConfig({
   plugins: [cloudflareTest({ wrangler: { configPath: './cloud/wrangler.jsonc' }, miniflare: { bindings: {
-    ADMIN_TOKEN: 'test-only-token-with-more-than-thirty-two-characters',
+    ADMIN_TOKEN: adminToken,
     GOOGLE_CREDENTIALS: JSON.stringify({ client_id: 'test', client_secret: 'test', refresh_token: 'test' }),
     SUBSTACK_SESSION_TOKEN: 'test', SUBSTACK_USER_ID: '1',
   } } })],

--- a/src/__tests__/http.test.ts
+++ b/src/__tests__/http.test.ts
@@ -305,22 +305,22 @@ describe("HTTP transport: origin and host validation", () => {
 
 describe("HTTP transport: bearer auth", () => {
   it("rejects a request with no token when one is configured", async () => {
-    await listen({ token: "FAKE-TEST-TOKEN" });
+    await listen({ token: "example-test-token" });
     const res = await post();
     expect(res.status).toBe(401);
     expect(factory).not.toHaveBeenCalled();
   });
 
   it("rejects a wrong token", async () => {
-    await listen({ token: "FAKE-TEST-TOKEN" });
+    await listen({ token: "example-test-token" });
     const res = await post({ Authorization: "Bearer WRONG" });
     expect(res.status).toBe(401);
     expect(factory).not.toHaveBeenCalled();
   });
 
   it("accepts the configured token", async () => {
-    await listen({ token: "FAKE-TEST-TOKEN" });
-    const res = await post({ Authorization: "Bearer FAKE-TEST-TOKEN" });
+    await listen({ token: "example-test-token" });
+    const res = await post({ Authorization: "Bearer example-test-token" });
     expect(res.status).toBe(200);
     expect(factory).toHaveBeenCalledTimes(1);
   });
@@ -328,29 +328,29 @@ describe("HTTP transport: bearer auth", () => {
   // RFC 9110 §11.1: the auth scheme is case-insensitive and is separated from
   // the credential by one or more spaces. Both of these were 401s.
   it("accepts a lowercase bearer scheme", async () => {
-    await listen({ token: "FAKE-TEST-TOKEN" });
-    const res = await post({ Authorization: "bearer FAKE-TEST-TOKEN" });
+    await listen({ token: "example-test-token" });
+    const res = await post({ Authorization: "bearer example-test-token" });
     expect(res.status).toBe(200);
     expect(factory).toHaveBeenCalledTimes(1);
   });
 
   it("accepts more than one space after the scheme", async () => {
-    await listen({ token: "FAKE-TEST-TOKEN" });
-    const res = await post({ Authorization: "Bearer   FAKE-TEST-TOKEN" });
+    await listen({ token: "example-test-token" });
+    const res = await post({ Authorization: "Bearer   example-test-token" });
     expect(res.status).toBe(200);
     expect(factory).toHaveBeenCalledTimes(1);
   });
 
   it("still rejects a token that only shares a prefix", async () => {
-    await listen({ token: "FAKE-TEST-TOKEN" });
-    const res = await post({ Authorization: "Bearer FAKE-TEST-TOKEN-EXTRA" });
+    await listen({ token: "example-test-token" });
+    const res = await post({ Authorization: "Bearer example-test-token-EXTRA" });
     expect(res.status).toBe(401);
     expect(factory).not.toHaveBeenCalled();
   });
 
   it("rejects a non-bearer scheme carrying the right secret", async () => {
-    await listen({ token: "FAKE-TEST-TOKEN" });
-    const res = await post({ Authorization: "Basic FAKE-TEST-TOKEN" });
+    await listen({ token: "example-test-token" });
+    const res = await post({ Authorization: "Basic example-test-token" });
     expect(res.status).toBe(401);
     expect(factory).not.toHaveBeenCalled();
   });

--- a/src/__tests__/plugin-package.test.ts
+++ b/src/__tests__/plugin-package.test.ts
@@ -1,0 +1,29 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+const readJson = (path: string) =>
+  JSON.parse(readFileSync(new URL(`../../${path}`, import.meta.url), "utf8"));
+
+describe("Codex plugin package", () => {
+  it("launches a pinned public npm package over stdio without embedded credentials", () => {
+    const manifest = readJson(".codex-plugin/plugin.json");
+    const servers = readJson(".mcp.json").mcpServers;
+    expect(manifest.name).toBe("substack-mcp");
+    expect(manifest.mcpServers).toBe("./.mcp.json");
+    expect(manifest.version).toMatch(/^\d+\.\d+\.\d+$/);
+    expect(servers).toEqual({
+      substack: {
+        command: "npx",
+        args: ["-y", `@conorbronsdon/substack-mcp@${manifest.version}`],
+        env: { MCP_TRANSPORT: "stdio" },
+      },
+    });
+  });
+
+  it("discloses the immediate Notes publishing boundary", () => {
+    const manifest = readJson(".codex-plugin/plugin.json");
+    expect(manifest.description).toContain("Notes publish immediately");
+    expect(manifest.interface.longDescription).toContain("no publish, delete, or schedule tools");
+    expect(manifest.interface.longDescription).toContain("Notes publish immediately");
+  });
+});

--- a/src/__tests__/resolve-credentials.test.ts
+++ b/src/__tests__/resolve-credentials.test.ts
@@ -4,7 +4,7 @@ import type { StoredSession } from "../auth/session-store.js";
 
 const stored: StoredSession = {
   publicationUrl: "https://stored.substack.com",
-  sessionToken: "stored-tok",
+  sessionToken: "example-stored-token",
   userId: "99",
   savedAt: "2026-01-01T00:00:00Z",
 };
@@ -13,12 +13,12 @@ describe("resolveCredentials", () => {
   it("prefers env vars when present (source=env)", () => {
     const env = {
       SUBSTACK_PUBLICATION_URL: "https://env.substack.com",
-      SUBSTACK_SESSION_TOKEN: "env-tok",
+      SUBSTACK_SESSION_TOKEN: "example-env-token",
       SUBSTACK_USER_ID: "1",
     } as NodeJS.ProcessEnv;
     const r = resolveCredentials(env, () => stored);
     expect(r.publicationUrl).toBe("https://env.substack.com");
-    expect(r.sessionToken).toBe("env-tok");
+    expect(r.sessionToken).toBe("example-env-token");
     expect(r.userId).toBe("1");
     expect(r.source).toBe("env");
     expect(r.missing).toEqual([]);
@@ -27,16 +27,16 @@ describe("resolveCredentials", () => {
   it("falls back to the stored session when env vars are absent (source=stored)", () => {
     const r = resolveCredentials({} as NodeJS.ProcessEnv, () => stored);
     expect(r.publicationUrl).toBe("https://stored.substack.com");
-    expect(r.sessionToken).toBe("stored-tok");
+    expect(r.sessionToken).toBe("example-stored-token");
     expect(r.userId).toBe("99");
     expect(r.source).toBe("stored");
     expect(r.missing).toEqual([]);
   });
 
   it("mixes per field, env winning each present field (source=mixed)", () => {
-    const env = { SUBSTACK_SESSION_TOKEN: "env-tok" } as NodeJS.ProcessEnv;
+    const env = { SUBSTACK_SESSION_TOKEN: "example-env-token" } as NodeJS.ProcessEnv;
     const r = resolveCredentials(env, () => stored);
-    expect(r.sessionToken).toBe("env-tok"); // env
+    expect(r.sessionToken).toBe("example-env-token"); // env
     expect(r.publicationUrl).toBe("https://stored.substack.com"); // store
     expect(r.userId).toBe("99"); // store
     expect(r.source).toBe("mixed");

--- a/src/__tests__/resolve-publications.test.ts
+++ b/src/__tests__/resolve-publications.test.ts
@@ -4,7 +4,7 @@ import type { StoredSession } from "../auth/session-store.js";
 
 const stored: StoredSession = {
   publicationUrl: "https://stored.substack.com",
-  sessionToken: "stored-tok",
+  sessionToken: "example-stored-token",
   userId: "99",
   savedAt: "2026-01-01T00:00:00Z",
 };
@@ -17,7 +17,7 @@ describe("resolvePublications", () => {
   it("falls back to resolveCredentials (single 'default' entry) when no prefixed vars are set", () => {
     const env = {
       SUBSTACK_PUBLICATION_URL: "https://env.substack.com",
-      SUBSTACK_SESSION_TOKEN: "env-tok",
+      SUBSTACK_SESSION_TOKEN: "example-env-token",
       SUBSTACK_USER_ID: "1",
     } as NodeJS.ProcessEnv;
     const pubs = resolvePublications(env, () => stored);
@@ -25,7 +25,7 @@ describe("resolvePublications", () => {
     expect(pubs[0]).toMatchObject({
       key: "default",
       publicationUrl: "https://env.substack.com",
-      sessionToken: "env-tok",
+      sessionToken: "example-env-token",
       userId: "1",
       source: "env",
       missing: [],
@@ -86,7 +86,7 @@ describe("resolvePublications", () => {
     const warn = vi.spyOn(console, "error").mockImplementation(() => {});
     const env = {
       SUBSTACK_PUBLICATION_URL: "https://legacy.substack.com",
-      SUBSTACK_SESSION_TOKEN: "legacy-tok",
+      SUBSTACK_SESSION_TOKEN: "example-legacy-token",
       SUBSTACK_USER_ID: "1",
       SUBSTACK_PUB_SAPERE_PUBLICATION_URL: "https://sapere.substack.com",
       SUBSTACK_PUB_SAPERE_SESSION_TOKEN: "tok-2",
@@ -245,7 +245,7 @@ describe("resolvePublications: names that do not match the grammar", () => {
   it("control: the legacy SUBSTACK_PUBLICATION_URL is not mistaken for a malformed prefixed name", () => {
     const env = {
       SUBSTACK_PUBLICATION_URL: "https://legacy.substack.com",
-      SUBSTACK_SESSION_TOKEN: "FAKE-LEGACY",
+      SUBSTACK_SESSION_TOKEN: "example-legacy-fallback",
       SUBSTACK_USER_ID: "1",
     } as NodeJS.ProcessEnv;
     expect(resolvePublications(env, () => null)[0].key).toBe("default");
@@ -258,10 +258,10 @@ describe("resolvePublications: key collisions", () => {
     // merge them, and can pair one publication's URL with the other's cookie.
     const env = {
       SUBSTACK_PUB_ALPHA_PUBLICATION_URL: "https://alpha.substack.com",
-      SUBSTACK_PUB_ALPHA_SESSION_TOKEN: "tok-alpha",
+      SUBSTACK_PUB_ALPHA_SESSION_TOKEN: "example-alpha-token",
       SUBSTACK_PUB_ALPHA_USER_ID: "1",
       SUBSTACK_PUB_Alpha_PUBLICATION_URL: "https://beta.substack.com",
-      SUBSTACK_PUB_Alpha_SESSION_TOKEN: "tok-beta",
+      SUBSTACK_PUB_Alpha_SESSION_TOKEN: "example-beta-token",
       SUBSTACK_PUB_Alpha_USER_ID: "2",
     } as NodeJS.ProcessEnv;
     expect(() => resolvePublications(env, () => null)).toThrow(/same publication key/i);
@@ -271,7 +271,7 @@ describe("resolvePublications: key collisions", () => {
   it("does not fire on a single key used across all three of its variables", () => {
     const env = {
       SUBSTACK_PUB_ALPHA_PUBLICATION_URL: "https://alpha.substack.com",
-      SUBSTACK_PUB_ALPHA_SESSION_TOKEN: "tok-alpha",
+      SUBSTACK_PUB_ALPHA_SESSION_TOKEN: "example-alpha-token",
       SUBSTACK_PUB_ALPHA_USER_ID: "1",
     } as NodeJS.ProcessEnv;
     expect(resolvePublications(env, () => null).map((p) => p.key)).toEqual(["alpha"]);

--- a/src/__tests__/session-store.test.ts
+++ b/src/__tests__/session-store.test.ts
@@ -50,11 +50,11 @@ describe("session store", () => {
   it("does not write the token or URL in plaintext", () => {
     saveSession({
       publicationUrl: "https://secret.substack.com",
-      sessionToken: "SUPERSECRET",
+      sessionToken: "example-secret-token",
       userId: "1",
     });
     const raw = readFileSync(join(dir, "session.json"), "utf8");
-    expect(raw).not.toContain("SUPERSECRET");
+    expect(raw).not.toContain("example-secret-token");
     expect(raw).not.toContain("secret.substack.com");
   });
 


### PR DESCRIPTION
Adds a Codex manifest and stdio configuration for the published npm package, pinned to 0.6.2. Credentials remain external. Long-form posts stay drafts; Notes publish immediately, and the plugin metadata says so.

Pins CI actions and makes synthetic test credentials explicit without changing production auth or publishing code. No version bump or npm release.

Validation: official plugin validator; 284 server tests; 8 cloud tests; release checks; TypeScript checks; server build and cloud dry-run build. The published package initialized and listed 14 tools through the exact stdio config with no real credentials and no tool calls. Hosted CI passes on Node 20 and 22.

Reviewed commit: `fdea176e7faf81bd38cf7b3671bad84f09962655`. Authenticated `claude-sonnet-5`, free `opencode/muse-spark-1.3-contributor-free`, and free `opencode/big-pickle` completed independent reviews. No verified blocking findings. Metadata and skill instructions describe boundaries; they do not establish host enforcement.

The unchanged lockfile reports 13 npm advisories; dependency upgrades are outside this packaging change. Catalog scanning still requires the separate upstream scanner fix for a token-generation example and typed environment-field maps. This PR does not disable those checks.
