### PR TITLE
fix: bound response streams and reject request redirects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and the git tag history (`v0.1.0`–`v0.5.0`).
 - Missing or malformed credentials now stop server startup before transport connection. All configured publications must be valid; none are silently dropped. Use `doctor` for diagnostics and `substack-mcp-login` for first-time setup. This replaces the previous missing-credential warning followed by unusable tools.
 
 ### Fixed
+- Shared API/doctor/public-count requests now bound streamed response bytes and deadlines through body consumption, reject redirects without replay, classify malformed JSON/HTML, preserve rate-limit guidance and cap/redact error details. Requests never retry automatically; failed write outcomes still require reconciliation.
 - The API client and doctor share strict origin, user-ID and cookie-value validation. Invalid configurations fail before requests, with credential-safe errors; valid custom domains and encoded cookie values remain supported.
 - Archive search rejects duplicate post IDs, unsafe numeric IDs/totals and nonempty pages that exceed the reported total, while preserving valid final and empty out-of-range pages.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and the git tag history (`v0.1.0`–`v0.5.0`).
 ## [Unreleased]
 
 ### Changed
+- Authenticated API requests no longer follow redirects. Configure a direct HTTPS API origin; public subscriber-count pages retain up to three cookie-free HTTPS redirect hops.
 - Missing or malformed credentials now stop server startup before transport connection. All configured publications must be valid; none are silently dropped. Use `doctor` for diagnostics and `substack-mcp-login` for first-time setup. This replaces the previous missing-credential warning followed by unusable tools.
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ and the git tag history (`v0.1.0`–`v0.5.0`).
 - Missing or malformed credentials now stop server startup before transport connection. All configured publications must be valid; none are silently dropped. Use `doctor` for diagnostics and `substack-mcp-login` for first-time setup. This replaces the previous missing-credential warning followed by unusable tools.
 
 ### Fixed
-- Shared API/doctor/public-count requests now bound streamed response bytes and deadlines through body consumption, reject redirects without replay, classify malformed JSON/HTML, preserve rate-limit guidance and cap/redact error details. Requests never retry automatically; failed write outcomes still require reconciliation.
+- Shared API/doctor/public-count requests now bound streamed response bytes and deadlines through body consumption, reject authenticated redirects, bound cookie-free public-page redirects, classify malformed JSON/HTML, preserve rate-limit guidance and cap/redact error details. Requests never retry automatically; failed write outcomes still require reconciliation.
 - The API client and doctor share strict origin, user-ID and cookie-value validation. Invalid configurations fail before requests, with credential-safe errors; valid custom domains and encoded cookie values remain supported.
 - Archive search rejects duplicate post IDs, unsafe numeric IDs/totals and nonempty pages that exceed the reported total, while preserving valid final and empty out-of-range pages.
 

--- a/README.md
+++ b/README.md
@@ -109,6 +109,9 @@ by default, five seconds for `doctor --check-auth`). Streamed response limits
 are 10 MiB for API JSON, 1 MiB for doctor, 2 MiB for the public-page count
 fallback, and 64 KiB for error bodies. Limits apply to bytes delivered by fetch,
 including decompressed bytes. Oversized responses fail without partial results.
+JSON parsing is synchronous and bounded by input bytes, so it cannot be
+interrupted mid-parse; a complete parsed result is retained if parsing finishes
+after the I/O deadline.
 The public count fallback permits at most three HTTPS redirects within the same
 deadline. It sends no cookies or authorization and rejects destinations with
 URL credentials or custom ports. It returns unavailable when its read fails.

--- a/README.md
+++ b/README.md
@@ -109,6 +109,8 @@ by default, five seconds for `doctor --check-auth`). Streamed response limits
 are 10 MiB for API JSON, 1 MiB for doctor, 2 MiB for the public-page count
 fallback, and 64 KiB for error bodies. Limits apply to bytes delivered by fetch,
 including decompressed bytes. Oversized responses fail without partial results.
+For an oversized HTTP error body, the HTTP error classification is preserved
+and diagnostic details are discarded.
 JSON parsing is synchronous and bounded by input bytes, so it cannot be
 interrupted mid-parse; a complete parsed result is retained if parsing finishes
 after the I/O deadline.

--- a/README.md
+++ b/README.md
@@ -99,6 +99,27 @@ adds one draft-list GET per valid publication, with a five-second request
 deadline and redirects disabled. Use an HTTPS publication origin (no path,
 query, credentials, or custom port); a redirect or custom-domain block may
 require switching to the publication's canonical `name.substack.com` origin.
+All API requests reject redirects, including same-origin redirects, without
+following the destination or replaying a write. The publish-page Referer is
+retained for direct custom-domain requests. Configure the origin that serves
+the API directly; a redirect response is reported as `redirect_rejected`.
+
+Each request has one deadline through headers and body consumption (30 seconds
+by default, five seconds for `doctor --check-auth`). Streamed response limits
+are 10 MiB for API JSON, 1 MiB for doctor, 2 MiB for the public-page count
+fallback, and 64 KiB for error bodies. Limits apply to bytes delivered by fetch,
+including decompressed bytes. Oversized responses fail without partial results.
+The public count fallback returns unavailable when its read fails.
+
+Doctor distinguishes `unexpected_html`, `malformed_json`, `response_too_large`,
+`redirect_rejected`, `timeout`, `rate_limited`, and `unauthorized_or_blocked`.
+HTTP 401/403/429 bodies are discarded without waiting; rate-limit errors retain
+valid delta-seconds or standard HTTP-date `Retry-After` guidance. Error details
+are capped at 500 characters (plus an ellipsis) and matching cookie values are
+redacted before truncation. Requests are never automatically retried. A failed
+or timed-out write may have succeeded upstream; reconcile its state before
+trying again.
+
 Output includes publication key, origin, credential source, configuration and
 authentication status. It omits session tokens, user IDs and upstream error
 bodies. A successful read does not establish user-ID binding or write access.

--- a/README.md
+++ b/README.md
@@ -109,7 +109,9 @@ by default, five seconds for `doctor --check-auth`). Streamed response limits
 are 10 MiB for API JSON, 1 MiB for doctor, 2 MiB for the public-page count
 fallback, and 64 KiB for error bodies. Limits apply to bytes delivered by fetch,
 including decompressed bytes. Oversized responses fail without partial results.
-The public count fallback returns unavailable when its read fails.
+The public count fallback permits at most three HTTPS redirects within the same
+deadline. It sends no cookies or authorization and rejects destinations with
+URL credentials or custom ports. It returns unavailable when its read fails.
 
 Doctor distinguishes `unexpected_html`, `malformed_json`, `response_too_large`,
 `redirect_rejected`, `timeout`, `rate_limited`, and `unauthorized_or_blocked`.

