### PR TITLE
fix: share strict credential validation with doctor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and the git tag history (`v0.1.0`–`v0.5.0`).
 
 ## [Unreleased]
 
+### Changed
+- Missing or malformed credentials now stop server startup before transport connection. All configured publications must be valid; none are silently dropped. Use `doctor` for diagnostics and `substack-mcp-login` for first-time setup. This replaces the previous missing-credential warning followed by unusable tools.
+
 ### Fixed
 - The API client and doctor share strict origin, user-ID and cookie-value validation. Invalid configurations fail before requests, with credential-safe errors; valid custom domains and encoded cookie values remain supported.
 - Archive search rejects duplicate post IDs, unsafe numeric IDs/totals and nonempty pages that exceed the reported total, while preserving valid final and empty out-of-range pages.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and the git tag history (`v0.1.0`–`v0.5.0`).
 ## [Unreleased]
 
 ### Fixed
+- The API client and doctor share strict origin, user-ID and cookie-value validation. Invalid configurations fail before requests, with credential-safe errors; valid custom domains and encoded cookie values remain supported.
 - Archive search rejects duplicate post IDs, unsafe numeric IDs/totals and nonempty pages that exceed the reported total, while preserving valid final and empty out-of-range pages.
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -88,7 +88,13 @@ containing only digits, and an unquoted cookie value without whitespace or
 cookie separators. Invalid configuration stops server startup before requests.
 Percent-encoded cookie values are preserved exactly. Configuration checks do
 not prove that the supplied host belongs to Substack or that credentials work.
-By default it checks configuration without network requests. `--check-auth`
+
+Upgrading: missing or malformed credentials now stop startup instead of
+starting tools that fail later. Correct all configured publications; invalid
+entries are never silently dropped. `doctor` and `--help` still run without a
+working session. Use `substack-mcp-login` to set up a first session.
+
+By default, `doctor` checks configuration without network requests. `--check-auth`
 adds one draft-list GET per valid publication, with a five-second request
 deadline and redirects disabled. Use an HTTPS publication origin (no path,
 query, credentials, or custom port); a redirect or custom-domain block may

