### PR TITLE
fix: reject inconsistent archive search pages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and the git tag history (`v0.1.0`–`v0.5.0`).
 
 ## [Unreleased]
 
+### Fixed
+- Archive search rejects duplicate post IDs, unsafe numeric IDs/totals and nonempty pages that exceed the reported total, while preserving valid final and empty out-of-range pages.
+
 ### Added
 - `list_publication_tags` and `get_post_tags`: publication-bound tag reads, hidden-tag handling, unresolved IDs and bounded local snapshot pagination. These tools never assign or remove tags.
 - `get_publication`: projected publication metadata with normalized host matching, explicit absent fields, structured MCP output and a text fallback. Does not infer account identity or permissions. A read-only live check passed on one custom-domain publication; broader 0.9 contract validation remains pending.

--- a/src/__tests__/creator-workflows.test.ts
+++ b/src/__tests__/creator-workflows.test.ts
@@ -41,6 +41,19 @@ describe("archive search", () => {
   it("rejects an empty page before the reported total instead of returning a contradictory cursor", async () => {
     await expect(searchPosts({ query: "x", offset: 2 }, async () => ({ posts: [], total: 10 }))).rejects.toThrow(/Inconsistent/);
   });
+  it.each([
+    { offset: 0, posts: [{ id: 1 }], total: 0 },
+    { offset: 2, posts: [{ id: 1 }, { id: 2 }], total: 3 },
+    { offset: 0, posts: [{ id: 1 }, { id: 1 }], total: 2 },
+    { offset: 0, posts: [{ id: Number.MAX_SAFE_INTEGER + 1 }], total: 1 },
+    { offset: 0, posts: [], total: Number.MAX_SAFE_INTEGER + 1 },
+  ])("rejects inconsistent totals, duplicate rows and unsafe integers", async ({ offset, ...response }) => {
+    await expect(searchPosts({ query: "x", offset }, async () => response)).rejects.toThrow(/archive search/i);
+  });
+  it("accepts an exact final page and an empty page beyond a now-smaller archive", async () => {
+    expect(await searchPosts({ query: "x", offset: 2 }, async () => ({ posts: [{ id: 3 }], total: 3 }))).toMatchObject({ has_more: false, next_offset: null, returned: 1 });
+    expect(await searchPosts({ query: "x", offset: 5 }, async () => ({ posts: [], total: 3 }))).toMatchObject({ has_more: false, next_offset: null, returned: 0 });
+  });
 });
 
 describe("draft preflight", () => {

--- a/src/__tests__/creator-workflows.test.ts
+++ b/src/__tests__/creator-workflows.test.ts
@@ -42,17 +42,21 @@ describe("archive search", () => {
     await expect(searchPosts({ query: "x", offset: 2 }, async () => ({ posts: [], total: 10 }))).rejects.toThrow(/Inconsistent/);
   });
   it.each([
-    { offset: 0, posts: [{ id: 1 }], total: 0 },
-    { offset: 2, posts: [{ id: 1 }, { id: 2 }], total: 3 },
-    { offset: 0, posts: [{ id: 1 }, { id: 1 }], total: 2 },
-    { offset: 0, posts: [{ id: Number.MAX_SAFE_INTEGER + 1 }], total: 1 },
-    { offset: 0, posts: [], total: Number.MAX_SAFE_INTEGER + 1 },
-  ])("rejects inconsistent totals, duplicate rows and unsafe integers", async ({ offset, ...response }) => {
-    await expect(searchPosts({ query: "x", offset }, async () => response)).rejects.toThrow(/archive search/i);
+    { offset: 0, posts: [{ id: 1 }], total: 0, expected: "returned rows exceed the reported total" },
+    { offset: 2, posts: [{ id: 1 }, { id: 2 }], total: 3, expected: "returned rows exceed the reported total" },
+    { offset: 0, posts: [{ id: 1 }, { id: 1 }], total: 2, expected: "duplicate post IDs" },
+    { offset: 0, posts: [{ id: Number.MAX_SAFE_INTEGER + 1 }], total: 1, expected: "Unexpected archive search response" },
+    { offset: 0, posts: [], total: Number.MAX_SAFE_INTEGER + 1, expected: "Unexpected archive search response" },
+  ])("rejects inconsistent totals, duplicate rows and unsafe integers", async ({ offset, expected, ...response }) => {
+    await expect(searchPosts({ query: "x", offset }, async () => response)).rejects.toThrow(expected);
   });
   it("accepts an exact final page and an empty page beyond a now-smaller archive", async () => {
     expect(await searchPosts({ query: "x", offset: 2 }, async () => ({ posts: [{ id: 3 }], total: 3 }))).toMatchObject({ has_more: false, next_offset: null, returned: 1 });
     expect(await searchPosts({ query: "x", offset: 5 }, async () => ({ posts: [], total: 3 }))).toMatchObject({ has_more: false, next_offset: null, returned: 0 });
+  });
+  it("advances a short nonempty page and stops a full final page", async () => {
+    expect(await searchPosts({ query: "x", limit: 25 }, async () => ({ posts: [{ id: 1 }], total: 3 }))).toMatchObject({ has_more: true, next_offset: 1 });
+    expect(await searchPosts({ query: "x", offset: 2, limit: 1 }, async () => ({ posts: [{ id: 3 }], total: 3 }))).toMatchObject({ has_more: false, next_offset: null });
   });
 });
 