--- a/src/__tests__/client.test.ts
+++ b/src/__tests__/client.test.ts
@@ -55,12 +55,7 @@ describe("SubstackClient requests", () => {
   afterEach(() => vi.unstubAllGlobals());
 
   function stubFetch(jsonBody: unknown) {
-    const fetchMock = vi.fn(async (..._args: any[]) => ({
-      ok: true,
-      status: 200,
-      json: async () => jsonBody,
-      text: async () => JSON.stringify(jsonBody),
-    }));
+    const fetchMock = vi.fn(async (..._args: any[]) => new Response(JSON.stringify(jsonBody)));
     vi.stubGlobal("fetch", fetchMock);
     return fetchMock;
   }
@@ -254,12 +249,7 @@ describe("pagination limit cap (regression: #28)", () => {
         })),
         total: totalPosts,
       };
-      return {
-        ok: true,
-        status: 200,
-        json: async () => body,
-        text: async () => JSON.stringify(body),
-      };
+      return new Response(JSON.stringify(body));
     });
     vi.stubGlobal("fetch", fetchMock);
     return fetchMock;
@@ -324,12 +314,7 @@ describe("SubstackClient error mapping (end-to-end through request())", () => {
   afterEach(() => vi.unstubAllGlobals());
 
   function stubFetchError(status: number, body: string) {
-    const fetchMock = vi.fn(async (..._args: any[]) => ({
-      ok: false,
-      status,
-      json: async () => JSON.parse(body),
-      text: async () => body,
-    }));
+    const fetchMock = vi.fn(async (..._args: any[]) => new Response(body, { status }));
     vi.stubGlobal("fetch", fetchMock);
     return fetchMock;
   }
@@ -446,9 +431,9 @@ describe("SubstackClient.getSubscriberCount", () => {
   });
 
   const jsonResponse = (body: unknown) =>
-    ({ ok: true, status: 200, json: async () => body, text: async () => JSON.stringify(body) }) as Response;
+    new Response(JSON.stringify(body));
   const htmlResponse = (html: string) =>
-    ({ ok: true, status: 200, text: async () => html }) as Response;
+    new Response(html);
 
   it("reports exact when the API returns subscriber_count", async () => {
     vi.spyOn(globalThis, "fetch").mockResolvedValue(jsonResponse({ subscriber_count: 1073 }));
@@ -500,12 +485,7 @@ describe("SubstackClient request timeout", () => {
   });
 
   function stubOk() {
-    const fetchMock = vi.fn(async (..._args: any[]) => ({
-      ok: true,
-      status: 200,
-      json: async () => ({ posts: [] }),
-      text: async () => "{}",
-    }));
+    const fetchMock = vi.fn(async (..._args: any[]) => new Response('{"posts":[]}'));
     vi.stubGlobal("fetch", fetchMock);
     return fetchMock;
   }

--- a/src/__tests__/creator-workflows.test.ts
+++ b/src/__tests__/creator-workflows.test.ts
@@ -138,7 +138,7 @@ describe("doctor", () => {
     vi.stubGlobal("fetch", fetchMock);
     const report = await doctor(true, () => [credential]);
     expect(report).toMatchObject({ ok: true, publications: [{ authentication: "authenticated_read_succeeded", user_identity: "not_verified" }] });
-    expect(fetchMock.mock.calls[0][1]).toMatchObject({ redirect: "error", signal: expect.any(AbortSignal) });
+    expect(fetchMock.mock.calls[0][1]).toMatchObject({ redirect: "manual", signal: expect.any(AbortSignal) });
   });
   it.each([401, 403, 429, 500])("reports HTTP %s without echoing server content", async status => {
     vi.stubGlobal("fetch", vi.fn(async () => new Response("private-error-secret", { status })));

--- a/src/__tests__/request.test.ts
+++ b/src/__tests__/request.test.ts
@@ -104,6 +104,15 @@ describe("bounded response bodies", () => {
 });
 
 describe("response classification", () => {
+  it.each([400, 404, 500, 502])("preserves HTTP %s classification when its diagnostic body is oversized", async status => {
+    const cancel = vi.fn();
+    vi.stubGlobal("fetch", vi.fn(async () => new Response(new ReadableStream({ cancel }), { status, headers: { "content-length": "65537" } })));
+    const error = await requestJson(url).catch(error => error) as Error;
+    expect(error.name).toBe(status === 400 ? "ValidationError" : status === 404 ? "NotFoundError" : "ServerError");
+    expect(error.message).toContain("details were discarded");
+    expect(cancel).toHaveBeenCalledTimes(1);
+    expect((await doctor(true, config)).publications[0].authentication).toBe("upstream_error");
+  });
   it.each([
     { body: "private HTML", headers: { "content-type": "text/html" }, code: "unexpected_html" },
     { body: " <html>private</html>", headers: {}, code: "unexpected_html" },

--- a/src/__tests__/request.test.ts
+++ b/src/__tests__/request.test.ts
@@ -22,6 +22,18 @@ function streaming(chunks: Uint8Array[], headers: HeadersInit = {}) {
 }
 
 describe("bounded response bodies", () => {
+  it("retains a complete result when bounded synchronous parsing crosses the I/O deadline", async () => {
+    let clock = 0;
+    vi.spyOn(performance, "now").mockImplementation(() => clock);
+    const parse = JSON.parse;
+    vi.spyOn(JSON, "parse").mockImplementation(text => {
+      const value = parse(text);
+      if (text === '{"complete":true}') clock = 1000;
+      return value;
+    });
+    vi.stubGlobal("fetch", vi.fn(async () => new Response('{"complete":true}')));
+    expect(await requestJson(url, {}, 50)).toEqual({ complete: true });
+  });
   it("counts bytes across UTF-8 chunk boundaries and accepts the exact limit", async () => {
     const bytes = encode('"é"');
     expect(bytes.length).toBe(4);
@@ -191,6 +203,18 @@ describe("public page redirect policy", () => {
 });
 
 describe("real fetch contract", () => {
+  it("Node manual redirects expose the real status and Location header", async () => {
+    const server = createHttpServer((_req, res) => { res.writeHead(301, { Location: "https://example.invalid/" }); res.end(); });
+    await new Promise<void>(resolve => server.listen(0, "127.0.0.1", resolve));
+    try {
+      const { port } = server.address() as { port: number };
+      const response = await fetch(`http://127.0.0.1:${port}`, { redirect: "manual" });
+      expect(response.status).toBe(301);
+      expect(response.type).not.toBe("opaqueredirect");
+      expect(response.headers.get("location")).toBe("https://example.invalid/");
+      await response.body?.cancel();
+    } finally { server.closeAllConnections(); await new Promise<void>(resolve => server.close(() => resolve())); }
+  });
   it("never follows same-origin or cross-origin redirects or replays a POST", async () => {
     let hits = 0;
     const received: string[] = [];

--- a/src/__tests__/request.test.ts
+++ b/src/__tests__/request.test.ts
@@ -1,0 +1,174 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { createServer as createHttpServer } from "node:http";
+import { gzipSync } from "node:zlib";
+import { SubstackClient } from "../api/client.js";
+import { MAX_JSON_BYTES, readBounded, requestJson, requestText } from "../api/request.js";
+import { AuthenticationError, RateLimitError, ResponseError, TimeoutError, extractErrorDetail } from "../utils/errors.js";
+import { doctor } from "../doctor.js";
+
+afterEach(() => { vi.unstubAllGlobals(); vi.restoreAllMocks(); });
+const url = "https://example.substack.com/api/test";
+const encode = (value: string) => new TextEncoder().encode(value);
+const signal = () => new AbortController().signal;
+const config = () => [{ key: "test", label: "Test", publicationUrl: "https://example.substack.com", sessionToken: "synthetic-session", userId: "1", missing: [], source: "env" as const }];
+
+function streaming(chunks: Uint8Array[], headers: HeadersInit = {}) {
+  let index = 0;
+  const cancel = vi.fn();
+  const response = new Response(new ReadableStream({
+    pull(controller) { if (index < chunks.length) controller.enqueue(chunks[index++]); else controller.close(); }, cancel,
+  }), { headers });
+  return { response, cancel };
+}
+
+describe("bounded response bodies", () => {
+  it("counts bytes across UTF-8 chunk boundaries and accepts the exact limit", async () => {
+    const bytes = encode('"é"');
+    expect(bytes.length).toBe(4);
+    const { response } = streaming([bytes.slice(0, 2), bytes.slice(2)]);
+    expect(await readBounded(response, 4, signal(), url)).toBe('"é"');
+  });
+  it.each([{}, { "content-length": "1" }])("rejects streamed overflow even with missing or dishonest length: %j", async headers => {
+    const { response, cancel } = streaming([encode("123"), encode("45"), encode("6")], headers as HeadersInit);
+    await expect(readBounded(response, 4, signal(), url)).rejects.toMatchObject({ code: "response_too_large" });
+    expect(cancel).toHaveBeenCalledTimes(1);
+  });
+  it("rejects an excessive announced body without reading it", async () => {
+    const cancel = vi.fn();
+    const response = new Response(new ReadableStream({ cancel }), { headers: { "content-length": "500" } });
+    await expect(readBounded(response, 4, signal(), url)).rejects.toMatchObject({ code: "response_too_large" });
+    expect(response.body?.locked).toBe(false);
+    expect(cancel).toHaveBeenCalledTimes(1);
+  });
+  it("does not let a stalled body or slow cancellation outlive the deadline", async () => {
+    const cancel = vi.fn(() => new Promise<void>(() => {}));
+    vi.stubGlobal("fetch", vi.fn(async () => new Response(new ReadableStream({ cancel }))));
+    await expect(requestJson(url, {}, 20)).rejects.toBeInstanceOf(TimeoutError);
+    expect(cancel).toHaveBeenCalledTimes(1);
+  });
+  it("shares the deadline across headers and body instead of resetting it", async () => {
+    const controller = new AbortController();
+    const timeout = vi.spyOn(AbortSignal, "timeout").mockReturnValue(controller.signal);
+    const cancel = vi.fn();
+    let headersReady!: (response: Response) => void;
+    vi.stubGlobal("fetch", vi.fn(() => new Promise<Response>(resolve => { headersReady = resolve; })));
+    const operation = requestJson(url, {}, 50).catch(error => error);
+    expect(timeout).toHaveBeenCalledExactlyOnceWith(50);
+    headersReady(new Response(new ReadableStream({ cancel })));
+    await Promise.resolve(); await Promise.resolve(); await Promise.resolve();
+    controller.abort(new DOMException("expired", "TimeoutError"));
+    expect(await operation).toBeInstanceOf(TimeoutError);
+    expect(timeout).toHaveBeenCalledTimes(1);
+    expect(cancel).toHaveBeenCalledTimes(1);
+  });
+  it("honors caller cancellation and distinguishes it from timeout", async () => {
+    const controller = new AbortController(), cancel = vi.fn();
+    vi.stubGlobal("fetch", vi.fn(async () => new Response(new ReadableStream({ cancel }))));
+    const operation = requestJson(url, { signal: controller.signal }, 5000).catch(error => error);
+    await Promise.resolve(); await Promise.resolve();
+    controller.abort(new Error("private cancellation reason"));
+    const error = await operation as ResponseError;
+    expect(error).toMatchObject({ code: "request_cancelled" });
+    expect(error.message).not.toContain("private cancellation reason");
+  });
+  it("does not fetch with an already-cancelled caller signal", async () => {
+    const fetchMock = vi.fn(); vi.stubGlobal("fetch", fetchMock);
+    await expect(requestJson(url, { signal: AbortSignal.abort() })).rejects.toMatchObject({ code: "request_cancelled" });
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+  it("discards a response that arrives after a header timeout", async () => {
+    let respond!: (response: Response) => void;
+    const cancel = vi.fn();
+    vi.stubGlobal("fetch", vi.fn(() => new Promise<Response>(resolve => { respond = resolve; })));
+    await expect(requestJson(url, {}, 20)).rejects.toBeInstanceOf(TimeoutError);
+    respond(new Response(new ReadableStream({ cancel })));
+    await Promise.resolve();
+    expect(cancel).toHaveBeenCalledTimes(1);
+  });
+  it("bounds the public HTML fallback too", async () => {
+    vi.stubGlobal("fetch", vi.fn(async () => new Response("x", { headers: { "content-length": "3000000" } })));
+    await expect(requestText(url)).rejects.toMatchObject({ code: "response_too_large" });
+  });
+});
+
+describe("response classification", () => {
+  it.each([
+    { body: "private HTML", headers: { "content-type": "text/html" }, code: "unexpected_html" },
+    { body: " <html>private</html>", headers: {}, code: "unexpected_html" },
+    { body: "{private", headers: {}, code: "malformed_json" },
+  ])("classifies $code without echoing response bodies", async ({ body, headers, code }) => {
+    vi.stubGlobal("fetch", vi.fn(async () => new Response(body, { headers: headers as HeadersInit })));
+    const error = await requestJson(url).catch(error => error) as RateLimitError & ResponseError;
+    expect(error).toMatchObject({ code });
+    expect(error.message).not.toContain("private");
+    const result = await doctor(true, config);
+    expect(result.publications[0].authentication).toBe(code);
+  });
+  it.each([401, 403, 429])("classifies HTTP %s without waiting for its body", async status => {
+    const cancel = vi.fn();
+    vi.stubGlobal("fetch", vi.fn(async () => new Response(new ReadableStream({ cancel }), { status, headers: { "retry-after": "120" } })));
+    const error = await requestJson(url).catch(error => error) as RateLimitError & ResponseError;
+    expect(error).toBeInstanceOf(status === 429 ? RateLimitError : AuthenticationError);
+    if (status === 429) { expect(error.retryAfter).toBe("120"); expect(error.message).toContain("Retry-After: 120"); }
+    expect(cancel).toHaveBeenCalledTimes(1);
+  });
+  it.each(["Mon, 07 Sep 2026 22:00:00 GMT", "30", "private-injected-value"])("validates Retry-After %s", async value => {
+    vi.stubGlobal("fetch", vi.fn(async () => new Response("", { status: 429, headers: { "retry-after": value } })));
+    const error = await requestJson(url).catch(error => error) as RateLimitError & ResponseError;
+    expect(error.retryAfter).toBe(value.startsWith("private") ? undefined : value);
+    expect(error.message).not.toContain("private");
+  });
+  it("keeps error details bounded and removes raw/decoded cookies", async () => {
+    for (const body of [{ error: "x".repeat(600) }, { message: "x".repeat(600) }, { errors: ["x".repeat(600)] }]) {
+      expect(extractErrorDetail(JSON.stringify(body), "fallback")).toBe("x".repeat(500) + "...");
+    }
+    vi.stubGlobal("fetch", vi.fn(async () => new Response('{"error":"s%3Aprivate and s:private"}', { status: 400 })));
+    const error = await requestJson(url, { headers: { Cookie: "connect.sid=s%3Aprivate;" } }).catch(error => error) as Error;
+    expect(error.message).not.toContain("private");
+    expect(error.message).toContain("[redacted] and [redacted]");
+    const prefix = "x".repeat(495);
+    vi.stubGlobal("fetch", vi.fn(async () => new Response(JSON.stringify({ error: prefix + "s%3Aprivate" }), { status: 400 })));
+    const boundary = await requestJson(url, { headers: { Cookie: "connect.sid=s%3Aprivate" } }).catch(error => error) as Error;
+    expect(boundary.message).not.toContain("s%3A");
+    expect(boundary.message).toContain("[reda...");
+  });
+  it("enforces doctor's smaller body budget", async () => {
+    vi.stubGlobal("fetch", vi.fn(async () => new Response("", { headers: { "content-length": "1048577" } })));
+    expect((await doctor(true, config)).publications[0].authentication).toBe("response_too_large");
+  });
+  it("routes API calls through the response limit with no automatic write retry", async () => {
+    const fetchMock = vi.fn(async () => new Response("", { headers: { "content-length": String(MAX_JSON_BYTES + 1) } }));
+    vi.stubGlobal("fetch", fetchMock);
+    await expect(new SubstackClient("https://example.substack.com", "synthetic", "1").createDraft("Sample")).rejects.toBeInstanceOf(ResponseError);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("real fetch contract", () => {
+  it("never follows same-origin or cross-origin redirects or replays a POST", async () => {
+    let hits = 0;
+    const received: string[] = [];
+    const server = createHttpServer((req, res) => {
+      hits++; received.push(req.headers.cookie ?? "");
+      if (req.url === "/destination") { res.end('{}'); return; }
+      res.writeHead(307, { Location: req.url === "/same" ? "/destination" : "https://example.invalid/private" }); res.end();
+    });
+    await new Promise<void>(resolve => server.listen(0, "127.0.0.1", resolve));
+    const address = server.address() as { port: number };
+    try {
+      for (const path of ["same", "cross"]) {
+        await expect(requestJson(`http://127.0.0.1:${address.port}/${path}`, { method: "POST", body: "sample", headers: { Cookie: "synthetic-cookie" }, redirect: "follow" })).rejects.toMatchObject({ code: "redirect_rejected" });
+      }
+      expect(hits).toBe(2); expect(received).toEqual(["synthetic-cookie", "synthetic-cookie"]);
+    } finally { server.closeAllConnections(); await new Promise<void>(resolve => server.close(() => resolve())); }
+  });
+  it("limits decompressed bytes instead of trusting compressed Content-Length", async () => {
+    const compressed = gzipSync('"' + "x".repeat(10000) + '"');
+    const server = createHttpServer((_req, res) => { res.writeHead(200, { "content-encoding": "gzip", "content-length": compressed.length }); res.end(compressed); });
+    await new Promise<void>(resolve => server.listen(0, "127.0.0.1", resolve));
+    try {
+      const { port } = server.address() as { port: number };
+      await expect(requestJson(`http://127.0.0.1:${port}`, {}, 1000, 1000)).rejects.toMatchObject({ code: "response_too_large" });
+    } finally { server.closeAllConnections(); await new Promise<void>(resolve => server.close(() => resolve())); }
+  });
+});

--- a/src/__tests__/request.test.ts
+++ b/src/__tests__/request.test.ts
@@ -144,6 +144,52 @@ describe("response classification", () => {
   });
 });
 
+describe("public page redirect policy", () => {
+  it("follows HTTPS redirects as cookie-free GETs with one shared deadline", async () => {
+    const fetchMock = vi.fn()
+      .mockResolvedValueOnce(new Response("", { status: 301, headers: { location: "https://newsletter.example.org/" } }))
+      .mockResolvedValueOnce(new Response('{"freeSubscriberCount":"1,000"}'));
+    vi.stubGlobal("fetch", fetchMock);
+    const timeout = vi.spyOn(AbortSignal, "timeout");
+    expect(await requestText(url, { headers: { "User-Agent": "sample" } }, 1000)).toContain('"1,000"');
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(fetchMock.mock.calls[1][0]).toBe("https://newsletter.example.org/");
+    for (const [, options] of fetchMock.mock.calls) {
+      expect(options).toMatchObject({ method: "GET", credentials: "omit", redirect: "manual" });
+      expect([...new Headers(options.headers)]).toEqual([["user-agent", "sample"]]);
+    }
+    expect(fetchMock.mock.calls[0][1].signal).toBe(fetchMock.mock.calls[1][1].signal);
+    expect(timeout).toHaveBeenCalledExactlyOnceWith(1000);
+  });
+  it("retains the public subscriber-count fallback after an HTTPS canonical redirect", async () => {
+    const fetchMock = vi.fn()
+      .mockResolvedValueOnce(new Response('{}'))
+      .mockResolvedValueOnce(new Response("", { status: 302, headers: { location: "https://newsletter.example.org/" } }))
+      .mockResolvedValueOnce(new Response('{"freeSubscriberCount":"1,000"}'));
+    vi.stubGlobal("fetch", fetchMock);
+    expect(await new SubstackClient("https://example.substack.com", "synthetic", "1").getSubscriberCount()).toMatchObject({ count: 1000, precision: "approximate" });
+    expect(new Headers(fetchMock.mock.calls[0][1].headers).has("Cookie")).toBe(true);
+    for (const [, options] of fetchMock.mock.calls.slice(1)) expect(new Headers(options.headers).has("Cookie")).toBe(false);
+  });
+  it.each(["http://example.org/", "https://user:password@example.org/", "https://example.org:8443/", "https://["])("rejects an unsafe redirect without visiting it: %s", async location => {
+    const fetchMock = vi.fn(async () => new Response("", { status: 302, headers: { location } }));
+    vi.stubGlobal("fetch", fetchMock);
+    await expect(requestText(url)).rejects.toMatchObject({ code: "redirect_rejected" });
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+  it("caps redirect loops at three hops", async () => {
+    const fetchMock = vi.fn(async () => new Response("", { status: 301, headers: { location: "/again" } }));
+    vi.stubGlobal("fetch", fetchMock);
+    await expect(requestText(url)).rejects.toMatchObject({ code: "redirect_rejected" });
+    expect(fetchMock).toHaveBeenCalledTimes(4);
+  });
+  it.each([{ headers: { Cookie: "secret" } }, { headers: { Authorization: "secret" } }, { headers: { "X-API-Key": "secret" } }, { method: "POST", body: "sample" }])("rejects authenticated or writing public-page calls before fetching", async options => {
+    const fetchMock = vi.fn(); vi.stubGlobal("fetch", fetchMock);
+    await expect(requestText(url, options as RequestInit)).rejects.toThrow("credentials are not allowed");
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+});
+
 describe("real fetch contract", () => {
   it("never follows same-origin or cross-origin redirects or replays a POST", async () => {
     let hits = 0;

--- a/src/__tests__/server-publications.test.ts
+++ b/src/__tests__/server-publications.test.ts
@@ -14,12 +14,7 @@ describe("multi-publication support", () => {
 
   function stubFetch() {
     const body = { sections: [] };
-    const fetchMock = vi.fn(async (..._args: any[]) => ({
-      ok: true,
-      status: 200,
-      json: async () => body,
-      text: async () => JSON.stringify(body),
-    }));
+    const fetchMock = vi.fn(async (..._args: any[]) => new Response(JSON.stringify(body)));
     vi.stubGlobal("fetch", fetchMock);
     return fetchMock;
   }

--- a/src/__tests__/server.test.ts
+++ b/src/__tests__/server.test.ts
@@ -22,12 +22,7 @@ describe("tool pagination limits (regression: #28)", () => {
 
   function stubFetch() {
     const body = { posts: [], total: 0 };
-    const fetchMock = vi.fn(async (..._args: any[]) => ({
-      ok: true,
-      status: 200,
-      json: async () => body,
-      text: async () => JSON.stringify(body),
-    }));
+    const fetchMock = vi.fn(async (..._args: any[]) => new Response(JSON.stringify(body)));
     vi.stubGlobal("fetch", fetchMock);
     return fetchMock;
   }

--- a/src/__tests__/subscribers.test.ts
+++ b/src/__tests__/subscribers.test.ts
@@ -157,7 +157,7 @@ describe("subscriber management", () => {
 describe("subscriber tools over MCP", () => {
   afterEach(() => vi.unstubAllGlobals());
   it("routes to the selected publication and rejects missing consent/publication without requests", async () => {
-    const fetchMock = vi.fn().mockResolvedValue({ ok: true, json: async () => empty });
+    const fetchMock = vi.fn().mockImplementation(async () => new Response(JSON.stringify(empty)));
     vi.stubGlobal("fetch", fetchMock);
     const server = createServer(["one", "two"].map(key => ({ key, label: key, client: new SubstackClient(`https://${key}.substack.com`, "token", "1") })));
     const client = new Client({ name: "test", version: "1" });
@@ -175,7 +175,7 @@ describe("subscriber tools over MCP", () => {
       const missingEvidence = await client.callTool({ name: "add_free_subscriber", arguments: { email, consent_confirmed: true, dry_run: false, publication: "two" } });
       expect(missingEvidence.isError).toBe(true);
       expect(fetchMock).toHaveBeenCalledTimes(1);
-      fetchMock.mockResolvedValue({ ok: true, json: async () => found });
+      fetchMock.mockImplementation(async () => new Response(JSON.stringify(found)));
       const audited = await client.callTool({ name: "add_free_subscriber", arguments: { email, consent_confirmed: true, consent_evidence: evidence, dry_run: false, publication: "one" } });
       expect(JSON.parse((audited.content as Array<{text: string}>)[0].text)).toMatchObject({ status: "existing", publication: "one", consent_evidence: evidence });
       const tools = (await client.listTools()).tools;

--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -12,7 +12,7 @@ import {
   SubstackSection,
   SubstackScheduledPost,
 } from "./types.js";
-import { mapHttpStatusToError, extractErrorDetail, TimeoutError, isAbortError } from "../utils/errors.js";
+import { requestJson, requestText } from "./request.js";
 import { SubscriberService } from "./subscribers.js";
 import { searchPosts } from "./search.js";
 import { getPublication } from "./publication.js";
@@ -133,28 +133,7 @@ export class SubstackClient {
       headers["Content-Type"] = "application/json";
     }
 
-    // The signal is set last so it can't be overridden by `options`: every
-    // request through this method is bounded, no exceptions.
-    let response: Response;
-    try {
-      response = await fetch(url, {
-        ...options,
-        headers,
-        redirect: "follow",
-        signal: AbortSignal.timeout(this.timeoutMs),
-      });
-    } catch (err) {
-      if (isAbortError(err)) throw new TimeoutError(url, this.timeoutMs);
-      throw err;
-    }
-
-    if (!response.ok) {
-      const body = await response.text().catch(() => "unknown error");
-      const detail = extractErrorDetail(body, "unknown error");
-      throw mapHttpStatusToError(response.status, detail, url);
-    }
-
-    return response.json() as Promise<T>;
+    return requestJson<T>(url, { ...options, headers }, this.timeoutMs);
   }
 
   async validateAuth(): Promise<{ id: number; name: string }> {
@@ -246,13 +225,9 @@ export class SubstackClient {
   private async getRoundedSubscriberCount(): Promise<number | null> {
     let html: string;
     try {
-      const res = await fetch(`${this.publicationUrl}/`, {
+      html = await requestText(`${this.publicationUrl}/`, {
         headers: { "User-Agent": this.userAgent },
-        redirect: "follow",
-        signal: AbortSignal.timeout(this.timeoutMs),
-      });
-      if (!res.ok) return null;
-      html = await res.text();
+      }, this.timeoutMs);
     } catch {
       return null;
     }

--- a/src/api/request.ts
+++ b/src/api/request.ts
@@ -68,20 +68,38 @@ function redactDetail(detail: string, options: RequestInit): string {
   return detail;
 }
 
-/** One request, no redirects or retries. Deadline includes headers and body. */
+/** One deadline through headers/body. JSON calls never follow redirects or retry. */
 async function request(url: string, options: RequestInit, timeoutMs: number, format: "json" | "text", maxBytes: number): Promise<unknown> {
   const expiresAt = performance.now() + timeoutMs;
   const deadline = AbortSignal.timeout(Math.max(1, Math.min(2_147_483_647, Math.floor(timeoutMs))));
   const signal = options.signal ? AbortSignal.any([deadline, options.signal]) : deadline;
   try {
     signal.throwIfAborted();
-    const pending = fetch(url, { ...options, redirect: "manual", signal });
-    // A substituted fetch may return after cancellation; discard its late body.
-    void pending.then(response => { if (signal.aborted) discard(response); }, () => {});
-    const response = await abortable(pending, signal);
-    if (response.type === "opaqueredirect" || (response.status >= 300 && response.status < 400)) {
-      discard(response);
-      throw new ResponseError(url, "redirect_rejected");
+    let currentUrl = url, redirects = 0;
+    let response: Response;
+    while (true) {
+      signal.throwIfAborted();
+      if (performance.now() >= expiresAt) throw new TimeoutError(url, timeoutMs);
+      const pending = fetch(currentUrl, { ...options, redirect: "manual", signal });
+      // A substituted fetch may return after cancellation; discard its late body.
+      void pending.then(response => { if (signal.aborted) discard(response); }, () => {});
+      response = await abortable(pending, signal);
+      if (signal.aborted || performance.now() >= expiresAt) {
+        discard(response); signal.throwIfAborted(); throw new TimeoutError(url, timeoutMs);
+      }
+      const redirect = [301, 302, 303, 307, 308].includes(response.status);
+      if (response.type === "opaqueredirect" || redirect) {
+        discard(response);
+        const location = response.headers.get("location");
+        if (format !== "text" || !location || redirects >= 3) throw new ResponseError(url, "redirect_rejected");
+        let target: URL;
+        try { target = new URL(location, currentUrl); }
+        catch { throw new ResponseError(url, "redirect_rejected"); }
+        if (target.protocol !== "https:" || target.username || target.password || target.port) throw new ResponseError(url, "redirect_rejected");
+        currentUrl = target.href; redirects++;
+        continue;
+      }
+      break;
     }
     if ([401, 403, 429].includes(response.status)) {
       discard(response);
@@ -115,6 +133,11 @@ export function requestJson<T>(url: string, options: RequestInit = {}, timeoutMs
   return request(url, options, timeoutMs, "json", maxBytes) as Promise<T>;
 }
 
-export function requestText(url: string, options: RequestInit = {}, timeoutMs = 30_000): Promise<string> {
-  return request(url, options, timeoutMs, "text", MAX_HTML_BYTES) as Promise<string>;
+/** Public page GET only; never forward credentials or arbitrary caller headers. */
+export async function requestText(url: string, options: RequestInit = {}, timeoutMs = 30_000): Promise<string> {
+  const headers = new Headers(options.headers);
+  if ((options.method && options.method !== "GET") || options.body || [...headers.keys()].some(name => !["user-agent", "accept"].includes(name))) {
+    throw new Error("Public page reads accept only GET, User-Agent and Accept; credentials are not allowed.");
+  }
+  return request(url, { headers, method: "GET", credentials: "omit", signal: options.signal }, timeoutMs, "text", MAX_HTML_BYTES) as Promise<string>;
 }

--- a/src/api/request.ts
+++ b/src/api/request.ts
@@ -1,0 +1,120 @@
+import { extractErrorDetail, isAbortError, mapHttpStatusToError, ResponseError, TimeoutError } from "../utils/errors.js";
+
+export const MAX_JSON_BYTES = 10 * 1024 * 1024;
+export const MAX_HTML_BYTES = 2 * 1024 * 1024;
+export const MAX_ERROR_BYTES = 64 * 1024;
+
+/** Race operations against cancellation, including body reads and custom fetches. */
+async function abortable<T>(operation: Promise<T>, signal: AbortSignal): Promise<T> {
+  let onAbort: () => void = () => {};
+  const aborted = new Promise<never>((_, reject) => {
+    onAbort = () => reject(signal.reason);
+    if (signal.aborted) onAbort();
+    else signal.addEventListener("abort", onAbort, { once: true });
+  });
+  try { return await Promise.race([operation, aborted]); }
+  finally { signal.removeEventListener("abort", onAbort); }
+}
+
+function discard(response: Response) { void response.body?.cancel().catch(() => {}); }
+
+/** Count decoded transport bytes as they arrive, not just Content-Length. */
+export async function readBounded(response: Response, maxBytes: number, signal: AbortSignal, endpoint: string, expiresAt = Infinity): Promise<string> {
+  if (!Number.isSafeInteger(maxBytes) || maxBytes <= 0) throw new Error("Invalid response byte limit.");
+  const length = response.headers.get("content-length");
+  if (length && /^\d+$/.test(length) && Number(length) > maxBytes) {
+    discard(response);
+    throw new ResponseError(endpoint, "response_too_large");
+  }
+  if (!response.body) { signal.throwIfAborted(); return ""; }
+  const reader = response.body.getReader();
+  const decoder = new TextDecoder();
+  let bytes = 0, text = "", complete = false;
+  try {
+    while (true) {
+      signal.throwIfAborted();
+      if (performance.now() >= expiresAt) throw new DOMException("Response deadline exceeded", "TimeoutError");
+      const { done, value } = await abortable(reader.read(), signal);
+      signal.throwIfAborted();
+      if (done) { complete = true; return text + decoder.decode(); }
+      bytes += value.byteLength;
+      if (bytes > maxBytes) throw new ResponseError(endpoint, "response_too_large");
+      text += decoder.decode(value, { stream: true });
+    }
+  } finally {
+    // Cancellation itself can be slow: never wait for it to enforce a deadline.
+    if (!complete) void reader.cancel().catch(() => {});
+    reader.releaseLock();
+  }
+}
+
+function retryAfter(response: Response): string | undefined {
+  const raw = response.headers.get("retry-after");
+  if (!raw || raw.length > 64) return undefined;
+  if (/^\d{1,10}$/.test(raw)) return raw;
+  if (/^(Mon|Tue|Wed|Thu|Fri|Sat|Sun), \d{2} (Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec) \d{4} \d{2}:\d{2}:\d{2} GMT$/.test(raw) && Number.isFinite(Date.parse(raw))) return raw;
+  return undefined;
+}
+
+function redactDetail(detail: string, options: RequestInit): string {
+  const cookie = new Headers(options.headers).get("cookie");
+  if (!cookie) return detail;
+  for (const part of cookie.split(";")) {
+    const value = part.slice(part.indexOf("=") + 1).trim();
+    if (!value) continue;
+    detail = detail.replaceAll(value, "[redacted]");
+    try { detail = detail.replaceAll(decodeURIComponent(value), "[redacted]"); } catch { /* Preserve opaque cookie values. */ }
+  }
+  return detail;
+}
+
+/** One request, no redirects or retries. Deadline includes headers and body. */
+async function request(url: string, options: RequestInit, timeoutMs: number, format: "json" | "text", maxBytes: number): Promise<unknown> {
+  const expiresAt = performance.now() + timeoutMs;
+  const deadline = AbortSignal.timeout(Math.max(1, Math.min(2_147_483_647, Math.floor(timeoutMs))));
+  const signal = options.signal ? AbortSignal.any([deadline, options.signal]) : deadline;
+  try {
+    signal.throwIfAborted();
+    const pending = fetch(url, { ...options, redirect: "manual", signal });
+    // A substituted fetch may return after cancellation; discard its late body.
+    void pending.then(response => { if (signal.aborted) discard(response); }, () => {});
+    const response = await abortable(pending, signal);
+    if (response.type === "opaqueredirect" || (response.status >= 300 && response.status < 400)) {
+      discard(response);
+      throw new ResponseError(url, "redirect_rejected");
+    }
+    if ([401, 403, 429].includes(response.status)) {
+      discard(response);
+      throw mapHttpStatusToError(response.status, "Too many requests", url, retryAfter(response));
+    }
+    if (!response.ok) {
+      const text = await readBounded(response, MAX_ERROR_BYTES, signal, url, expiresAt);
+      throw mapHttpStatusToError(response.status, extractErrorDetail(text, "unknown error", detail => redactDetail(detail, options)), url);
+    }
+    if (format === "json" && /(?:text\/html|application\/xhtml\+xml)/i.test(response.headers.get("content-type") ?? "")) {
+      discard(response);
+      throw new ResponseError(url, "unexpected_html");
+    }
+    const text = await readBounded(response, maxBytes, signal, url, expiresAt);
+    if (performance.now() >= expiresAt) throw new TimeoutError(url, timeoutMs);
+    if (format === "text") return text;
+    if (text.trimStart().startsWith("<")) throw new ResponseError(url, "unexpected_html");
+    let value: unknown;
+    try { value = JSON.parse(text); }
+    catch { throw new ResponseError(url, "malformed_json"); }
+    if (performance.now() >= expiresAt) throw new TimeoutError(url, timeoutMs);
+    return value;
+  } catch (error) {
+    if (options.signal?.aborted && !deadline.aborted) throw new ResponseError(url, "request_cancelled");
+    if (deadline.aborted || isAbortError(error)) throw new TimeoutError(url, timeoutMs);
+    throw error;
+  }
+}
+
+export function requestJson<T>(url: string, options: RequestInit = {}, timeoutMs = 30_000, maxBytes = MAX_JSON_BYTES): Promise<T> {
+  return request(url, options, timeoutMs, "json", maxBytes) as Promise<T>;
+}
+
+export function requestText(url: string, options: RequestInit = {}, timeoutMs = 30_000): Promise<string> {
+  return request(url, options, timeoutMs, "text", MAX_HTML_BYTES) as Promise<string>;
+}

--- a/src/api/request.ts
+++ b/src/api/request.ts
@@ -36,6 +36,7 @@ export async function readBounded(response: Response, maxBytes: number, signal: 
       if (performance.now() >= expiresAt) throw new DOMException("Response deadline exceeded", "TimeoutError");
       const { done, value } = await abortable(reader.read(), signal);
       signal.throwIfAborted();
+      if (performance.now() >= expiresAt) throw new DOMException("Response deadline exceeded", "TimeoutError");
       if (done) { complete = true; return text + decoder.decode(); }
       bytes += value.byteLength;
       if (bytes > maxBytes) throw new ResponseError(endpoint, "response_too_large");
@@ -114,13 +115,13 @@ async function request(url: string, options: RequestInit, timeoutMs: number, for
       throw new ResponseError(url, "unexpected_html");
     }
     const text = await readBounded(response, maxBytes, signal, url, expiresAt);
-    if (performance.now() >= expiresAt) throw new TimeoutError(url, timeoutMs);
     if (format === "text") return text;
     if (text.trimStart().startsWith("<")) throw new ResponseError(url, "unexpected_html");
     let value: unknown;
     try { value = JSON.parse(text); }
     catch { throw new ResponseError(url, "malformed_json"); }
-    if (performance.now() >= expiresAt) throw new TimeoutError(url, timeoutMs);
+    // Parsing is synchronous and byte-bounded, not preemptible. Preserve the
+    // known complete result rather than manufacture an uncertain write outcome.
     return value;
   } catch (error) {
     if (options.signal?.aborted && !deadline.aborted) throw new ResponseError(url, "request_cancelled");

--- a/src/api/request.ts
+++ b/src/api/request.ts
@@ -107,8 +107,16 @@ async function request(url: string, options: RequestInit, timeoutMs: number, for
       throw mapHttpStatusToError(response.status, "Too many requests", url, retryAfter(response));
     }
     if (!response.ok) {
-      const text = await readBounded(response, MAX_ERROR_BYTES, signal, url, expiresAt);
-      throw mapHttpStatusToError(response.status, extractErrorDetail(text, "unknown error", detail => redactDetail(detail, options)), url);
+      let detail: string;
+      try {
+        const text = await readBounded(response, MAX_ERROR_BYTES, signal, url, expiresAt);
+        detail = extractErrorDetail(text, "unknown error", value => redactDetail(value, options));
+      } catch (error) {
+        if (!(error instanceof ResponseError) || error.code !== "response_too_large") throw error;
+        // The HTTP failure is known even when its diagnostic body is oversized.
+        detail = "Error response exceeded the byte limit; details were discarded";
+      }
+      throw mapHttpStatusToError(response.status, detail, url);
     }
     if (format === "json" && /(?:text\/html|application\/xhtml\+xml)/i.test(response.headers.get("content-type") ?? "")) {
       discard(response);

--- a/src/doctor.ts
+++ b/src/doctor.ts
@@ -1,5 +1,6 @@
 import { resolvePublications } from "./auth/resolve-publications.js";
-import { isAbortError } from "./utils/errors.js";
+import { AuthenticationError, RateLimitError, ResponseError, SubstackAPIError, TimeoutError } from "./utils/errors.js";
+import { requestJson } from "./api/request.js";
 import { publicationOrigin, validateCredentials } from "./auth/validate-credentials.js";
 
 export async function doctor(checkAuth = false, resolve = resolvePublications) {
@@ -17,20 +18,19 @@ export async function doctor(checkAuth = false, resolve = resolvePublications) {
     let authentication = "not_checked";
     if (checkAuth && valid && validated) {
       try {
-        // No redirects: never forward the session cookie to a redirected host.
-        const response = await fetch(`${origin}/api/v1/post_management/drafts?offset=0&limit=1&order_by=draft_updated_at&order_direction=desc`, {
+        const body = await requestJson<unknown>(`${origin}/api/v1/post_management/drafts?offset=0&limit=1&order_by=draft_updated_at&order_direction=desc`, {
           headers: { Cookie: validated.cookie, Accept: "application/json",
             "User-Agent": "Mozilla/5.0", Referer: `${origin}/publish/home` },
-          redirect: "error", signal: AbortSignal.timeout(5000),
-        });
-        if (response.status === 401 || response.status === 403) authentication = "unauthorized_or_blocked";
-        else if (response.status === 429) authentication = "rate_limited";
-        else if (!response.ok) authentication = "upstream_error";
-        else {
-          const body: unknown = await response.json();
-          authentication = body && typeof body === "object" && "posts" in body && Array.isArray(body.posts) ? "authenticated_read_succeeded" : "unexpected_response";
-        }
-      } catch (error) { authentication = isAbortError(error) ? "timeout" : "network_or_response_error"; }
+        }, 5000, 1024 * 1024);
+        authentication = body && typeof body === "object" && "posts" in body && Array.isArray(body.posts) ? "authenticated_read_succeeded" : "unexpected_response";
+      } catch (error) {
+        authentication = error instanceof AuthenticationError ? "unauthorized_or_blocked"
+          : error instanceof RateLimitError ? "rate_limited"
+          : error instanceof TimeoutError ? "timeout"
+          : error instanceof ResponseError ? error.code
+          : error instanceof SubstackAPIError ? "upstream_error"
+          : "network_or_response_error";
+      }
     }
     reports.push({ publication: p.key, origin, credential_source: p.source,
       configuration: valid ? "valid" : "invalid", missing: p.missing, authentication,

--- a/src/utils/errors.ts
+++ b/src/utils/errors.ts
@@ -155,7 +155,7 @@ export class ResponseError extends SubstackAPIError {
       response_too_large: "Response exceeds the byte limit; no partial result was returned.",
       unexpected_html: "Expected JSON but received HTML, possibly a sign-in or blocking page.",
       malformed_json: "Response is not valid JSON; no result can be verified.",
-      redirect_rejected: "Redirect rejected. Configure the publication origin that serves API requests directly; no redirect was followed.",
+      redirect_rejected: "Redirect rejected by the request policy. Configure the publication origin that serves the requested endpoint directly.",
       request_cancelled: "Request cancelled before completion.",
     };
     super(502, messages[code], endpoint); // Synthetic status for a client-side failure.

--- a/src/utils/errors.ts
+++ b/src/utils/errors.ts
@@ -18,8 +18,8 @@ export class AuthenticationError extends SubstackAPIError {
 
 /** HTTP 429 — too many requests against the Substack API. */
 export class RateLimitError extends SubstackAPIError {
-  constructor(endpoint: string, detail: string) {
-    super(429, "Rate limited by Substack: " + detail + ". Slow down requests and try again shortly.", endpoint);
+  constructor(endpoint: string, detail: string, public retryAfter?: string) {
+    super(429, "Rate limited by Substack: " + detail + ". Slow down requests and try again shortly." + (retryAfter ? ` Retry-After: ${retryAfter}.` : ""), endpoint);
     this.name = "RateLimitError";
   }
 }
@@ -49,9 +49,9 @@ export class ServerError extends SubstackAPIError {
 }
 
 /**
- * The client's own request deadline fired before any response arrived.
+ * The client's deadline fired before the full response was received.
  *
- * There is no real status here — Substack never answered — so 408 is synthetic,
+ * There is no real status here — 408 is synthetic,
  * chosen only so this fits the `SubstackAPIError` shape every tool handler
  * already renders. Without it, an aborted fetch surfaces as a bare
  * `DOMException: The operation was aborted due to timeout`, which says nothing
@@ -61,7 +61,7 @@ export class TimeoutError extends SubstackAPIError {
   constructor(endpoint: string, timeoutMs: number) {
     super(
       408,
-      `Request timed out after ${timeoutMs}ms with no response. The host may be unreachable, ` +
+      `Request timed out after ${timeoutMs}ms before the full response was received. The host may be unreachable, ` +
         "or behind a proxy that drops packets instead of refusing the connection. " +
         "Set SUBSTACK_REQUEST_TIMEOUT_MS to raise the limit if the publication is just slow.",
       endpoint,
@@ -99,9 +99,9 @@ export function isAbortError(err: unknown): boolean {
  * that message or require duplicating it. Falls back to the base
  * `SubstackAPIError` for status codes outside the mapped classes.
  */
-export function mapHttpStatusToError(status: number, detail: string, endpoint: string): SubstackAPIError {
+export function mapHttpStatusToError(status: number, detail: string, endpoint: string, retryAfter?: string): SubstackAPIError {
   if (status === 401 || status === 403) return new AuthenticationError(endpoint);
-  if (status === 429) return new RateLimitError(endpoint, detail);
+  if (status === 429) return new RateLimitError(endpoint, detail, retryAfter);
   if (status === 400) return new ValidationError(endpoint, detail);
   if (status === 404) return new NotFoundError(endpoint, detail);
   if (status >= 500) return new ServerError(endpoint, detail);
@@ -117,22 +117,23 @@ export function mapHttpStatusToError(status: number, detail: string, endpoint: s
  * tries JSON first, then falls back to the raw text (trimmed and capped so
  * a multi-KB Cloudflare HTML blob doesn't become the entire error message).
  */
-export function extractErrorDetail(responseData: string, fallback: string): string {
+export function extractErrorDetail(responseData: string, fallback: string, redact = (value: string) => value): string {
   const MAX_LENGTH = 500;
+  const cap = (value: string) => { const safe = redact(value); return safe.length > MAX_LENGTH ? safe.slice(0, MAX_LENGTH) + "..." : safe; };
 
   try {
     const parsed = JSON.parse(responseData);
     if (parsed && typeof parsed === "object") {
       if (typeof parsed.error === "string" && parsed.error.length > 0) {
-        return parsed.error;
+        return cap(parsed.error);
       }
       if (typeof parsed.message === "string" && parsed.message.length > 0) {
-        return parsed.message;
+        return cap(parsed.message);
       }
       if (Array.isArray(parsed.errors) && parsed.errors.length > 0) {
-        return parsed.errors
+        return cap(parsed.errors
           .map((e: unknown) => (typeof e === "string" ? e : JSON.stringify(e)))
-          .join("; ");
+          .join("; "));
       }
     }
   } catch {
@@ -141,8 +142,23 @@ export function extractErrorDetail(responseData: string, fallback: string): stri
 
   const trimmed = responseData.trim();
   if (trimmed.length > 0) {
-    return trimmed.length > MAX_LENGTH ? trimmed.slice(0, MAX_LENGTH) + "..." : trimmed;
+    return cap(trimmed);
   }
 
-  return fallback;
+  return cap(fallback);
+}
+
+export type ResponseErrorCode = "response_too_large" | "unexpected_html" | "malformed_json" | "redirect_rejected" | "request_cancelled";
+export class ResponseError extends SubstackAPIError {
+  constructor(endpoint: string, public code: ResponseErrorCode) {
+    const messages: Record<ResponseErrorCode, string> = {
+      response_too_large: "Response exceeds the byte limit; no partial result was returned.",
+      unexpected_html: "Expected JSON but received HTML, possibly a sign-in or blocking page.",
+      malformed_json: "Response is not valid JSON; no result can be verified.",
+      redirect_rejected: "Redirect rejected. Configure the publication origin that serves API requests directly; no redirect was followed.",
+      request_cancelled: "Request cancelled before completion.",
+    };
+    super(502, messages[code], endpoint); // Synthetic status for a client-side failure.
+    this.name = "ResponseError";
+  }
 }


### PR DESCRIPTION
API requests previously followed redirects and read unbounded response bodies; timeouts during body consumption were not consistently classified. The shared request path now caps streamed/decompressed bytes, keeps one deadline through headers and body, discards rejected responses, rejects authenticated redirects without replay, and never automatically retries. The public subscriber-count fallback preserves up to three HTTPS redirects as cookie-free GETs under the same deadline. Doctor uses the shared path with a smaller response budget and explicit diagnostic codes. Error details are capped and matching cookie values redacted before truncation; rate-limit errors retain validated Retry-After guidance.

Validation: lint, 468 core tests, eight cloud tests, clean installed package (54 files, both bins, version handshake and all 22 tools). Real local HTTP tests cover authenticated redirect rejection, visible Node manual-redirect headers and compressed response overflow; controls cover bounded public redirects without cookies, body stalls, cancellation, dishonest Content-Length, byte/UTF-8 boundaries, redaction and diagnostics. Removing each byte/redirect/body-cancellation/redaction guard fails its targeted control. Read-only custom-domain draft-list, publication and doctor checks passed without authenticated redirects or writes. A separate live canonical-to-custom-domain public page read followed a visible 301 to 200 with no cookies and retained subscriber-count data. Completed results survive bounded synchronous parsing after the I/O deadline.

Part of #65 and #61. Independent exact-SHA reviews and required CI must pass before merge. This does not establish host ownership, account identity, write rollback or an atomic draft-edit guarantee. Release lookup/recovery and other release gates remain tracked separately in #65.
