### PR TITLE
feat: read publication and post tags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and the git tag history (`v0.1.0`–`v0.5.0`).
 ## [Unreleased]
 
 ### Added
+- `list_publication_tags` and `get_post_tags`: publication-bound tag reads, hidden-tag handling, unresolved IDs and bounded local snapshot pagination. These tools never assign or remove tags.
 - `get_publication`: projected publication metadata with normalized host matching, explicit absent fields, structured MCP output and a text fallback. Does not infer account identity or permissions. A read-only live check passed on one custom-domain publication; broader 0.9 contract validation remains pending.
 
 ## [0.8.0] - 2026-09-07

--- a/README.md
+++ b/README.md
@@ -38,6 +38,8 @@ Every tool declares MCP [tool annotations](https://modelcontextprotocol.io/docs/
 | `get_subscriber` | Look up membership by exact email; reconcile pending additions |
 | `list_published_posts` | List published posts with pagination |
 | `get_publication` | Read projected publication identity/settings, verify the configured host, and report missing fields; does not verify account identity or role |
+| `list_publication_tags` | Read tag definitions, including hidden tags by default, with bounded local pagination |
+| `get_post_tags` | Resolve post/draft tag associations; preserves unresolved IDs and reports empty-result identity uncertainty |
 | `search_posts` | Search a publication archive by query and status; bounded pages with continuation metadata |
 | `preflight_draft` | Read-only checks for title, audience, body structure, images, and paywalls |
 | `list_drafts` | List draft posts |

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Every tool declares MCP [tool annotations](https://modelcontextprotocol.io/docs/
 | `list_published_posts` | List published posts with pagination |
 | `get_publication` | Read projected publication identity/settings, verify the configured host, and report missing fields; does not verify account identity or role |
 | `list_publication_tags` | Read tag definitions, including hidden tags by default, with bounded local pagination |
-| `get_post_tags` | Resolve post/draft tag associations; preserves unresolved IDs and reports empty-result identity uncertainty |
+| `get_post_tags` | Resolve post tag associations; preserves unresolved IDs and reports empty-result identity uncertainty. Draft coverage is currently live-verified only for empty responses |
 | `search_posts` | Search a publication archive by query and status; bounded pages with continuation metadata |
 | `preflight_draft` | Read-only checks for title, audience, body structure, images, and paywalls |
 | `list_drafts` | List draft posts |

--- a/scripts/test-package.mjs
+++ b/scripts/test-package.mjs
@@ -24,6 +24,7 @@ const expectedTools = [
   'list_scheduled_posts', 'list_subscribers', 'update_draft', 'upload_image',
   'search_posts', 'preflight_draft',
   'get_publication',
+  'list_publication_tags', 'get_post_tags',
 ].sort();
 
 const requiredFiles = ['package.json', 'server.json', 'README.md', 'LICENSE', 'CHANGELOG.md',

--- a/src/__tests__/annotations.test.ts
+++ b/src/__tests__/annotations.test.ts
@@ -20,6 +20,8 @@ const registered = (
 )._registeredTools;
 
 const READ_TOOLS: ToolName[] = [
+  "list_publication_tags",
+  "get_post_tags",
   "get_publication",
   "search_posts",
   "preflight_draft",

--- a/src/__tests__/tags.test.ts
+++ b/src/__tests__/tags.test.ts
@@ -1,0 +1,122 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+import { listPublicationTags, getPostTags } from "../api/tags.js";
+import { SubstackClient } from "../api/client.js";
+import { createServer } from "../server.js";
+
+const context = async () => ({ data: { id: 7 } });
+const tag = (id: string, hidden = false) => ({ id, publication_id: 7, name: `Name ${id}`, slug: id, hidden });
+const link = (id: string) => ({ id: `link-${id}`, publication_id: 7, post_id: 42, post_tag_id: id });
+afterEach(() => vi.unstubAllGlobals());
+
+describe("publication tags", () => {
+  it("filters hidden rows before pagination and projects only supported fields", async () => {
+    const read = vi.fn(async () => [tag("a", true), { ...tag("b"), private_field: "excluded" }, tag("c")]);
+    const result = await listPublicationTags({ include_hidden: false, limit: 1 }, context, read);
+    expect(read).toHaveBeenCalledExactlyOnceWith("/api/v1/publication/post-tag");
+    expect(result).toMatchObject({ publication_id: 7, total: 2, returned: 1, has_more: true, next_offset: 1, tags: [tag("b")] });
+    expect(JSON.stringify(result)).not.toContain("excluded");
+    expect(await listPublicationTags({ include_hidden: false, offset: 1, limit: 1 }, context, read)).toMatchObject({ tags: [tag("c")], has_more: false, next_offset: null });
+  });
+  it("includes hidden tags by default and reports out-of-range/empty pages honestly", async () => {
+    expect(await listPublicationTags({}, context, async () => [tag("a", true)])).toMatchObject({ include_hidden: true, tags: [tag("a", true)], total: 1 });
+    expect(await listPublicationTags({ offset: 9 }, context, async () => [tag("a")])).toMatchObject({ total: 1, returned: 0, has_more: false, next_offset: null });
+    expect(await listPublicationTags({}, context, async () => [])).toMatchObject({ total: 0, tags: [], has_more: false });
+  });
+  it.each([{ limit: 101 }, { offset: -1 }, { offset: Number.MAX_SAFE_INTEGER }, { limit: 1.1 }])("rejects invalid input before any request", async input => {
+    const ctx = vi.fn(context), read = vi.fn();
+    await expect(listPublicationTags(input, ctx, read)).rejects.toThrow();
+    expect(ctx).not.toHaveBeenCalled(); expect(read).not.toHaveBeenCalled();
+  });
+  it.each([null, {}, [null], [{ ...tag("a"), hidden: "false" }], [{ ...tag("a"), id: 5 }],
+    [{ ...tag("a"), publication_id: 8 }], [tag("a"), tag("a")], Array.from({ length: 10001 }, (_, i) => tag(String(i)))].map(response => ({ response })))("rejects malformed, duplicate, oversized and wrong-publication arrays", async ({ response }) => {
+    await expect(listPublicationTags({}, context, async () => response)).rejects.toThrow(/tag|publication/i);
+  });
+  it("does not fetch tags after failed publication verification", async () => {
+    const read = vi.fn();
+    await expect(listPublicationTags({}, async () => { throw new Error("host mismatch"); }, read)).rejects.toThrow("host mismatch");
+    expect(read).not.toHaveBeenCalled();
+  });
+});
+
+describe("post tags", () => {
+  it("resolves hidden definitions and retains unresolved IDs without inventing names", async () => {
+    const read = vi.fn(async (path: string) => path.includes("/post/42/") ? [link("a"), link("missing")] : [tag("a", true)]);
+    expect(await getPostTags({ post_id: 42 }, context, read)).toMatchObject({
+      post_id: 42, publication_id: 7, total: 2, returned: 2,
+      post_identity: "association_rows_match_requested_id",
+      tags: [{ tag_id: "a", resolved: true, tag: tag("a", true) }, { tag_id: "missing", resolved: false, tag: null }],
+    });
+    expect(read.mock.calls.map(([path]) => path)).toEqual(["/api/v1/post/42/tag", "/api/v1/publication/post-tag"]);
+  });
+  it("paginates associations while retaining unresolved rows in totals", async () => {
+    const result = await getPostTags({ post_id: 42, offset: 1, limit: 1 }, context,
+      async path => path.includes("/post/42/") ? [link("a"), link("b"), link("c")] : [tag("a")]);
+    expect(result).toMatchObject({ total: 3, returned: 1, next_offset: 2, has_more: true, tags: [{ tag_id: "b", resolved: false, tag: null }] });
+  });
+  it("does not claim an empty association response verifies post identity", async () => {
+    const read = vi.fn(async () => []);
+    expect(await getPostTags({ post_id: 42 }, context, read)).toMatchObject({ tags: [], total: 0, post_identity: "not_verified_empty_associations" });
+    expect(read).toHaveBeenCalledTimes(1);
+  });
+  it.each([-1, 0, 1.5, Number.MAX_SAFE_INTEGER + 1])("rejects unsafe post IDs before reads: %s", async post_id => {
+    const ctx = vi.fn(context), read = vi.fn();
+    await expect(getPostTags({ post_id }, ctx, read)).rejects.toThrow();
+    expect(ctx).not.toHaveBeenCalled(); expect(read).not.toHaveBeenCalled();
+  });
+  it.each([
+    [{ ...link("a"), post_id: 43 }], [{ ...link("a"), publication_id: 8 }],
+    [link("a"), link("a")], [link("a"), { ...link("a"), id: "different-link" }], [{}],
+  ].map(associations => ({ associations })))("rejects wrong identity or duplicate associations before resolving definitions", async ({ associations }) => {
+    const read = vi.fn(async () => associations);
+    await expect(getPostTags({ post_id: 42 }, context, read)).rejects.toThrow(/tag|publication/i);
+    expect(read).toHaveBeenCalledTimes(1);
+  });
+  it("validates definition publication even when association IDs were valid", async () => {
+    await expect(getPostTags({ post_id: 42 }, context, async path => path.includes("/post/42/") ? [link("a")] : [{ ...tag("a"), publication_id: 8 }])).rejects.toThrow(/different publication/);
+  });
+  it("propagates definition read failure instead of converting failure into unresolved IDs", async () => {
+    await expect(getPostTags({ post_id: 42 }, context, async path => {
+      if (path.includes("/post/42/")) return [link("a")];
+      throw new Error("upstream unavailable");
+    })).rejects.toThrow("upstream unavailable");
+  });
+});
+
+describe("tag MCP routing", () => {
+  it.each([1, 2])("publishes output contracts and routes reads with %s configured publications", async count => {
+    const fetchMock = vi.fn(async (url: string, _options?: RequestInit) => new Response(JSON.stringify(
+      url.endsWith("/api/v1/publication") ? { id: 7, name: "Sample", subdomain: "b" } :
+        url.includes("/post/42/") ? [link("a")] : [tag("a")])));
+    vi.stubGlobal("fetch", fetchMock);
+    const server = createServer((count === 1 ? ["b"] : ["a", "b"]).map(key => ({ key, label: key, client: new SubstackClient(`https://${key}.substack.com`, "fixture", "1") })));
+    const [ct, st] = InMemoryTransport.createLinkedPair();
+    const client = new Client({ name: "test", version: "1" });
+    await Promise.all([client.connect(ct), server.connect(st)]);
+    try {
+      for (const name of ["list_publication_tags", "get_post_tags"]) {
+        const tool = (await client.listTools()).tools.find(t => t.name === name)!;
+        expect(tool.annotations?.readOnlyHint).toBe(true);
+        expect(tool.outputSchema?.required).toContain("tags");
+        const args = name === "get_post_tags" ? { post_id: 42 } : {};
+        if (count === 2) {
+          expect(tool.inputSchema.required).toContain("publication");
+          expect((await client.callTool({ name, arguments: args })).isError).toBe(true);
+          expect((await client.callTool({ name, arguments: { ...args, publication: "unknown" } })).isError).toBe(true);
+        } else expect(tool.inputSchema.properties).not.toHaveProperty("publication");
+        const before = fetchMock.mock.calls.length;
+        const result = await client.callTool({ name, arguments: { ...args, ...(count === 2 ? { publication: "b" } : {}) } });
+        expect(result.isError).toBeFalsy();
+        expect(result.structuredContent).toMatchObject({ publication: "b", total: 1, returned: 1 });
+        expect(JSON.parse((result.content as { text: string }[])[0].text)).toEqual(result.structuredContent);
+        expect(fetchMock.mock.calls.length - before).toBe(name === "get_post_tags" ? 3 : 2);
+      }
+      for (const [url, options] of fetchMock.mock.calls) {
+        expect(url).toMatch(/^https:\/\/b\.substack\.com\//);
+        expect(options?.method ?? "GET").toBe("GET");
+      }
+      expect(fetchMock).toHaveBeenCalledTimes(5);
+    } finally { await client.close(); await server.close(); }
+  });
+});

--- a/src/annotations.ts
+++ b/src/annotations.ts
@@ -58,6 +58,8 @@ export type ToolKind =
  */
 export const TOOL_KINDS = {
   // Reads
+  list_publication_tags: "read",
+  get_post_tags: "read",
   get_publication: "read",
   search_posts: "read",
   preflight_draft: "read",

--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -16,6 +16,7 @@ import { mapHttpStatusToError, extractErrorDetail, TimeoutError, isAbortError } 
 import { SubscriberService } from "./subscribers.js";
 import { searchPosts } from "./search.js";
 import { getPublication } from "./publication.js";
+import { listPublicationTags, getPostTags } from "./tags.js";
 
 /**
  * Per-request deadline applied to every outbound fetch.
@@ -174,6 +175,14 @@ export class SubstackClient {
     return getPublication(this.publicationUrl, path => this.request(`${this.publicationUrl}${path}`, {
       headers: { Referer: `${this.publicationUrl}/publish/settings` },
     }));
+  }
+
+  listPublicationTags(input: Parameters<typeof listPublicationTags>[0]) {
+    return listPublicationTags(input, () => this.getPublication(), path => this.request(`${this.publicationUrl}${path}`));
+  }
+
+  getPostTags(input: Parameters<typeof getPostTags>[0]) {
+    return getPostTags(input, () => this.getPublication(), path => this.request(`${this.publicationUrl}${path}`));
   }
 
   /**

--- a/src/api/tags.ts
+++ b/src/api/tags.ts
@@ -1,0 +1,88 @@
+import { z } from "zod";
+
+const positiveId = z.number().int().positive().max(Number.MAX_SAFE_INTEGER);
+const tagId = z.string().min(1).max(128);
+export const tagPageInput = z.object({
+  offset: z.number().int().min(0).max(Number.MAX_SAFE_INTEGER - 100).default(0),
+  limit: z.number().int().min(1).max(100).default(25),
+});
+export const listTagsInput = tagPageInput.extend({ include_hidden: z.boolean().default(true) });
+export const postTagsInput = tagPageInput.extend({ post_id: positiveId });
+const tag = z.object({
+  id: tagId, publication_id: positiveId,
+  name: z.string().max(1000), slug: z.string().max(1000), hidden: z.boolean(),
+});
+const association = z.object({ id: tagId, publication_id: positiveId, post_id: positiveId, post_tag_id: tagId });
+const pageFields = {
+  publication: z.string(), publication_id: positiveId,
+  offset: z.number().int().nonnegative(), limit: z.number().int().min(1).max(100),
+  total: z.number().int().nonnegative(), returned: z.number().int().nonnegative(),
+  has_more: z.boolean(), next_offset: z.number().int().nonnegative().nullable(),
+  pagination: z.literal("Local pagination of a fresh upstream array; results may change between calls."),
+};
+export const listTagsOutput = z.object({ ...pageFields, include_hidden: z.boolean(), tags: z.array(tag).max(100) });
+export const postTagsOutput = z.object({
+  ...pageFields, post_id: positiveId,
+  post_identity: z.enum(["association_rows_match_requested_id", "not_verified_empty_associations"]),
+  tags: z.array(z.object({ tag_id: tagId, resolved: z.boolean(), tag: tag.nullable() })).max(100),
+  resolution_scope: z.literal("Association and publication-tag reads are separate snapshots; unresolved IDs are retained."),
+});
+
+type Read = (path: string) => Promise<unknown>;
+type Context = () => Promise<{ data: { id: number } }>;
+const MAX_ROWS = 10_000;
+
+function parseRows<T extends z.ZodTypeAny>(raw: unknown, schema: T): z.output<T>[] {
+  // Check length before parsing rows. This is a processing bound, not an upstream API limit.
+  if (!Array.isArray(raw) || raw.length > MAX_ROWS) throw new Error("Unexpected or oversized tag response; no tag results can be verified.");
+  const parsed = z.array(schema).safeParse(raw);
+  if (!parsed.success) throw new Error("Unexpected tag response; no tag results can be verified.");
+  return parsed.data;
+}
+
+function verifyRows(rows: { id: string; publication_id: number }[], publicationId: number) {
+  const seen = new Set<string>();
+  for (const row of rows) {
+    if (row.publication_id !== publicationId) throw new Error("Tag response belongs to a different publication.");
+    if (seen.has(row.id)) throw new Error("Duplicate tag response identifiers; retry the read.");
+    seen.add(row.id);
+  }
+}
+
+function page<T>(rows: T[], offset: number, limit: number) {
+  const tags = rows.slice(offset, offset + limit);
+  const has_more = offset + tags.length < rows.length;
+  return { offset, limit, total: rows.length, returned: tags.length, has_more,
+    next_offset: has_more ? offset + tags.length : null,
+    pagination: "Local pagination of a fresh upstream array; results may change between calls." as const, tags };
+}
+
+export async function listPublicationTags(input: z.input<typeof listTagsInput>, context: Context, read: Read) {
+  const { offset, limit, include_hidden } = listTagsInput.parse(input);
+  const publication_id = positiveId.parse((await context()).data.id);
+  const rows = parseRows(await read("/api/v1/publication/post-tag"), tag);
+  verifyRows(rows, publication_id);
+  return { publication_id, include_hidden, ...page(rows.filter(row => include_hidden || !row.hidden), offset, limit) };
+}
+
+export async function getPostTags(input: z.input<typeof postTagsInput>, context: Context, read: Read) {
+  const { post_id, offset, limit } = postTagsInput.parse(input);
+  const publication_id = positiveId.parse((await context()).data.id);
+  const associations = parseRows(await read(`/api/v1/post/${post_id}/tag`), association);
+  verifyRows(associations, publication_id);
+  const seenTags = new Set<string>();
+  for (const row of associations) {
+    if (row.post_id !== post_id) throw new Error("Tag associations do not match the requested post.");
+    if (seenTags.has(row.post_tag_id)) throw new Error("Duplicate post tag associations; retry the read.");
+    seenTags.add(row.post_tag_id);
+  }
+  // Empty association responses do not prove that the post exists or is accessible.
+  const definitions = associations.length ? parseRows(await read("/api/v1/publication/post-tag"), tag) : [];
+  verifyRows(definitions, publication_id);
+  const byId = new Map(definitions.map(row => [row.id, row]));
+  const rows = associations.map(row => ({ tag_id: row.post_tag_id, resolved: byId.has(row.post_tag_id), tag: byId.get(row.post_tag_id) ?? null }));
+  return { publication_id, post_id,
+    post_identity: associations.length ? "association_rows_match_requested_id" as const : "not_verified_empty_associations" as const,
+    resolution_scope: "Association and publication-tag reads are separate snapshots; unresolved IDs are retained." as const,
+    ...page(rows, offset, limit) };
+}

--- a/src/api/tags.ts
+++ b/src/api/tags.ts
@@ -18,14 +18,16 @@ const pageFields = {
   offset: z.number().int().nonnegative(), limit: z.number().int().min(1).max(100),
   total: z.number().int().nonnegative(), returned: z.number().int().nonnegative(),
   has_more: z.boolean(), next_offset: z.number().int().nonnegative().nullable(),
-  pagination: z.literal("Local pagination of a fresh upstream array; results may change between calls."),
+  pagination: z.literal("local_snapshot"),
+  pagination_note: z.string(),
 };
 export const listTagsOutput = z.object({ ...pageFields, include_hidden: z.boolean(), tags: z.array(tag).max(100) });
 export const postTagsOutput = z.object({
   ...pageFields, post_id: positiveId,
   post_identity: z.enum(["association_rows_match_requested_id", "not_verified_empty_associations"]),
   tags: z.array(z.object({ tag_id: tagId, resolved: z.boolean(), tag: tag.nullable() })).max(100),
-  resolution_scope: z.literal("Association and publication-tag reads are separate snapshots; unresolved IDs are retained."),
+  resolution_scope: z.literal("separate_snapshots"),
+  resolution_note: z.string(),
 });
 
 type Read = (path: string) => Promise<unknown>;
@@ -54,7 +56,8 @@ function page<T>(rows: T[], offset: number, limit: number) {
   const has_more = offset + tags.length < rows.length;
   return { offset, limit, total: rows.length, returned: tags.length, has_more,
     next_offset: has_more ? offset + tags.length : null,
-    pagination: "Local pagination of a fresh upstream array; results may change between calls." as const, tags };
+    pagination: "local_snapshot" as const,
+    pagination_note: "Local pagination of a fresh upstream array; results may change between calls.", tags };
 }
 
 export async function listPublicationTags(input: z.input<typeof listTagsInput>, context: Context, read: Read) {
@@ -83,6 +86,7 @@ export async function getPostTags(input: z.input<typeof postTagsInput>, context:
   const rows = associations.map(row => ({ tag_id: row.post_tag_id, resolved: byId.has(row.post_tag_id), tag: byId.get(row.post_tag_id) ?? null }));
   return { publication_id, post_id,
     post_identity: associations.length ? "association_rows_match_requested_id" as const : "not_verified_empty_associations" as const,
-    resolution_scope: "Association and publication-tag reads are separate snapshots; unresolved IDs are retained." as const,
+    resolution_scope: "separate_snapshots" as const,
+    resolution_note: "Association and publication-tag reads are separate snapshots; unresolved IDs are retained.",
     ...page(rows, offset, limit) };
 }

--- a/src/server.ts
+++ b/src/server.ts
@@ -69,7 +69,7 @@ export function createServer(publications: PublicationConfig[]): McpServer {
   // --- Read tools ---
 
   server.registerTool("list_publication_tags", {
-    description: "Read this publication's tag definitions. Includes hidden tags by default. Returns at most 100 rows; offset/limit paginate a fresh upstream array locally, so results can change between calls. Validates publication identity and rejects malformed or oversized responses. Never creates or assigns tags.",
+    description: "Read this publication's tag definitions. Includes hidden tags by default. Returns 25 rows by default, at most 100. Each call makes two reads (publication context and the full tag array), then paginates locally; results can change between calls. Validates publication identity and rejects malformed or oversized responses. Never creates or assigns tags.",
     inputSchema: { ...listTagsInput.shape, ...publicationField() },
     outputSchema: listTagsOutput.shape,
     annotations: buildAnnotations("list_publication_tags"),
@@ -79,7 +79,7 @@ export function createServer(publications: PublicationConfig[]): McpServer {
   });
 
   server.registerTool("get_post_tags", {
-    description: "Read tag associations for a post or draft, resolving names from this publication's tag definitions. Includes hidden tags and preserves unresolved IDs. At most 100 rows per call with local snapshot pagination. Empty associations do not verify post existence. Separate reads are not an atomic snapshot. Never assigns or removes tags.",
+    description: "Read tag associations by post ID, resolving names from this publication's tag definitions. Includes hidden tags and preserves unresolved IDs. Returns 25 rows by default, at most 100, with local snapshot pagination. Each call makes up to three reads, including the full association and definition arrays; they are not an atomic snapshot. Empty associations do not verify post existence. Nonempty draft associations are not yet live-verified. Never assigns or removes tags.",
     inputSchema: { ...postTagsInput.shape, ...publicationField() },
     outputSchema: postTagsOutput.shape,
     annotations: buildAnnotations("get_post_tags"),

--- a/src/server.ts
+++ b/src/server.ts
@@ -13,6 +13,7 @@ import { fileToDataUri } from "./utils/image.js";
 import { searchInput } from "./api/search.js";
 import { preflightDraft } from "./utils/draft-preflight.js";
 import { publicationOutput } from "./api/publication.js";
+import { listTagsInput, postTagsInput, listTagsOutput, postTagsOutput } from "./api/tags.js";
 
 export interface PublicationConfig {
   /** Tool-facing `publication` enum value, e.g. "kevin-muldoon". */
@@ -66,6 +67,26 @@ export function createServer(publications: PublicationConfig[]): McpServer {
   // additive; the Note tools publish public content immediately.
 
   // --- Read tools ---
+
+  server.registerTool("list_publication_tags", {
+    description: "Read this publication's tag definitions. Includes hidden tags by default. Returns at most 100 rows; offset/limit paginate a fresh upstream array locally, so results can change between calls. Validates publication identity and rejects malformed or oversized responses. Never creates or assigns tags.",
+    inputSchema: { ...listTagsInput.shape, ...publicationField() },
+    outputSchema: listTagsOutput.shape,
+    annotations: buildAnnotations("list_publication_tags"),
+  }, async ({ publication, ...input }: z.output<typeof listTagsInput> & { publication?: string }) => {
+    const result = listTagsOutput.parse({ ...await clientFor(publication).listPublicationTags(input), publication: publication ?? pubKeys[0] });
+    return { structuredContent: result, content: [{ type: "text", text: JSON.stringify(result) }] };
+  });
+
+  server.registerTool("get_post_tags", {
+    description: "Read tag associations for a post or draft, resolving names from this publication's tag definitions. Includes hidden tags and preserves unresolved IDs. At most 100 rows per call with local snapshot pagination. Empty associations do not verify post existence. Separate reads are not an atomic snapshot. Never assigns or removes tags.",
+    inputSchema: { ...postTagsInput.shape, ...publicationField() },
+    outputSchema: postTagsOutput.shape,
+    annotations: buildAnnotations("get_post_tags"),
+  }, async ({ publication, ...input }: z.output<typeof postTagsInput> & { publication?: string }) => {
+    const result = postTagsOutput.parse({ ...await clientFor(publication).getPostTags(input), publication: publication ?? pubKeys[0] });
+    return { structuredContent: result, content: [{ type: "text", text: JSON.stringify(result) }] };
+  });
 
   server.registerTool("get_publication", {
     description: "Read projected identity and selected settings for this publication. Verifies the returned publication host; does not verify your account identity or admin role. Missing API fields are named explicitly. No changes are made.",


### PR DESCRIPTION
Adds `list_publication_tags` and `get_post_tags` with publication/post identity checks, hidden-tag handling and explicit unresolved definitions. Results have bounded local pagination over fresh upstream arrays; empty associations do not claim to verify post existence. Both tools provide structured results and a text fallback, and never assign or remove tags.

Part of #50/#61; follows the output convention in #64. Shared request hardening remains #65.

Validation: lint, 384 core tests, clean package installation with 22 tools. Removing the publication check, post check or array processing cap makes the relevant assertions fail. Read-only live checks passed for tag definitions and nonempty resolved post tags on one publication; no private content is retained in review evidence. Required reviews and CI will be recorded against the final commit.