--- a/src/api/search.ts
+++ b/src/api/search.ts
@@ -36,12 +36,15 @@ export async function searchPosts(
   if (parsed.data.posts.length > limit) throw new Error("Archive search exceeded the requested page size.");
   const { posts } = parsed.data;
   const total = parsed.data.total ?? null;
+  // This call can detect duplicates within its page, not across changing snapshots.
   if (new Set(posts.map(post => post.id)).size !== posts.length) {
     throw new Error("Inconsistent archive search page: duplicate post IDs. Retry the query; the archive may have changed.");
   }
   if (posts.length > 0 && total !== null && offset + posts.length > total) {
     throw new Error("Inconsistent archive search page: returned rows exceed the reported total. Retry the query; the archive may have changed.");
   }
+  // A short nonempty page can still advance; an empty page before total cannot.
+  // `limit` is an upper bound, not a guarantee that upstream fills each page.
   if (posts.length === 0 && total !== null && offset < total) {
     throw new Error("Inconsistent archive search page: no rows before the reported total. Retry the query; the archive may have changed.");
   }

--- a/src/api/search.ts
+++ b/src/api/search.ts
@@ -8,7 +8,7 @@ export const searchInput = z.object({
 });
 
 const row = z.object({
-  id: z.number().int().positive(),
+  id: z.number().int().positive().max(Number.MAX_SAFE_INTEGER),
   title: z.string().nullable().optional(),
   draft_title: z.string().nullable().optional(),
   subtitle: z.string().nullable().optional(),
@@ -20,7 +20,7 @@ const row = z.object({
   draft_updated_at: z.string().nullable().optional(),
   canonical_url: z.string().nullable().optional(),
 });
-const page = z.object({ posts: z.array(row), total: z.number().int().nonnegative().nullish() });
+const page = z.object({ posts: z.array(row), total: z.number().int().nonnegative().max(Number.MAX_SAFE_INTEGER).nullish() });
 
 /** One upstream query, never an implicit full-archive crawl. */
 export async function searchPosts(
@@ -36,6 +36,12 @@ export async function searchPosts(
   if (parsed.data.posts.length > limit) throw new Error("Archive search exceeded the requested page size.");
   const { posts } = parsed.data;
   const total = parsed.data.total ?? null;
+  if (new Set(posts.map(post => post.id)).size !== posts.length) {
+    throw new Error("Inconsistent archive search page: duplicate post IDs. Retry the query; the archive may have changed.");
+  }
+  if (posts.length > 0 && total !== null && offset + posts.length > total) {
+    throw new Error("Inconsistent archive search page: returned rows exceed the reported total. Retry the query; the archive may have changed.");
+  }
   if (posts.length === 0 && total !== null && offset < total) {
     throw new Error("Inconsistent archive search page: no rows before the reported total. Retry the query; the archive may have changed.");
   }


### PR DESCRIPTION
Archive search now rejects nonempty pages whose end exceeds the reported total, duplicate post IDs, and unsafe integer IDs/totals. Valid final pages and empty pages beyond a reduced total retain their existing behavior.

Completes the remaining archive consistency work in #50/#61. Validation: lint and 390 core tests; removing either the inverse-total or duplicate-row check causes regression assertions to fail. Independent reviews and required CI are recorded on this PR.
