### PR TITLE
test: generate dummy tokens for redaction fixtures

### DIFF
--- a/scripts/test-package.mjs
+++ b/scripts/test-package.mjs
@@ -1,4 +1,5 @@
 import assert from 'node:assert/strict';
+import { randomUUID } from 'node:crypto';
 import { execFileSync } from 'node:child_process';
 import { mkdtempSync, readFileSync, rmSync, existsSync } from 'node:fs';
 import { tmpdir } from 'node:os';
@@ -50,10 +51,11 @@ try {
   // A deliberately tiny environment excludes actual credentials and multi-publication config.
   const env = Object.fromEntries(Object.entries(process.env).filter(([key, value]) =>
     /^(PATH|SYSTEMROOT|WINDIR|TEMP|TMP)$/i.test(key) && value !== undefined));
+  const testSessionToken = randomUUID();
   Object.assign(env, {
     SUBSTACK_MCP_HOME: join(scratch, 'empty-session'),
     SUBSTACK_PUBLICATION_URL: 'http://127.0.0.1:1',
-    SUBSTACK_USER_ID: '0', SUBSTACK_SESSION_TOKEN: 'package-test',
+    SUBSTACK_USER_ID: '0', SUBSTACK_SESSION_TOKEN: testSessionToken,
     SUBSTACK_REQUEST_TIMEOUT_MS: '100', MCP_TRANSPORT: 'stdio',
   });
   const cli = resolve(installed, installedPkg.bin['substack-mcp']);
@@ -63,7 +65,7 @@ try {
   assert.equal(diagnosis.ok, true);
   assert.equal(diagnosis.mode, 'configuration_only');
   assert.equal(diagnosis.publications[0].authentication, 'not_checked');
-  assert.ok(!JSON.stringify(diagnosis).includes('package-test'), 'Doctor must not print session tokens');
+  assert.ok(!JSON.stringify(diagnosis).includes(testSessionToken), 'Doctor must not print session tokens');
   for (const [args, commandEnv, status] of [
     [['doctor', '--json'], env, 1],
     [['doctor', '--unknown'], doctorEnv, 2],

--- a/src/__tests__/creator-workflows.test.ts
+++ b/src/__tests__/creator-workflows.test.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from "node:crypto";
 import { describe, it, expect, vi, afterEach } from "vitest";
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
@@ -84,13 +85,15 @@ describe("draft preflight", () => {
   });
 });
 
-const credential: PublicationCredentials = { key: "example", label: "Example", publicationUrl: "https://example.substack.com", sessionToken: "test-only-secret", userId: "123", source: "env", missing: [] };
+const testSessionToken = randomUUID();
+const credential: PublicationCredentials = { key: "example", label: "Example", publicationUrl: "https://example.substack.com", sessionToken: testSessionToken, userId: "123", source: "env", missing: [] };
 describe("doctor", () => {
   it("is offline by default and omits credentials and user IDs", async () => {
     const fetchMock = vi.fn(); vi.stubGlobal("fetch", fetchMock);
     const report = await doctor(false, () => [credential]);
     expect(report.ok).toBe(true);
-    expect(JSON.stringify(report)).not.toMatch(/test-only-secret|123/);
+    expect(JSON.stringify(report)).not.toContain(testSessionToken);
+    expect(JSON.stringify(report)).not.toContain("123");
     expect(fetchMock).not.toHaveBeenCalled();
   });
   it.each(["https://name:secret@example.org", "https://example.org/path?secret", "http://example.org", "invalid"])("rejects and redacts malformed origin %s", async publicationUrl => {


### PR DESCRIPTION
﻿Two dummy credential literals in the package smoke test and creator-workflow tests trigger the catalog's secret scanner. Generate tokens with `randomUUID()` and assert that the same generated values stay out of doctor output. User-ID redaction coverage remains intact.

Validation: type checking, 334 tests, and the installed-package smoke test pass (19 tools). All four Node 22/24 Linux/Windows CI jobs pass. Published plugin-scanner 3.0.123 passes the unchanged score-80/high-severity scan policy.

Authenticated Claude Sonnet 5 and independent Muse Spark 1.3 Contributor Free reviewed `c34cac1c488686cd6950da95f519743398610ddc`. No verified blockers. Suggestions to randomize unrelated IDs or other fixture strings are outside this repair and do not identify a current failing redaction control.
