### PR TITLE
docs: keep subscriber guide focused on its API contract

### DIFF
--- a/docs/subscribers.md
+++ b/docs/subscribers.md
@@ -36,8 +36,6 @@ request an email. Membership verification does not establish email delivery; an
 uncertain request must not be repeated merely to resend the welcome email.
 
 The field names are shown in the publisher's [working request screenshots](https://substack.com/@huryn/note/c-181571328).
-The [subscriber-query implementation](https://github.com/marcomoauro/substack-mcp/blob/main/src/api/substack/SubscriberQuery.js)
-documents the exact filter encoding and paid-access field semantics.
 
 A real opted-in address absent from the membership query received HTTP 400:
 `No valid emails found. This could be because an email previously unsubscribed.`


### PR DESCRIPTION
Keep the subscriber guide focused on the documented request fields and observed behavior. Removes an unnecessary external implementation link; endpoint descriptions, live evidence, and consent requirements are unchanged.

Documentation-only change. No runtime behavior changes. Required independent reviews and CI are recorded on this PR.