--- a/README.md
+++ b/README.md
@@ -83,6 +83,11 @@ substack-mcp doctor --json --check-auth
 ```
 
 `doctor` uses the same environment/stored-session resolution as the server.
+Both validate an HTTPS publication origin, a positive safe-integer user ID
+containing only digits, and an unquoted cookie value without whitespace or
+cookie separators. Invalid configuration stops server startup before requests.
+Percent-encoded cookie values are preserved exactly. Configuration checks do
+not prove that the supplied host belongs to Substack or that credentials work.
 By default it checks configuration without network requests. `--check-auth`
 adds one draft-list GET per valid publication, with a five-second request
 deadline and redirects disabled. Use an HTTPS publication origin (no path,

--- a/scripts/test-package.mjs
+++ b/scripts/test-package.mjs
@@ -62,7 +62,7 @@ try {
   });
   const cli = resolve(installed, installedPkg.bin['substack-mcp']);
   assert.match(execFileSync(process.execPath, [cli, '--help'], { env, encoding: 'utf8', timeout: 10_000 }), /Usage: substack-mcp/);
-  const doctorEnv = { ...env, SUBSTACK_PUBLICATION_URL: 'https://example.substack.com', SUBSTACK_USER_ID: '1' };
+  const doctorEnv = { ...env, SUBSTACK_PUBLICATION_URL: 'https://example.invalid', SUBSTACK_USER_ID: '1' };
   const diagnosis = JSON.parse(execFileSync(process.execPath, [cli, 'doctor', '--json'], { env: doctorEnv, encoding: 'utf8', timeout: 10_000 }));
   assert.equal(diagnosis.ok, true);
   assert.equal(diagnosis.mode, 'configuration_only');
@@ -75,8 +75,24 @@ try {
   ]) {
     assert.throws(() => execFileSync(process.execPath, [cli, ...args], { env: commandEnv, encoding: 'utf8', timeout: 10_000, stdio: 'pipe' }), error => error.status === status);
   }
-  // Startup now validates the same credentials as doctor. The handshake only
-  // lists tools: it makes no publication requests with this synthetic config.
+  for (const overrides of [
+    { SUBSTACK_PUBLICATION_URL: '', SUBSTACK_SESSION_TOKEN: '', SUBSTACK_USER_ID: '' },
+    { SUBSTACK_PUBLICATION_URL: 'https://example.invalid/path' },
+    { SUBSTACK_USER_ID: '1partial' },
+    { SUBSTACK_SESSION_TOKEN: `${testSessionToken}; other=value` },
+    { SUBSTACK_PUB_A_PUBLICATION_URL: 'https://example.invalid', SUBSTACK_PUB_A_SESSION_TOKEN: testSessionToken, SUBSTACK_PUB_A_USER_ID: '1',
+      SUBSTACK_PUB_B_PUBLICATION_URL: 'https://example.invalid', SUBSTACK_PUB_B_SESSION_TOKEN: testSessionToken, SUBSTACK_PUB_B_USER_ID: '0' },
+  ]) {
+    assert.throws(() => execFileSync(process.execPath, [cli, 'serve'], { env: { ...doctorEnv, ...overrides }, encoding: 'utf8', timeout: 10_000, stdio: 'pipe' }), error => {
+      assert.equal(error.status, 1);
+      assert.match(error.stderr, /Invalid (publication URL|SUBSTACK_USER_ID|session token)/);
+      assert.ok(!error.stderr.includes(testSessionToken), 'Startup must not print session tokens');
+      assert.ok(!error.stderr.includes('server running'), 'Invalid configuration must fail before connection');
+      return true;
+    });
+  }
+  // Startup validates the same config as doctor. Its background auth read may
+  // attempt the reserved .invalid host, bounded by the synthetic 100ms deadline.
   transport = new StdioClientTransport({ command: process.execPath, args: [resolve(installed, installedPkg.bin['substack-mcp'])], env: doctorEnv, stderr: 'pipe' });
   const client = new Client({ name: 'package-smoke', version: '1.0.0' });
   await client.connect(transport, { timeout: 10_000 });

--- a/scripts/test-package.mjs
+++ b/scripts/test-package.mjs
@@ -75,7 +75,9 @@ try {
   ]) {
     assert.throws(() => execFileSync(process.execPath, [cli, ...args], { env: commandEnv, encoding: 'utf8', timeout: 10_000, stdio: 'pipe' }), error => error.status === status);
   }
-  transport = new StdioClientTransport({ command: process.execPath, args: [resolve(installed, installedPkg.bin['substack-mcp'])], env, stderr: 'pipe' });
+  // Startup now validates the same credentials as doctor. The handshake only
+  // lists tools: it makes no publication requests with this synthetic config.
+  transport = new StdioClientTransport({ command: process.execPath, args: [resolve(installed, installedPkg.bin['substack-mcp'])], env: doctorEnv, stderr: 'pipe' });
   const client = new Client({ name: 'package-smoke', version: '1.0.0' });
   await client.connect(transport, { timeout: 10_000 });
   assert.equal(client.getServerVersion()?.version, pkg.version, 'MCP handshake version must match npm');

--- a/scripts/test-package.mjs
+++ b/scripts/test-package.mjs
@@ -88,6 +88,9 @@ try {
       assert.match(error.stderr, /Invalid (publication URL|SUBSTACK_USER_ID|session token)/);
       assert.ok(!error.stderr.includes(testSessionToken), 'Startup must not print session tokens');
       assert.ok(!error.stderr.includes('server running'), 'Invalid configuration must fail before connection');
+      assert.ok(error.stderr.includes('substack-mcp doctor --json'), 'Startup must explain the diagnostic command');
+      assert.ok(!/\n\s+at /.test(error.stderr), 'Configuration failures should not dump a stack');
+      if (overrides.SUBSTACK_PUB_B_USER_ID) assert.match(error.stderr, /publication "b"/);
       return true;
     });
   }

--- a/src/__tests__/client.test.ts
+++ b/src/__tests__/client.test.ts
@@ -27,7 +27,7 @@ describe("SubstackClient constructor", () => {
   it("throws with clear message for invalid userId", () => {
     expect(
       () => new SubstackClient("https://example.substack.com", "tok123", "abc")
-    ).toThrow('Invalid SUBSTACK_USER_ID: "abc" — must be a number');
+    ).toThrow('Invalid SUBSTACK_USER_ID: use a positive safe integer containing only digits.');
   });
 
   it("strips trailing slash from publication URL", () => {

--- a/src/__tests__/validate-credentials.test.ts
+++ b/src/__tests__/validate-credentials.test.ts
@@ -1,0 +1,56 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { SubstackClient } from "../api/client.js";
+import { doctor } from "../doctor.js";
+import { validateCredentials } from "../auth/validate-credentials.js";
+
+afterEach(() => vi.unstubAllGlobals());
+const base = { publicationUrl: "https://example.substack.com", sessionToken: "s%3Aexample.signature", userId: "123" };
+const resolve = (overrides: Partial<typeof base>) => () => [{ ...base, ...overrides, key: "test", label: "Test", source: "env" as const, missing: [] }];
+
+describe("shared configuration boundary", () => {
+  const invalid = [
+    ...["https://example.org/path/..", "https://example.org/?", "https://example.org/#", "https:example.org"].map(publicationUrl => ({ publicationUrl })),
+    ...["http://example.org", "https://name:password@example.org", "https://example.org/path", "https://example.org/?private", "https://example.org/#private", "https://example.org:8443", " https://example.org", "https://exam\nple.org", "https:\\example.org", "invalid"].map(publicationUrl => ({ publicationUrl })),
+    ...["0", "-1", "1oops", "1.5", "1e3", " 1", "1\n", "9007199254740992", ""].map(userId => ({ userId })),
+    ...["", "token; other=value", "token,other", "token\n", "token\r", "token with spaces", '"quoted"', "token\\value", "nonasciié"].map(sessionToken => ({ sessionToken })),
+  ];
+  it.each(invalid)("rejects invalid config in both paths before fetching: %j", async override => {
+    const fetchMock = vi.fn(); vi.stubGlobal("fetch", fetchMock);
+    const p = { ...base, ...override };
+    let error: unknown;
+    try { new SubstackClient(p.publicationUrl, p.sessionToken, p.userId); }
+    catch (caught) { error = caught; }
+    expect(error).toBeInstanceOf(Error);
+    expect((error as Error).message).not.toContain(base.sessionToken);
+    const report = await doctor(true, resolve(override));
+    expect(report.ok).toBe(false);
+    expect(report.publications[0].configuration).toBe("invalid");
+    expect(report.publications[0].authentication).toBe("not_checked");
+    expect(fetchMock).not.toHaveBeenCalled();
+    if ("publicationUrl" in override) expect(report.publications[0].origin).toBeNull();
+  });
+
+  it.each([
+    ["https://EXAMPLE.substack.com/", "https://example.substack.com"],
+    ["https://newsletter.example.org:443/", "https://newsletter.example.org"],
+    ["https://münchen.example/", "https://xn--mnchen-3ya.example"],
+  ])("normalizes %s and preserves cookies in both request paths", async (publicationUrl, origin) => {
+    const fetchMock = vi.fn(async (_url: string, _options: RequestInit) => new Response('{"posts":[]}'));
+    vi.stubGlobal("fetch", fetchMock);
+    const client = new SubstackClient(publicationUrl, base.sessionToken, "000123");
+    await client.getDrafts(0, 1);
+    const report = await doctor(true, resolve({ publicationUrl, userId: "000123" }));
+    expect(report.ok).toBe(true);
+    expect(report.publications[0].origin).toBe(origin);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    for (const [url, options] of fetchMock.mock.calls) {
+      expect(new URL(url).origin).toBe(origin);
+      expect(new Headers(options.headers).get("Cookie")).toBe(`connect.sid=${base.sessionToken}; substack.sid=${base.sessionToken};`);
+    }
+    expect(validateCredentials(publicationUrl, base.sessionToken, "000123").userId).toBe(123);
+    expect(JSON.stringify(report)).not.toContain(base.sessionToken);
+  });
+  it("retains the largest safe ID without rounding and accepts cookie-octet punctuation", () => {
+    expect(validateCredentials(base.publicationUrl, "!#$%&'()*+-./012:<=?>@[]^_`{|}~", String(Number.MAX_SAFE_INTEGER)).userId).toBe(Number.MAX_SAFE_INTEGER);
+  });
+});

