### PR TITLE
feat: read validated publication context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html). Releases before
 `0.6.0` are recorded in the [GitHub Releases](https://github.com/conorbronsdon/substack-mcp/releases)
 and the git tag history (`v0.1.0`–`v0.5.0`).
 
+## [Unreleased]
+
+### Added
+- `get_publication`: projected publication metadata with host matching, explicit missing fields, structured MCP output and a text fallback. Does not infer account identity or permissions. Endpoint mapping is source-referenced; live contract validation remains pending for 0.9.
+
 ## [0.8.0] - 2026-09-07
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and the git tag history (`v0.1.0`–`v0.5.0`).
 ## [Unreleased]
 
 ### Added
-- `get_publication`: projected publication metadata with host matching, explicit missing fields, structured MCP output and a text fallback. Does not infer account identity or permissions. Endpoint mapping is source-referenced; live contract validation remains pending for 0.9.
+- `get_publication`: projected publication metadata with normalized host matching, explicit absent fields, structured MCP output and a text fallback. Does not infer account identity or permissions. A read-only live check passed on one custom-domain publication; broader 0.9 contract validation remains pending.
 
 ## [0.8.0] - 2026-09-07
 

--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ Every tool declares MCP [tool annotations](https://modelcontextprotocol.io/docs/
 | `list_subscribers` | Read a bounded page of private subscriber records |
 | `get_subscriber` | Look up membership by exact email; reconcile pending additions |
 | `list_published_posts` | List published posts with pagination |
+| `get_publication` | Read projected publication identity/settings, verify the configured host, and report missing fields; does not verify account identity or role |
 | `search_posts` | Search a publication archive by query and status; bounded pages with continuation metadata |
 | `preflight_draft` | Read-only checks for title, audience, body structure, images, and paywalls |
 | `list_drafts` | List draft posts |

--- a/scripts/test-package.mjs
+++ b/scripts/test-package.mjs
@@ -23,6 +23,7 @@ const expectedTools = [
   'get_subscriber', 'get_subscriber_count', 'list_drafts', 'list_published_posts',
   'list_scheduled_posts', 'list_subscribers', 'update_draft', 'upload_image',
   'search_posts', 'preflight_draft',
+  'get_publication',
 ].sort();
 
 const requiredFiles = ['package.json', 'server.json', 'README.md', 'LICENSE', 'CHANGELOG.md',

--- a/src/__tests__/annotations.test.ts
+++ b/src/__tests__/annotations.test.ts
@@ -20,6 +20,7 @@ const registered = (
 )._registeredTools;
 
 const READ_TOOLS: ToolName[] = [
+  "get_publication",
   "search_posts",
   "preflight_draft",
   "get_subscriber_count",

--- a/src/__tests__/publication.test.ts
+++ b/src/__tests__/publication.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+import { getPublication } from "../api/publication.js";
+import { SubstackClient } from "../api/client.js";
+import { createServer } from "../server.js";
+
+afterEach(() => vi.unstubAllGlobals());
+const publication = { id: 42, name: "Sample", subdomain: "sample" };
+
+describe("publication context", () => {
+  it("projects only known fields and distinguishes absent, null and false", async () => {
+    const read = vi.fn(async () => ({ ...publication, hero_text: null, paused: false, private_payload: "excluded" }));
+    const result = await getPublication("https://sample.substack.com", read);
+    expect(read).toHaveBeenCalledExactlyOnceWith("/api/v1/publication");
+    expect(result.data).toEqual({ ...publication, hero_text: null, paused: false });
+    expect(result.fields_not_returned_by_api).toContain("language");
+    expect(result.fields_not_returned_by_api).not.toContain("hero_text");
+    expect(result.fields_not_returned_by_api).not.toContain("paused");
+    expect(JSON.stringify(result)).not.toContain("excluded");
+    expect(result.identity_scope).toContain("role are not verified");
+  });
+  it("accepts an exact custom domain", async () => {
+    expect((await getPublication("https://news.example.com", async () => ({ ...publication, custom_domain: "news.example.com" }))).data.id).toBe(42);
+  });
+  it.each(["https://ample.substack.com", "https://sample.substack.com.attacker.example", "https://unrelated.example"])("rejects wrong publication %s", async url => {
+    await expect(getPublication(url, async () => publication)).rejects.toThrow(/does not match/);
+  });
+  it.each([{}, null, { ...publication, id: -1 }, { ...publication, id: Number.MAX_SAFE_INTEGER + 1 },
+    { ...publication, name: "x".repeat(1001) }, { ...publication, paused: "false" },
+    { ...publication, custom_domain: "https://example.com" }])("fails closed on malformed context", async response => {
+    await expect(getPublication("https://sample.substack.com", async () => response)).rejects.toThrow(/cannot be verified/);
+  });
+  it("propagates read failures without inventing context", async () => {
+    await expect(getPublication("https://sample.substack.com", async () => { throw new Error("read failed"); })).rejects.toThrow("read failed");
+  });
+  it("exposes structured output and routes only the selected publication without writes", async () => {
+    const fetchMock = vi.fn(async (_url: string, _options?: RequestInit) => new Response(JSON.stringify({ ...publication, subdomain: "b" })));
+    vi.stubGlobal("fetch", fetchMock);
+    const server = createServer(["a", "b"].map(key => ({ key, label: key, client: new SubstackClient(`https://${key}.substack.com`, "fixture", "1") })));
+    const [ct, st] = InMemoryTransport.createLinkedPair();
+    const client = new Client({ name: "test", version: "1" });
+    await Promise.all([client.connect(ct), server.connect(st)]);
+    try {
+      const tool = (await client.listTools()).tools.find(t => t.name === "get_publication")!;
+      expect(tool.inputSchema.required).toContain("publication");
+      expect(tool.outputSchema?.required).toContain("data");
+      expect(tool.annotations?.readOnlyHint).toBe(true);
+      for (const args of [{}, { publication: "unknown" }]) {
+        expect((await client.callTool({ name: "get_publication", arguments: args })).isError).toBe(true);
+      }
+      expect(fetchMock).not.toHaveBeenCalled();
+      const result = await client.callTool({ name: "get_publication", arguments: { publication: "b" } });
+      expect(result.isError).toBeFalsy();
+      expect(result.structuredContent).toMatchObject({ publication: "b", data: { id: 42, subdomain: "b" } });
+      expect(JSON.parse((result.content as { text: string }[])[0].text)).toEqual(result.structuredContent);
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+      expect(fetchMock.mock.calls[0][0]).toBe("https://b.substack.com/api/v1/publication");
+      expect(fetchMock.mock.calls[0][1]?.method ?? "GET").toBe("GET");
+      expect(fetchMock.mock.calls[0][1]?.headers).toMatchObject({ Referer: "https://b.substack.com/publish/settings" });
+    } finally { await client.close(); await server.close(); }
+  });
+});

--- a/src/__tests__/publication.test.ts
+++ b/src/__tests__/publication.test.ts
@@ -23,12 +23,20 @@ describe("publication context", () => {
   it("accepts an exact custom domain", async () => {
     expect((await getPublication("https://news.example.com", async () => ({ ...publication, custom_domain: "news.example.com" }))).data.id).toBe(42);
   });
+  it.each([
+    ["https://sample.substack.com.", null],
+    ["https://news.example.com", "NEWS.EXAMPLE.COM."],
+    ["https://bücher.example", "bücher.example"],
+  ])("normalizes equivalent hostname representations for %s", async (url, custom_domain) => {
+    expect((await getPublication(url, async () => ({ ...publication, custom_domain }))).data.id).toBe(42);
+  });
   it.each(["https://ample.substack.com", "https://sample.substack.com.attacker.example", "https://unrelated.example"])("rejects wrong publication %s", async url => {
     await expect(getPublication(url, async () => publication)).rejects.toThrow(/does not match/);
   });
   it.each([{}, null, { ...publication, id: -1 }, { ...publication, id: Number.MAX_SAFE_INTEGER + 1 },
     { ...publication, name: "x".repeat(1001) }, { ...publication, paused: "false" },
-    { ...publication, custom_domain: "https://example.com" }])("fails closed on malformed context", async response => {
+    { ...publication, custom_domain: "https://example.com" }, { ...publication, custom_domain: "news..example.com" },
+    { ...publication, custom_domain: "news.example.com/path" }])("fails closed on malformed context", async response => {
     await expect(getPublication("https://sample.substack.com", async () => response)).rejects.toThrow(/cannot be verified/);
   });
   it("propagates read failures without inventing context", async () => {

--- a/src/annotations.ts
+++ b/src/annotations.ts
@@ -58,6 +58,7 @@ export type ToolKind =
  */
 export const TOOL_KINDS = {
   // Reads
+  get_publication: "read",
   search_posts: "read",
   preflight_draft: "read",
   get_subscriber_count: "read",

--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -15,6 +15,7 @@ import {
 import { mapHttpStatusToError, extractErrorDetail, TimeoutError, isAbortError } from "../utils/errors.js";
 import { SubscriberService } from "./subscribers.js";
 import { searchPosts } from "./search.js";
+import { getPublication } from "./publication.js";
 
 /**
  * Per-request deadline applied to every outbound fetch.
@@ -167,6 +168,12 @@ export class SubstackClient {
 
   searchPosts(input: Parameters<typeof searchPosts>[0]) {
     return searchPosts(input, path => this.request(`${this.publicationUrl}${path}`));
+  }
+
+  getPublication() {
+    return getPublication(this.publicationUrl, path => this.request(`${this.publicationUrl}${path}`, {
+      headers: { Referer: `${this.publicationUrl}/publish/settings` },
+    }));
   }
 
   /**

--- a/src/api/publication.ts
+++ b/src/api/publication.ts
@@ -1,6 +1,15 @@
 import { z } from "zod";
+import { domainToASCII } from "node:url";
 
-const host = z.string().max(253).regex(/^[a-z0-9](?:[a-z0-9.-]*[a-z0-9])?$/i);
+function normalizedHost(value: string): string {
+  return domainToASCII(value.replace(/\.$/, "")).toLowerCase();
+}
+const host = z.string().max(253).refine(value => {
+  if (/[\s/:?#@%\\]/.test(value)) return false;
+  const ascii = normalizedHost(value);
+  return ascii.length > 0 && ascii.length <= 253 && ascii.split(".").every(label =>
+    label.length <= 63 && /^[a-z0-9](?:[a-z0-9-]*[a-z0-9])?$/.test(label));
+});
 export const publicationSummary = z.object({
   id: z.number().int().positive().max(Number.MAX_SAFE_INTEGER),
   name: z.string().min(1).max(1000),
@@ -33,7 +42,7 @@ export async function getPublication(
   if (!parsed.success) throw new Error("Unexpected publication response; publication context cannot be verified.");
   const data = parsed.data;
   const hosts = [`${data.subdomain}.substack.com`, data.custom_domain].filter(Boolean);
-  if (!hosts.some(value => value!.toLowerCase() === origin.hostname.toLowerCase())) {
+  if (!hosts.some(value => normalizedHost(value!) === normalizedHost(origin.hostname))) {
     throw new Error("Publication response does not match the configured publication host.");
   }
   return {

--- a/src/api/publication.ts
+++ b/src/api/publication.ts
@@ -1,0 +1,45 @@
+import { z } from "zod";
+
+const host = z.string().max(253).regex(/^[a-z0-9](?:[a-z0-9.-]*[a-z0-9])?$/i);
+export const publicationSummary = z.object({
+  id: z.number().int().positive().max(Number.MAX_SAFE_INTEGER),
+  name: z.string().min(1).max(1000),
+  subdomain: z.string().min(1).max(63).regex(/^[a-z0-9](?:[a-z0-9-]*[a-z0-9])?$/i),
+  custom_domain: host.nullish(),
+  hero_text: z.string().max(5000).nullish(),
+  language: z.string().max(100).nullish(),
+  payments_state: z.string().max(100).nullish(),
+  community_enabled: z.boolean().nullish(),
+  podcast_enabled: z.boolean().nullish(),
+  invite_only: z.boolean().nullish(),
+  paused: z.boolean().nullish(),
+});
+
+export const publicationOutput = z.object({
+  publication: z.string(),
+  publication_url: z.string().url(),
+  data: publicationSummary,
+  fields_not_returned_by_api: z.array(z.string()),
+  identity_scope: z.literal("Publication host matched; account identity and role are not verified."),
+});
+
+/** Project metadata only. Never return arbitrary account payloads or infer roles. */
+export async function getPublication(
+  publicationUrl: string,
+  read: (path: string) => Promise<unknown>,
+) {
+  const origin = new URL(publicationUrl);
+  const parsed = publicationSummary.safeParse(await read("/api/v1/publication"));
+  if (!parsed.success) throw new Error("Unexpected publication response; publication context cannot be verified.");
+  const data = parsed.data;
+  const hosts = [`${data.subdomain}.substack.com`, data.custom_domain].filter(Boolean);
+  if (!hosts.some(value => value!.toLowerCase() === origin.hostname.toLowerCase())) {
+    throw new Error("Publication response does not match the configured publication host.");
+  }
+  return {
+    publication_url: origin.origin,
+    data,
+    fields_not_returned_by_api: Object.keys(publicationSummary.shape).filter(key => !(key in data)),
+    identity_scope: "Publication host matched; account identity and role are not verified." as const,
+  };
+}

--- a/src/server.ts
+++ b/src/server.ts
@@ -12,6 +12,7 @@ import { markdownToProseMirror, markdownToProseMirrorContent } from "./utils/mar
 import { fileToDataUri } from "./utils/image.js";
 import { searchInput } from "./api/search.js";
 import { preflightDraft } from "./utils/draft-preflight.js";
+import { publicationOutput } from "./api/publication.js";
 
 export interface PublicationConfig {
   /** Tool-facing `publication` enum value, e.g. "kevin-muldoon". */
@@ -65,6 +66,16 @@ export function createServer(publications: PublicationConfig[]): McpServer {
   // additive; the Note tools publish public content immediately.
 
   // --- Read tools ---
+
+  server.registerTool("get_publication", {
+    description: "Read projected identity and selected settings for this publication. Verifies the returned publication host; does not verify your account identity or admin role. Missing API fields are named explicitly. No changes are made.",
+    inputSchema: { ...publicationField() },
+    outputSchema: publicationOutput.shape,
+    annotations: buildAnnotations("get_publication"),
+  }, async ({ publication }: { publication?: string }) => {
+    const result = publicationOutput.parse({ ...await clientFor(publication).getPublication(), publication: publication ?? pubKeys[0] });
+    return { structuredContent: result, content: [{ type: "text", text: JSON.stringify(result) }] };
+  });
 
   server.registerTool("search_posts", {
     description: "Search this publication's published, draft, or scheduled archive using Substack's server-side query. One page per call, at most 50 results; use next_offset to continue. Matching/indexing is controlled by Substack, not a guaranteed full-text scan. Returns metadata only; get_post/get_draft fetch full content.",


### PR DESCRIPTION
Adds `get_publication` to return selected identity/settings fields and reject responses whose Substack or custom domain does not match the configured publication. Missing fields are explicit; the result does not claim to identify the account or its role. Includes structured MCP output and a text fallback.

Part of #50 and #61; establishes the new-tool output convention in #64. Tag reads remain separate. Endpoint mapping is referenced from an existing implementation; live validation remains a 0.9 release requirement.

Validation: lint, 348 core tests, clean package installation with all 20 tools; removing the host check makes all three wrong-publication tests fail. Independent reviews and CI will be recorded against the final commit.
