### PR TITLE
Release 0.8.0: archive search, draft preflight and diagnostics

### DIFF
--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "substack-mcp",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "description": "Read Substack content and manage long-form drafts; Notes publish immediately.",
   "author": {
     "name": "Conor Bronsdon",

--- a/.mcp.json
+++ b/.mcp.json
@@ -4,7 +4,7 @@
       "command": "npx",
       "args": [
         "-y",
-        "@conorbronsdon/substack-mcp@0.7.0"
+        "@conorbronsdon/substack-mcp@0.8.0"
       ],
       "env": {
         "MCP_TRANSPORT": "stdio"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html). Releases before
 `0.6.0` are recorded in the [GitHub Releases](https://github.com/conorbronsdon/substack-mcp/releases)
 and the git tag history (`v0.1.0`–`v0.5.0`).
 
+## [0.8.0] - 2026-09-07
+
+### Added
+- `search_posts`: bounded server-side archive queries for published, draft and scheduled posts, projected metadata, explicit continuation and unknown-total handling.
+- `preflight_draft`: read-only title, audience, body, image and paywall checks with structure limits and explicit coverage limitations.
+- `substack-mcp doctor [--json] [--check-auth]`: offline configuration checks, optional bounded authenticated reads, credential-safe results and stable exit codes. Auth checks disable redirects and do not claim user identity binding.
+- Explicit `serve` alias and server `--help`; bare MCP startup and the browser-login binary remain compatible.
+- Regression coverage for publication isolation, malformed responses, secret redaction, preflight limits and installed CLI behavior. The MCP catalog now contains 19 tools.
+
 ## [0.7.0] - 2026-09-07
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -64,7 +64,9 @@ findings with severity/code/message, and content counts. It checks title,
 audience, JSON/body shape, image wrappers and HTTPS sources, and paywall count
 and edge placement. Unknown nodes and external images produce review warnings.
 Bodies over two million characters, 10,000 nodes, or depth 100 are not fully
-checked. This is a focused static check, not full ProseMirror validation or
+checked; `counts.complete` is false and aggregate checks are skipped after a
+scan limit. Unknown-node warnings name up to five types for editor review.
+This is a focused static check, not full ProseMirror validation or
 publish approval. It does not fetch links/images, verify access settings, or
 prove final rendering. Review the draft in Substack; no content is modified.
 

--- a/README.md
+++ b/README.md
@@ -37,6 +37,8 @@ Every tool declares MCP [tool annotations](https://modelcontextprotocol.io/docs/
 | `list_subscribers` | Read a bounded page of private subscriber records |
 | `get_subscriber` | Look up membership by exact email; reconcile pending additions |
 | `list_published_posts` | List published posts with pagination |
+| `search_posts` | Search a publication archive by query and status; bounded pages with continuation metadata |
+| `preflight_draft` | Read-only checks for title, audience, body structure, images, and paywalls |
 | `list_drafts` | List draft posts |
 | `get_post` | Get full content of a published post by ID |
 | `get_draft` | Get full content of a draft by ID |
@@ -44,6 +46,52 @@ Every tool declares MCP [tool annotations](https://modelcontextprotocol.io/docs/
 | `get_sections` | List your publication's sections (categories) with their IDs |
 | `get_post_analytics` | Get a published post's stats (views, opens, signups, subscribes, reactions) by ID |
 | `list_scheduled_posts` | List posts scheduled for future publication (read-only; scheduling stays in Substack's editor) |
+
+### Archive search and draft review
+
+`search_posts` accepts `query` (1–500 characters), `status` (`published`, `drafts`,
+or `scheduled`, default `published`), `offset` (default 0), and `limit` (1–50,
+default 25). It makes one authenticated archive request and returns projected
+metadata, `returned`, `total`, `has_more`, and `next_offset`. Continue with
+`next_offset` and the same query/status. When Substack omits the total and a
+page is full, `has_more` is null (unknown); another page may be empty. Substack
+controls matching and indexing: this is not a guaranteed full-text scan. Use
+`get_post` or `get_draft` to retrieve full content. Pagination is not a snapshot;
+concurrent edits can move results between pages.
+
+`preflight_draft` accepts `draft_id`, reads it once, and returns `checks_passed`,
+findings with severity/code/message, and content counts. It checks title,
+audience, JSON/body shape, image wrappers and HTTPS sources, and paywall count
+and edge placement. Unknown nodes and external images produce review warnings.
+Bodies over two million characters, 10,000 nodes, or depth 100 are not fully
+checked. This is a focused static check, not full ProseMirror validation or
+publish approval. It does not fetch links/images, verify access settings, or
+prove final rendering. Review the draft in Substack; no content is modified.
+
+Both tools require `publication` when multiple publications are configured.
+
+### Operator diagnostics
+
+```sh
+substack-mcp doctor --json
+substack-mcp doctor --json --check-auth
+```
+
+`doctor` uses the same environment/stored-session resolution as the server.
+By default it checks configuration without network requests. `--check-auth`
+adds one draft-list GET per valid publication, with a five-second request
+deadline and redirects disabled. Use an HTTPS publication origin (no path,
+query, credentials, or custom port); a redirect or custom-domain block may
+require switching to the publication's canonical `name.substack.com` origin.
+Output includes publication key, origin, credential source, configuration and
+authentication status. It omits session tokens, user IDs and upstream error
+bodies. A successful read does not establish user-ID binding or write access.
+
+Exit codes: 0 = requested checks passed; 1 = configuration/authentication check
+failed; 2 = invalid command arguments. Without `--check-auth`, a 0 exit code
+does not mean the session is unexpired. Bare `substack-mcp` still starts the
+MCP server; `substack-mcp serve` is an explicit alias. `--help` does not connect
+to Substack. Browser login remains `substack-mcp-login`.
 
 ### Write (private drafts; image upload returns a public URL)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@conorbronsdon/substack-mcp",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@conorbronsdon/substack-mcp",
-      "version": "0.7.0",
+      "version": "0.8.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.30.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@conorbronsdon/substack-mcp",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "description": "Safe creator operations for Substack: rich drafts, Notes, analytics, and consented subscribers. Long-form posts stay draft-only; Notes publish immediately.",
   "type": "module",
   "bin": {

--- a/scripts/test-package.mjs
+++ b/scripts/test-package.mjs
@@ -21,6 +21,7 @@ const expectedTools = [
   'get_draft', 'get_post', 'get_post_analytics', 'get_post_comments', 'get_sections',
   'get_subscriber', 'get_subscriber_count', 'list_drafts', 'list_published_posts',
   'list_scheduled_posts', 'list_subscribers', 'update_draft', 'upload_image',
+  'search_posts', 'preflight_draft',
 ].sort();
 
 const requiredFiles = ['package.json', 'server.json', 'README.md', 'LICENSE', 'CHANGELOG.md',
@@ -55,6 +56,21 @@ try {
     SUBSTACK_USER_ID: '0', SUBSTACK_SESSION_TOKEN: 'package-test',
     SUBSTACK_REQUEST_TIMEOUT_MS: '100', MCP_TRANSPORT: 'stdio',
   });
+  const cli = resolve(installed, installedPkg.bin['substack-mcp']);
+  assert.match(execFileSync(process.execPath, [cli, '--help'], { env, encoding: 'utf8', timeout: 10_000 }), /Usage: substack-mcp/);
+  const doctorEnv = { ...env, SUBSTACK_PUBLICATION_URL: 'https://example.substack.com', SUBSTACK_USER_ID: '1' };
+  const diagnosis = JSON.parse(execFileSync(process.execPath, [cli, 'doctor', '--json'], { env: doctorEnv, encoding: 'utf8', timeout: 10_000 }));
+  assert.equal(diagnosis.ok, true);
+  assert.equal(diagnosis.mode, 'configuration_only');
+  assert.equal(diagnosis.publications[0].authentication, 'not_checked');
+  assert.ok(!JSON.stringify(diagnosis).includes('package-test'), 'Doctor must not print session tokens');
+  for (const [args, commandEnv, status] of [
+    [['doctor', '--json'], env, 1],
+    [['doctor', '--unknown'], doctorEnv, 2],
+    [['unknown'], doctorEnv, 2],
+  ]) {
+    assert.throws(() => execFileSync(process.execPath, [cli, ...args], { env: commandEnv, encoding: 'utf8', timeout: 10_000, stdio: 'pipe' }), error => error.status === status);
+  }
   transport = new StdioClientTransport({ command: process.execPath, args: [resolve(installed, installedPkg.bin['substack-mcp'])], env, stderr: 'pipe' });
   const client = new Client({ name: 'package-smoke', version: '1.0.0' });
   await client.connect(transport, { timeout: 10_000 });

--- a/server.json
+++ b/server.json
@@ -7,12 +7,12 @@
     "url": "https://github.com/conorbronsdon/substack-mcp",
     "source": "github"
   },
-  "version": "0.7.0",
+  "version": "0.8.0",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "@conorbronsdon/substack-mcp",
-      "version": "0.7.0",
+      "version": "0.8.0",
       "runtimeHint": "npx",
       "transport": {
         "type": "stdio"

--- a/src/__tests__/annotations.test.ts
+++ b/src/__tests__/annotations.test.ts
@@ -20,6 +20,8 @@ const registered = (
 )._registeredTools;
 
 const READ_TOOLS: ToolName[] = [
+  "search_posts",
+  "preflight_draft",
   "get_subscriber_count",
   "list_subscribers",
   "get_subscriber",

--- a/src/__tests__/creator-workflows.test.ts
+++ b/src/__tests__/creator-workflows.test.ts
@@ -1,0 +1,142 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+import { createServer } from "../server.js";
+import { SubstackClient } from "../api/client.js";
+import { searchPosts } from "../api/search.js";
+import { preflightDraft } from "../utils/draft-preflight.js";
+import { doctor } from "../doctor.js";
+import type { PublicationCredentials } from "../auth/resolve-publications.js";
+
+afterEach(() => vi.unstubAllGlobals());
+const body = (content: unknown[]) => JSON.stringify({ type: "doc", content });
+const draft = { id: 42, draft_title: "A draft", audience: "everyone", draft_body: body([{ type: "paragraph", content: [{ type: "text", text: "Content" }] }]) };
+const codes = (d: unknown) => preflightDraft(d, 42).findings.map(f => f.code);
+
+describe("archive search", () => {
+  it.each(["published", "drafts", "scheduled"] as const)("encodes the query and uses the %s archive in a single request", async status => {
+    const read = vi.fn(async (_path: string) => ({ posts: [{ id: 1, title: "Match", draft_body: "private full body", stats: { secret: true } }], total: 10 }));
+    const result = await searchPosts({ query: "A&B #test", status, offset: 2, limit: 1 }, read);
+    const url = new URL(read.mock.calls[0][0]!, "https://a.substack.com");
+    expect(url.pathname).toBe(`/api/v1/post_management/${status}`);
+    expect(url.searchParams.get("query")).toBe("A&B #test");
+    expect(url.searchParams.get("order_by")).toBe({ published: "post_date", drafts: "draft_updated_at", scheduled: "trigger_at" }[status]);
+    expect(read).toHaveBeenCalledTimes(1);
+    expect(result).toMatchObject({ next_offset: 3, has_more: true, returned: 1, total: 10 });
+    expect(result.posts).toEqual([{ id: 1, title: "Match" }]);
+  });
+  it.each([{ query: " " }, { query: "x", limit: 51 }, { query: "x", offset: -1 }, { query: "x", limit: 1.5 }])("rejects invalid bounds without a request: %j", async input => {
+    const read = vi.fn();
+    await expect(searchPosts(input, read)).rejects.toThrow();
+    expect(read).not.toHaveBeenCalled();
+  });
+  it.each([{}, { posts: null }, { posts: [{}] }, { posts: [], total: -1 }, { posts: [{ id: 1 }, { id: 2 }] }])("does not turn malformed responses into an empty archive: %j", async response => {
+    await expect(searchPosts({ query: "x", limit: 1 }, async () => response)).rejects.toThrow(/archive search/i);
+  });
+  it("preserves uncertainty when totals are omitted", async () => {
+    expect(await searchPosts({ query: "x", limit: 1 }, async () => ({ posts: [{ id: 1 }] }))).toMatchObject({ total: null, has_more: null, next_offset: 1 });
+    expect(await searchPosts({ query: "x" }, async () => ({ posts: [] }))).toMatchObject({ total: null, has_more: false, next_offset: null });
+  });
+});
+
+describe("draft preflight", () => {
+  it("passes ordinary content without mutating the draft", () => {
+    const copy = JSON.stringify(draft);
+    expect(preflightDraft(draft, 42)).toMatchObject({ checks_passed: true, findings: [] });
+    expect(JSON.stringify(draft)).toBe(copy);
+  });
+  it("rejects mismatched IDs", () => expect(() => preflightDraft(draft, 43)).toThrow(/mismatched/));
+  it.each([
+    [{ ...draft, draft_title: " " }, "missing_title"],
+    [{ ...draft, audience: "made_up" }, "unknown_audience"],
+    [{ ...draft, draft_body: "{" }, "invalid_json"],
+    [{ ...draft, draft_body: "null" }, "invalid_document"],
+    [{ ...draft, draft_body: body([{ type: "paragraph", content: "bad" }]) }, "invalid_content"],
+    [{ ...draft, draft_body: body([{ type: "captionedImage", attrs: { src: "https://example.org/a.png" } }]) }, "image_wrapper"],
+    [{ ...draft, draft_body: body([{ type: "image2", attrs: { src: "javascript:alert(1)" } }]) }, "invalid_image_url"],
+    [{ ...draft, draft_body: body([{ type: "paywall" }, { type: "paywall" }]) }, "multiple_paywalls"],
+    [{ ...draft, draft_body: "x".repeat(2_000_001) }, "body_limit"],
+  ])("reports blocking findings", (input, code) => {
+    expect(codes(input)).toContain(code);
+    expect(preflightDraft(input, 42).checks_passed).toBe(false);
+  });
+  it("flags unknown nodes and lookalike CDN domains without fetching images", () => {
+    const fetchMock = vi.fn(); vi.stubGlobal("fetch", fetchMock);
+    expect(codes({ ...draft, draft_body: body([{ type: "embed" }, { type: "image2", attrs: { src: "https://substackcdn.com.example.org/a.png" } }]) })).toEqual(expect.arrayContaining(["unrecognized_nodes", "external_images"]));
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+  it("bounds deeply nested bodies", () => {
+    let node: unknown = { type: "text", text: "deep" };
+    for (let i = 0; i < 102; i++) node = { type: "blockquote", content: [node] };
+    expect(codes({ ...draft, draft_body: body([node]) })).toContain("structure_limit");
+  });
+});
+
+const credential: PublicationCredentials = { key: "example", label: "Example", publicationUrl: "https://example.substack.com", sessionToken: "test-only-secret", userId: "123", source: "env", missing: [] };
+describe("doctor", () => {
+  it("is offline by default and omits credentials and user IDs", async () => {
+    const fetchMock = vi.fn(); vi.stubGlobal("fetch", fetchMock);
+    const report = await doctor(false, () => [credential]);
+    expect(report.ok).toBe(true);
+    expect(JSON.stringify(report)).not.toMatch(/test-only-secret|123/);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+  it.each(["https://name:secret@example.org", "https://example.org/path?secret", "http://example.org", "invalid"])("rejects and redacts malformed origin %s", async publicationUrl => {
+    const fetchMock = vi.fn(); vi.stubGlobal("fetch", fetchMock);
+    const report = await doctor(true, () => [{ ...credential, publicationUrl }]);
+    expect(report.ok).toBe(false);
+    expect(report.publications[0].origin).toBeNull();
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+  it.each(["0", "1foo", "-2", "9007199254740992"])("rejects invalid user ID %s", async userId => {
+    expect((await doctor(false, () => [{ ...credential, userId }])).ok).toBe(false);
+  });
+  it("redacts configuration exceptions", async () => {
+    const result = await doctor(false, () => { throw new Error("secret-value"); });
+    expect(result.ok).toBe(false);
+    expect(JSON.stringify(result)).not.toContain("secret-value");
+  });
+  it("checks reads with a timeout and no redirects without claiming user binding", async () => {
+    const fetchMock = vi.fn(async (_url: string, _options: RequestInit) => new Response(JSON.stringify({ posts: [] })));
+    vi.stubGlobal("fetch", fetchMock);
+    const report = await doctor(true, () => [credential]);
+    expect(report).toMatchObject({ ok: true, publications: [{ authentication: "authenticated_read_succeeded", user_identity: "not_verified" }] });
+    expect(fetchMock.mock.calls[0][1]).toMatchObject({ redirect: "error", signal: expect.any(AbortSignal) });
+  });
+  it.each([401, 403, 429, 500])("reports HTTP %s without echoing server content", async status => {
+    vi.stubGlobal("fetch", vi.fn(async () => new Response("private-error-secret", { status })));
+    const report = await doctor(true, () => [credential]);
+    expect(report.ok).toBe(false);
+    expect(JSON.stringify(report)).not.toContain("private-error-secret");
+  });
+  it("does not accept a successful response with the wrong shape", async () => {
+    vi.stubGlobal("fetch", vi.fn(async () => new Response("{}")));
+    expect((await doctor(true, () => [credential])).ok).toBe(false);
+  });
+});
+
+describe("MCP publication isolation", () => {
+  it("requires publication on every tool and routes both new reads without writes", async () => {
+    const fetchMock = vi.fn(async (url: string) => new Response(JSON.stringify(url.includes("/drafts/42") ? draft : { posts: [], total: 0 })));
+    vi.stubGlobal("fetch", fetchMock);
+    const server = createServer(["a", "b"].map(key => ({ key, label: key, client: new SubstackClient(`https://${key}.substack.com`, "test-only", "1") })));
+    const [ct, st] = InMemoryTransport.createLinkedPair();
+    const client = new Client({ name: "test", version: "1" });
+    await Promise.all([client.connect(ct), server.connect(st)]);
+    try {
+      for (const tool of (await client.listTools()).tools) expect(tool.inputSchema.required).toContain("publication");
+      for (const [name, args] of [["search_posts", { query: "x" }], ["preflight_draft", { draft_id: 42 }]] as const) {
+        expect((await client.callTool({ name, arguments: args })).isError).toBe(true);
+        expect((await client.callTool({ name, arguments: { ...args, publication: "unknown" } })).isError).toBe(true);
+      }
+      expect(fetchMock).not.toHaveBeenCalled();
+      for (const [name, args] of [["search_posts", { query: "x" }], ["preflight_draft", { draft_id: 42 }]] as const) {
+        const result = await client.callTool({ name, arguments: { ...args, publication: "b" } });
+        expect(result.isError).toBeFalsy();
+        expect(JSON.parse((result.content as { text: string }[])[0].text).publication).toBe("b");
+      }
+      expect(fetchMock).toHaveBeenCalledTimes(2);
+      for (const call of fetchMock.mock.calls) expect(call[0]).toMatch(/^https:\/\/b\.substack\.com\//);
+    } finally { await client.close(); await server.close(); }
+  });
+});

--- a/src/__tests__/creator-workflows.test.ts
+++ b/src/__tests__/creator-workflows.test.ts
@@ -37,6 +37,9 @@ describe("archive search", () => {
     expect(await searchPosts({ query: "x", limit: 1 }, async () => ({ posts: [{ id: 1 }] }))).toMatchObject({ total: null, has_more: null, next_offset: 1 });
     expect(await searchPosts({ query: "x" }, async () => ({ posts: [] }))).toMatchObject({ total: null, has_more: false, next_offset: null });
   });
+  it("rejects an empty page before the reported total instead of returning a contradictory cursor", async () => {
+    await expect(searchPosts({ query: "x", offset: 2 }, async () => ({ posts: [], total: 10 }))).rejects.toThrow(/Inconsistent/);
+  });
 });
 
 describe("draft preflight", () => {
@@ -68,7 +71,16 @@ describe("draft preflight", () => {
   it("bounds deeply nested bodies", () => {
     let node: unknown = { type: "text", text: "deep" };
     for (let i = 0; i < 102; i++) node = { type: "blockquote", content: [node] };
-    expect(codes({ ...draft, draft_body: body([node]) })).toContain("structure_limit");
+    const result = preflightDraft({ ...draft, draft_body: body([node]) }, 42);
+    expect(result.findings.map(f => f.code)).toContain("structure_limit");
+    expect(result.counts.complete).toBe(false);
+    expect(result.findings.map(f => f.code)).not.toContain("no_text_or_images");
+  });
+  it("names unknown node types in a bounded warning", () => {
+    const result = preflightDraft({ ...draft, draft_body: body(Array.from({ length: 12 }, (_, i) => ({ type: `custom_${i}` }))) }, 42);
+    const warning = result.findings.find(f => f.code === "unrecognized_nodes")!;
+    expect(warning.message.match(/custom_/g)).toHaveLength(5);
+    expect(result.counts.complete).toBe(true);
   });
 });
 
@@ -95,6 +107,11 @@ describe("doctor", () => {
     const result = await doctor(false, () => { throw new Error("secret-value"); });
     expect(result.ok).toBe(false);
     expect(JSON.stringify(result)).not.toContain("secret-value");
+  });
+  it.each(["token; other=cookie", "token,other", "token\n", '"quoted"', "token with spaces"])("rejects malformed cookie values without a request", async sessionToken => {
+    const fetchMock = vi.fn(); vi.stubGlobal("fetch", fetchMock);
+    expect((await doctor(true, () => [{ ...credential, sessionToken }])).ok).toBe(false);
+    expect(fetchMock).not.toHaveBeenCalled();
   });
   it("checks reads with a timeout and no redirects without claiming user binding", async () => {
     const fetchMock = vi.fn(async (_url: string, _options: RequestInit) => new Response(JSON.stringify({ posts: [] })));

--- a/src/annotations.ts
+++ b/src/annotations.ts
@@ -58,6 +58,8 @@ export type ToolKind =
  */
 export const TOOL_KINDS = {
   // Reads
+  search_posts: "read",
+  preflight_draft: "read",
   get_subscriber_count: "read",
   list_subscribers: "read",
   get_subscriber: "read",

--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -14,6 +14,7 @@ import {
 } from "./types.js";
 import { mapHttpStatusToError, extractErrorDetail, TimeoutError, isAbortError } from "../utils/errors.js";
 import { SubscriberService } from "./subscribers.js";
+import { searchPosts } from "./search.js";
 
 /**
  * Per-request deadline applied to every outbound fetch.
@@ -162,6 +163,10 @@ export class SubstackClient {
     // If we get here without a 401/403, auth is valid
     const byline = drafts[0]?.draft_bylines?.[0];
     return { id: byline?.id ?? this.userId, name: "authenticated" };
+  }
+
+  searchPosts(input: Parameters<typeof searchPosts>[0]) {
+    return searchPosts(input, path => this.request(`${this.publicationUrl}${path}`));
   }
 
   /**

--- a/src/api/search.ts
+++ b/src/api/search.ts
@@ -36,6 +36,9 @@ export async function searchPosts(
   if (parsed.data.posts.length > limit) throw new Error("Archive search exceeded the requested page size.");
   const { posts } = parsed.data;
   const total = parsed.data.total ?? null;
+  if (posts.length === 0 && total !== null && offset < total) {
+    throw new Error("Inconsistent archive search page: no rows before the reported total. Retry the query; the archive may have changed.");
+  }
   const hasMore = total === null ? (posts.length === limit ? null : false) : offset + posts.length < total;
   return { query, status, offset, limit, returned: posts.length, total,
     has_more: hasMore, next_offset: hasMore === false || posts.length === 0 ? null : offset + posts.length,

--- a/src/api/search.ts
+++ b/src/api/search.ts
@@ -1,0 +1,44 @@
+import { z } from "zod";
+
+export const searchInput = z.object({
+  query: z.string().trim().min(1).max(500),
+  status: z.enum(["published", "drafts", "scheduled"]).default("published"),
+  offset: z.number().int().min(0).max(Number.MAX_SAFE_INTEGER - 50).default(0),
+  limit: z.number().int().min(1).max(50).default(25),
+});
+
+const row = z.object({
+  id: z.number().int().positive(),
+  title: z.string().nullable().optional(),
+  draft_title: z.string().nullable().optional(),
+  subtitle: z.string().nullable().optional(),
+  draft_subtitle: z.string().nullable().optional(),
+  slug: z.string().nullable().optional(),
+  audience: z.string().nullable().optional(),
+  post_date: z.string().nullable().optional(),
+  trigger_at: z.string().nullable().optional(),
+  draft_updated_at: z.string().nullable().optional(),
+  canonical_url: z.string().nullable().optional(),
+});
+const page = z.object({ posts: z.array(row), total: z.number().int().nonnegative().nullish() });
+
+/** One upstream query, never an implicit full-archive crawl. */
+export async function searchPosts(
+  input: z.input<typeof searchInput>,
+  read: (path: string) => Promise<unknown>,
+) {
+  const { query, status, offset, limit } = searchInput.parse(input);
+  const orderBy = { published: "post_date", drafts: "draft_updated_at", scheduled: "trigger_at" }[status];
+  const params = new URLSearchParams({ query, offset: String(offset), limit: String(limit),
+    order_by: orderBy, order_direction: status === "scheduled" ? "asc" : "desc" });
+  const parsed = page.safeParse(await read(`/api/v1/post_management/${status}?${params}`));
+  if (!parsed.success) throw new Error("Unexpected archive search response; no search results can be verified.");
+  if (parsed.data.posts.length > limit) throw new Error("Archive search exceeded the requested page size.");
+  const { posts } = parsed.data;
+  const total = parsed.data.total ?? null;
+  const hasMore = total === null ? (posts.length === limit ? null : false) : offset + posts.length < total;
+  return { query, status, offset, limit, returned: posts.length, total,
+    has_more: hasMore, next_offset: hasMore === false || posts.length === 0 ? null : offset + posts.length,
+    search_scope: "Substack server-side archive query; matching and indexing are controlled by Substack.",
+    posts };
+}

--- a/src/doctor.ts
+++ b/src/doctor.ts
@@ -12,7 +12,7 @@ export async function doctor(checkAuth = false, resolve = resolvePublications) {
       const url = new URL(p.publicationUrl);
       if (url.protocol === "https:" && !url.username && !url.password && url.pathname === "/" && !url.search && !url.hash && !url.port) origin = url.origin;
     } catch { /* Report a static code, never the supplied URL. */ }
-    const valid = !!origin && p.missing.length === 0 && /^\d+$/.test(p.userId) && Number.isSafeInteger(Number(p.userId)) && Number(p.userId) > 0 && !!p.sessionToken.trim() && !/[\r\n]/.test(p.sessionToken);
+    const valid = !!origin && p.missing.length === 0 && /^\d+$/.test(p.userId) && Number.isSafeInteger(Number(p.userId)) && Number(p.userId) > 0 && /^[\x21\x23-\x2b\x2d-\x3a\x3c-\x5b\x5d-\x7e]+$/.test(p.sessionToken);
     let authentication = "not_checked";
     if (checkAuth && valid) {
       try {

--- a/src/doctor.ts
+++ b/src/doctor.ts
@@ -1,0 +1,52 @@
+import { resolvePublications } from "./auth/resolve-publications.js";
+import { isAbortError } from "./utils/errors.js";
+
+export async function doctor(checkAuth = false, resolve = resolvePublications) {
+  let publications: ReturnType<typeof resolvePublications>;
+  try { publications = resolve(); }
+  catch { return { ok: false, code: "invalid_configuration", publications: [], guidance: "Check named publication triplets and duplicate publication keys. No credential values are printed." }; }
+  const reports = [];
+  for (const p of publications) {
+    let origin: string | null = null;
+    try {
+      const url = new URL(p.publicationUrl);
+      if (url.protocol === "https:" && !url.username && !url.password && url.pathname === "/" && !url.search && !url.hash && !url.port) origin = url.origin;
+    } catch { /* Report a static code, never the supplied URL. */ }
+    const valid = !!origin && p.missing.length === 0 && /^\d+$/.test(p.userId) && Number.isSafeInteger(Number(p.userId)) && Number(p.userId) > 0 && !!p.sessionToken.trim() && !/[\r\n]/.test(p.sessionToken);
+    let authentication = "not_checked";
+    if (checkAuth && valid) {
+      try {
+        // No redirects: never forward the session cookie to a redirected host.
+        const response = await fetch(`${origin}/api/v1/post_management/drafts?offset=0&limit=1&order_by=draft_updated_at&order_direction=desc`, {
+          headers: { Cookie: `connect.sid=${p.sessionToken}; substack.sid=${p.sessionToken}`, Accept: "application/json",
+            "User-Agent": "Mozilla/5.0", Referer: `${origin}/publish/home` },
+          redirect: "error", signal: AbortSignal.timeout(5000),
+        });
+        if (response.status === 401 || response.status === 403) authentication = "unauthorized_or_blocked";
+        else if (response.status === 429) authentication = "rate_limited";
+        else if (!response.ok) authentication = "upstream_error";
+        else {
+          const body: unknown = await response.json();
+          authentication = body && typeof body === "object" && "posts" in body && Array.isArray(body.posts) ? "authenticated_read_succeeded" : "unexpected_response";
+        }
+      } catch (error) { authentication = isAbortError(error) ? "timeout" : "network_or_response_error"; }
+    }
+    reports.push({ publication: p.key, origin, credential_source: p.source,
+      configuration: valid ? "valid" : "invalid", missing: p.missing, authentication,
+      user_identity: "not_verified" });
+  }
+  return { ok: reports.every(p => p.configuration === "valid" && (!checkAuth || p.authentication === "authenticated_read_succeeded")),
+    mode: checkAuth ? "authenticated_read" : "configuration_only", publications: reports,
+    guidance: "Use an HTTPS publication origin and a positive numeric user ID. For expired sessions run substack-mcp-login. Authenticated reads do not verify the configured user ID or write permissions." };
+}
+
+export async function runDoctor(args: string[]) {
+  if (args.some(a => a !== "--json" && a !== "--check-auth")) {
+    console.error("Usage: substack-mcp doctor [--json] [--check-auth]");
+    process.exitCode = 2;
+    return;
+  }
+  const result = await doctor(args.includes("--check-auth"));
+  console.log(args.includes("--json") ? JSON.stringify(result) : JSON.stringify(result, null, 2));
+  process.exitCode = result.ok ? 0 : 1;
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -171,7 +171,25 @@ async function main() {
   );
 }
 
-main().catch((err) => {
+async function run() {
+  const args = process.argv.slice(2);
+  if (args[0] === "doctor") {
+    const { runDoctor } = await import("./doctor.js");
+    return runDoctor(args.slice(1));
+  }
+  if (args.length === 1 && ["--help", "-h"].includes(args[0])) {
+    console.log("Usage: substack-mcp [serve | doctor [--json] [--check-auth]]\nWith no command, starts the MCP server. doctor checks configuration without network access; --check-auth adds a bounded read per publication. Login: substack-mcp-login.");
+    return;
+  }
+  if (args.length && !(args.length === 1 && args[0] === "serve")) {
+    console.error("Unknown command. Run substack-mcp --help.");
+    process.exitCode = 2;
+    return;
+  }
+  await main();
+}
+
+run().catch((err) => {
   console.error("Fatal error:", err);
   process.exit(1);
 });

--- a/src/server.ts
+++ b/src/server.ts
@@ -10,6 +10,8 @@ import { buildAnnotations } from "./annotations.js";
 import { consentEvidenceSchema, type ConsentEvidence } from "./api/subscribers.js";
 import { markdownToProseMirror, markdownToProseMirrorContent } from "./utils/markdown-to-prosemirror.js";
 import { fileToDataUri } from "./utils/image.js";
+import { searchInput } from "./api/search.js";
+import { preflightDraft } from "./utils/draft-preflight.js";
 
 export interface PublicationConfig {
   /** Tool-facing `publication` enum value, e.g. "kevin-muldoon". */
@@ -63,6 +65,22 @@ export function createServer(publications: PublicationConfig[]): McpServer {
   // additive; the Note tools publish public content immediately.
 
   // --- Read tools ---
+
+  server.registerTool("search_posts", {
+    description: "Search this publication's published, draft, or scheduled archive using Substack's server-side query. One page per call, at most 50 results; use next_offset to continue. Matching/indexing is controlled by Substack, not a guaranteed full-text scan. Returns metadata only; get_post/get_draft fetch full content.",
+    inputSchema: { ...searchInput.shape, ...publicationField() },
+    annotations: buildAnnotations("search_posts"),
+  }, async ({ publication, ...input }: z.output<typeof searchInput> & { publication?: string }) => ({
+    content: [{ type: "text", text: JSON.stringify({ ...await clientFor(publication).searchPosts(input), publication: publication ?? pubKeys[0] }) }],
+  }));
+
+  server.registerTool("preflight_draft", {
+    description: "Read a draft and check title, audience, body structure, images and paywalls. Static review aid only: never modifies or publishes; does not guarantee rendering, link availability or publish readiness. Review the findings in Substack.",
+    inputSchema: { draft_id: z.number().int().positive().max(Number.MAX_SAFE_INTEGER), ...publicationField() },
+    annotations: buildAnnotations("preflight_draft"),
+  }, async ({ draft_id, publication }: { draft_id: number; publication?: string }) => ({
+    content: [{ type: "text", text: JSON.stringify({ ...preflightDraft(await clientFor(publication).getDraft(draft_id), draft_id), publication: publication ?? pubKeys[0] }) }],
+  }));
 
   server.registerTool("list_subscribers", {
     description: "Read a page of private subscriber email addresses and subscription IDs. Dashboard data may lag recent changes. Use get_subscriber for exact membership checks.",

--- a/src/utils/draft-preflight.ts
+++ b/src/utils/draft-preflight.ts
@@ -21,15 +21,18 @@ export function preflightDraft(draft: unknown, requestedId: number) {
     catch { add("error", "invalid_json", "Draft body is not valid ProseMirror JSON."); }
   }
   let nodes = 0, images = 0, paywalls = 0, textCharacters = 0;
+  let countsComplete = false;
+  const unknownTypes = new Set<string>();
   if (root !== undefined) {
     if (!object(root) || root.type !== "doc" || !Array.isArray(root.content)) add("error", "invalid_document", "Body must be a doc with a content array.");
     else {
+      countsComplete = true;
       const stack: { node: unknown; depth: number }[] = [{ node: root, depth: 0 }];
       while (stack.length) {
         const { node, depth } = stack.pop()!;
-        if (++nodes > 10_000 || depth > 100) { add("error", "structure_limit", "Body exceeds preflight structure limits; checks are incomplete."); break; }
+        if (++nodes > 10_000 || depth > 100) { countsComplete = false; add("error", "structure_limit", "Body exceeds preflight structure limits; checks are incomplete."); break; }
         if (!object(node) || typeof node.type !== "string") { add("error", "invalid_node", "Body contains a node without a valid type."); continue; }
-        if (!knownNodes.has(node.type)) add("warning", "unrecognized_nodes", "Some node types are outside this focused check; verify their rendering in Substack.");
+        if (!knownNodes.has(node.type) && unknownTypes.size < 5) unknownTypes.add(node.type.slice(0, 80));
         if (node.type === "text") {
           if (typeof node.text !== "string") add("error", "invalid_text", "A text node is missing its text.");
           else textCharacters += node.text.trim().length;
@@ -51,12 +54,15 @@ export function preflightDraft(draft: unknown, requestedId: number) {
           else for (const child of node.content) stack.push({ node: child, depth: depth + 1 });
         }
       }
-      if (!textCharacters && !images) add("warning", "no_text_or_images", "No text or image content was found; inspect any embeds in the editor.");
-      if (paywalls > 1) add("error", "multiple_paywalls", "Keep at most one paywall break.");
-      if (root.content.length && [root.content[0], root.content.at(-1)].some(n => object(n) && n.type === "paywall")) add("warning", "paywall_at_edge", "The paywall is at the start or end of the body; check its placement.");
+      if (unknownTypes.size) add("warning", "unrecognized_nodes", `Node types outside this focused check (up to five shown): ${[...unknownTypes].join(", ")}. Verify their rendering in Substack.`);
+      if (countsComplete) {
+        if (!textCharacters && !images) add("warning", "no_text_or_images", "No text or image content was found; inspect any embeds in the editor.");
+        if (paywalls > 1) add("error", "multiple_paywalls", "Keep at most one paywall break.");
+        if (root.content.length && [root.content[0], root.content.at(-1)].some(n => object(n) && n.type === "paywall")) add("warning", "paywall_at_edge", "The paywall is at the start or end of the body; check its placement.");
+      }
     }
   }
   return { draft_id: requestedId, checks_passed: !findings.some(f => f.severity === "error"),
-    findings, counts: { nodes, images, paywalls, text_characters: textCharacters },
+    findings, counts: { complete: countsComplete, nodes, images, paywalls, text_characters: textCharacters },
     limitations: "Read-only static checks, not a publish approval or full schema validation. Images, links, embeds, access settings and final rendering require review in Substack. Nothing was modified." };
 }

--- a/src/utils/draft-preflight.ts
+++ b/src/utils/draft-preflight.ts
@@ -1,0 +1,62 @@
+type Finding = { severity: "error" | "warning"; code: string; message: string };
+const object = (v: unknown): v is Record<string, unknown> => !!v && typeof v === "object" && !Array.isArray(v);
+const knownNodes = new Set(["doc", "paragraph", "text", "heading", "blockquote", "bullet_list", "ordered_list", "list_item", "code_block", "horizontal_rule", "hard_break", "captionedImage", "image2", "caption", "paywall"]);
+
+/** Static review aid, deliberately not a complete Substack schema validator. */
+export function preflightDraft(draft: unknown, requestedId: number) {
+  if (!object(draft) || draft.id !== requestedId) throw new Error("Unexpected draft response or mismatched draft ID.");
+  const findings: Finding[] = [];
+  const seen = new Set<string>();
+  const add = (severity: Finding["severity"], code: string, message: string) => {
+    if (!seen.has(code)) { findings.push({ severity, code, message }); seen.add(code); }
+  };
+  if (typeof draft.draft_title !== "string" || !draft.draft_title.trim()) add("error", "missing_title", "Add a draft title.");
+  if (!["everyone", "only_paid", "founding", "only_free"].includes(String(draft.audience))) add("error", "unknown_audience", "Check the draft audience in Substack.");
+  if (draft.is_published === true) add("warning", "already_published", "This draft belongs to a published post; review its current state in the editor.");
+  let root: unknown;
+  if (typeof draft.draft_body !== "string" || !draft.draft_body.trim()) add("error", "missing_body", "Add draft content.");
+  else if (draft.draft_body.length > 2_000_000) add("error", "body_limit", "Body exceeds the two-million-character preflight limit; inspect it in the editor.");
+  else {
+    try { root = JSON.parse(draft.draft_body); }
+    catch { add("error", "invalid_json", "Draft body is not valid ProseMirror JSON."); }
+  }
+  let nodes = 0, images = 0, paywalls = 0, textCharacters = 0;
+  if (root !== undefined) {
+    if (!object(root) || root.type !== "doc" || !Array.isArray(root.content)) add("error", "invalid_document", "Body must be a doc with a content array.");
+    else {
+      const stack: { node: unknown; depth: number }[] = [{ node: root, depth: 0 }];
+      while (stack.length) {
+        const { node, depth } = stack.pop()!;
+        if (++nodes > 10_000 || depth > 100) { add("error", "structure_limit", "Body exceeds preflight structure limits; checks are incomplete."); break; }
+        if (!object(node) || typeof node.type !== "string") { add("error", "invalid_node", "Body contains a node without a valid type."); continue; }
+        if (!knownNodes.has(node.type)) add("warning", "unrecognized_nodes", "Some node types are outside this focused check; verify their rendering in Substack.");
+        if (node.type === "text") {
+          if (typeof node.text !== "string") add("error", "invalid_text", "A text node is missing its text.");
+          else textCharacters += node.text.trim().length;
+        }
+        if (node.type === "paywall") paywalls++;
+        if (node.type === "captionedImage" && (!Array.isArray(node.content) || !node.content.some(n => object(n) && n.type === "image2"))) add("error", "image_wrapper", "A captioned image is missing its image2 child.");
+        if (node.type === "image2") {
+          images++;
+          const src = object(node.attrs) ? node.attrs.src : undefined;
+          try {
+            if (typeof src !== "string") throw new Error();
+            const url = new URL(src);
+            if (url.protocol !== "https:" || url.username || url.password) throw new Error();
+            if (!(url.hostname === "substackcdn.com" || url.hostname.endsWith(".substackcdn.com") || url.hostname === "substack-post-media.s3.amazonaws.com")) add("warning", "external_images", "External images may not render reliably; consider upload_image and review in the editor.");
+          } catch { add("error", "invalid_image_url", "An image lacks a valid HTTPS source URL."); }
+        }
+        if (node.content !== undefined) {
+          if (!Array.isArray(node.content)) add("error", "invalid_content", "A node content field is not an array.");
+          else for (const child of node.content) stack.push({ node: child, depth: depth + 1 });
+        }
+      }
+      if (!textCharacters && !images) add("warning", "no_text_or_images", "No text or image content was found; inspect any embeds in the editor.");
+      if (paywalls > 1) add("error", "multiple_paywalls", "Keep at most one paywall break.");
+      if (root.content.length && [root.content[0], root.content.at(-1)].some(n => object(n) && n.type === "paywall")) add("warning", "paywall_at_edge", "The paywall is at the start or end of the body; check its placement.");
+    }
+  }
+  return { draft_id: requestedId, checks_passed: !findings.some(f => f.severity === "error"),
+    findings, counts: { nodes, images, paywalls, text_characters: textCharacters },
+    limitations: "Read-only static checks, not a publish approval or full schema validation. Images, links, embeds, access settings and final rendering require review in Substack. Nothing was modified." };
+}


### PR DESCRIPTION
Creators can now search their archive and inspect draft issues without manually paging through posts or changing content. This release adds `search_posts`, `preflight_draft`, and `substack-mcp doctor`, bringing the catalog to 19 tools.

- Search sends one bounded server-side query for published, draft, or scheduled posts, projects metadata, and returns explicit pagination/unknown-total information.
- Preflight reads a draft once and checks title, audience, body structure, image wrappers/sources, and paywalls. Findings state the limits of static validation and require editor review.
- Doctor defaults to offline configuration checks. `--check-auth` adds bounded GET requests with redirects disabled; results redact credentials and never claim user-ID binding. Bare MCP startup, an explicit `serve` alias, and the existing login binary work.
- Required multi-publication selectors and read-only annotations cover both new tools. Release, registry and plugin versions align at 0.8.0.

Validation: 334 core tests, 8 cloud tests, 7 release controls; core/cloud type checks; Cloudflare dry-run build; clean tarball install exercising 19 tools, MCP version agreement, help, diagnostics and exit codes.

All four required Linux/Windows Node 22/24 CI jobs pass at 7bb13866e3a3379aea055ace6aa62a1ec5e217df. Authenticated Claude Opus 5 and verified-free Muse Spark reviews covered 38b3540, with affected-file follow-ups at 7bb1386: no blockers. One unreliable Claude follow-up was discarded and replaced by a valid source-only review. Review fixes address contradictory search pagination, partial preflight counts, actionable unknown-node warnings, and malformed cookies. Remaining minor hardening stays in #50/#53/#54.

Release goal: #59. Advances the bounded scope of #50, #53 and #54; their broader feature requests remain open. Roadmap: #57.