--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -17,6 +17,7 @@ import { SubscriberService } from "./subscribers.js";
 import { searchPosts } from "./search.js";
 import { getPublication } from "./publication.js";
 import { listPublicationTags, getPostTags } from "./tags.js";
+import { validateCredentials } from "../auth/validate-credentials.js";
 
 /**
  * Per-request deadline applied to every outbound fetch.
@@ -87,10 +88,10 @@ export class SubstackClient {
     userAgent?: string,
     timeoutMs?: number,
   ) {
-    this.publicationUrl = publicationUrl.replace(/\/$/, "");
-    // Substack uses connect.sid on custom domains, substack.sid on substack.com
-    this.cookie = `connect.sid=${sessionToken}; substack.sid=${sessionToken};`;
-    this.userId = parseInt(userId, 10);
+    const validated = validateCredentials(publicationUrl, sessionToken, userId);
+    this.publicationUrl = validated.origin;
+    this.cookie = validated.cookie;
+    this.userId = validated.userId;
     // Substack sits behind Cloudflare, which rejects non-browser User-Agents
     // (the default Node/undici UA, "node", etc.) with HTTP 403 "error code:
     // 1010" on some publications — notably custom domains. Default to a browser
@@ -107,9 +108,6 @@ export class SubstackClient {
         ? timeoutMs
         : DEFAULT_REQUEST_TIMEOUT_MS;
 
-    if (isNaN(this.userId)) {
-      throw new Error(`Invalid SUBSTACK_USER_ID: "${userId}" — must be a number`);
-    }
   }
 
   private async request<T>(

--- a/src/auth/validate-credentials.ts
+++ b/src/auth/validate-credentials.ts
@@ -1,0 +1,26 @@
+/** Configuration checks only: these do not establish identity or permissions. */
+export function publicationOrigin(value: string): string | null {
+  // URL parsing removes some whitespace/control characters. Reject those before
+  // parsing so a pasted credential or header delimiter is never normalized away.
+  if (/[\s\u0000-\u001f\u007f\\]/u.test(value) || !/^https:\/\/[^/?#]+\/?$/i.test(value)) return null;
+  try {
+    const url = new URL(value);
+    if (url.protocol !== "https:" || url.username || url.password ||
+        url.pathname !== "/" || url.search || url.hash || url.port) return null;
+    return url.origin;
+  } catch { return null; }
+}
+
+export function validateCredentials(publicationUrl: string, sessionToken: string, userId: string) {
+  const origin = publicationOrigin(publicationUrl);
+  if (!origin) throw new Error("Invalid publication URL: use an HTTPS origin without a path, query, credentials or custom port.");
+  if (!/^\d+$/.test(userId) || !Number.isSafeInteger(Number(userId)) || Number(userId) <= 0) {
+    throw new Error("Invalid SUBSTACK_USER_ID: use a positive safe integer containing only digits.");
+  }
+  // RFC 6265 cookie-octet, unquoted. Preserve percent-encoded session values;
+  // never decode/re-encode them or accept an entire Cookie header.
+  if (!/^[\x21\x23-\x2b\x2d-\x3a\x3c-\x5b\x5d-\x7e]+$/.test(sessionToken)) {
+    throw new Error("Invalid session token: use the cookie value without quotes, whitespace or cookie separators.");
+  }
+  return { origin, userId: Number(userId), cookie: `connect.sid=${sessionToken}; substack.sid=${sessionToken};` };
+}

--- a/src/doctor.ts
+++ b/src/doctor.ts
@@ -1,5 +1,6 @@
 import { resolvePublications } from "./auth/resolve-publications.js";
 import { isAbortError } from "./utils/errors.js";
+import { publicationOrigin, validateCredentials } from "./auth/validate-credentials.js";
 
 export async function doctor(checkAuth = false, resolve = resolvePublications) {
   let publications: ReturnType<typeof resolvePublications>;
@@ -7,18 +8,18 @@ export async function doctor(checkAuth = false, resolve = resolvePublications) {
   catch { return { ok: false, code: "invalid_configuration", publications: [], guidance: "Check named publication triplets and duplicate publication keys. No credential values are printed." }; }
   const reports = [];
   for (const p of publications) {
-    let origin: string | null = null;
+    const origin = publicationOrigin(p.publicationUrl);
+    let validated: ReturnType<typeof validateCredentials> | null = null;
     try {
-      const url = new URL(p.publicationUrl);
-      if (url.protocol === "https:" && !url.username && !url.password && url.pathname === "/" && !url.search && !url.hash && !url.port) origin = url.origin;
-    } catch { /* Report a static code, never the supplied URL. */ }
-    const valid = !!origin && p.missing.length === 0 && /^\d+$/.test(p.userId) && Number.isSafeInteger(Number(p.userId)) && Number(p.userId) > 0 && /^[\x21\x23-\x2b\x2d-\x3a\x3c-\x5b\x5d-\x7e]+$/.test(p.sessionToken);
+      validated = validateCredentials(p.publicationUrl, p.sessionToken, p.userId);
+    } catch { /* Report static codes, never supplied credential values. */ }
+    const valid = validated !== null && p.missing.length === 0;
     let authentication = "not_checked";
-    if (checkAuth && valid) {
+    if (checkAuth && valid && validated) {
       try {
         // No redirects: never forward the session cookie to a redirected host.
         const response = await fetch(`${origin}/api/v1/post_management/drafts?offset=0&limit=1&order_by=draft_updated_at&order_direction=desc`, {
-          headers: { Cookie: `connect.sid=${p.sessionToken}; substack.sid=${p.sessionToken}`, Accept: "application/json",
+          headers: { Cookie: validated.cookie, Accept: "application/json",
             "User-Agent": "Mozilla/5.0", Referer: `${origin}/publish/home` },
           redirect: "error", signal: AbortSignal.timeout(5000),
         });

--- a/src/index.ts
+++ b/src/index.ts
@@ -127,8 +127,12 @@ async function main() {
 
     // Fail before connecting if any publication is invalid. Dropping one would
     // change the publication selector and could route a write to the wrong host.
-    const client = new SubstackClient(p.publicationUrl, p.sessionToken, p.userId, userAgent, timeoutMs);
-    return { key: p.key, label: p.label, client };
+    try {
+      const client = new SubstackClient(p.publicationUrl, p.sessionToken, p.userId, userAgent, timeoutMs);
+      return { key: p.key, label: p.label, client };
+    } catch (error) {
+      throw new Error(`Invalid configuration for publication "${p.key}": ${error instanceof Error ? error.message : "Credential validation failed."} Run substack-mcp doctor --json to inspect each publication; run substack-mcp-login to set up a session.`);
+    }
   });
 
   const transportMode = process.env.MCP_TRANSPORT ?? "stdio";
@@ -189,6 +193,6 @@ async function run() {
 }
 
 run().catch((err) => {
-  console.error("Fatal error:", err);
+  console.error("Fatal error:", err instanceof Error ? err.message : String(err));
   process.exit(1);
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -125,10 +125,9 @@ async function main() {
       console.error(`Using stored credentials${pubSuffix(p.label)} (source: ${p.source}).`);
     }
 
-    // The client constructor rejects a non-numeric user id; fall back to "0"
-    // so startup surfaces the friendly missing-credentials warning above
-    // instead of throwing when nothing is configured yet.
-    const client = new SubstackClient(p.publicationUrl, p.sessionToken, p.userId || "0", userAgent, timeoutMs);
+    // Fail before connecting if any publication is invalid. Dropping one would
+    // change the publication selector and could route a write to the wrong host.
+    const client = new SubstackClient(p.publicationUrl, p.sessionToken, p.userId, userAgent, timeoutMs);
     return { key: p.key, label: p.label, client };
   });
 


### PR DESCRIPTION
The API client previously accepted partial numeric user IDs and malformed cookie/origin values that `doctor` rejected. Both now share configuration validation and normalize valid HTTPS origins before constructing requests. Errors omit supplied credential values; custom domains and percent-encoded session cookies remain supported.

Validation: lint, 427 core tests, eight cloud tests, clean package installation with both binaries and all 22 tools. Mutation controls fail when each origin/ID/cookie guard is removed. Four session-store tests fail under the restricted Windows account on the unchanged base as well; the full suite passes with normal account access. Independent exact-SHA reviews and CI are required before merge.

Part of #65 and #61. This establishes configuration consistency only. Redirect policy, bounded response bodies/deadlines and release recovery remain required work in #65. No identity, permissions or host-ownership guarantee is inferred from valid syntax.
