### PR TITLE
fix: preserve HTTP status and retry guidance through body failures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and the git tag history (`v0.1.0`–`v0.5.0`).
 - Missing or malformed credentials now stop server startup before transport connection. All configured publications must be valid; none are silently dropped. Use `doctor` for diagnostics and `substack-mcp-login` for first-time setup. This replaces the previous missing-credential warning followed by unusable tools.
 
 ### Fixed
+- HTTP failures retain their actual status and validated Retry-After guidance, including 503 responses with unreadable diagnostic bodies. Error metadata distinguishes upstream status from synthetic client errors and records body-read failures. Cancellation does not replace an already classified failure; requests never retry writes automatically.
 - Shared API/doctor/public-count requests now bound streamed response bytes and deadlines through body consumption, reject authenticated redirects, bound cookie-free public-page redirects, classify malformed JSON/HTML, preserve rate-limit guidance and cap/redact error details. Requests never retry automatically; failed write outcomes still require reconciliation.
 - The API client and doctor share strict origin, user-ID and cookie-value validation. Invalid configurations fail before requests, with credential-safe errors; valid custom domains and encoded cookie values remain supported.
 - Archive search rejects duplicate post IDs, unsafe numeric IDs/totals and nonempty pages that exceed the reported total, while preserving valid final and empty out-of-range pages.

--- a/src/__tests__/http-metadata.test.ts
+++ b/src/__tests__/http-metadata.test.ts
@@ -1,0 +1,116 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { requestJson } from "../api/request.js";
+import { ResponseError, SubstackAPIError, TimeoutError } from "../utils/errors.js";
+
+afterEach(() => { vi.unstubAllGlobals(); vi.restoreAllMocks(); });
+const url = "https://example.substack.com/api/test";
+
+describe("HTTP failure metadata", () => {
+  it.each([401, 403, 408, 429, 500, 502, 503, 504])("preserves actual HTTP %s", async status => {
+    vi.stubGlobal("fetch", vi.fn(async () => new Response("failure", { status })));
+    const error = await requestJson(url).catch(error => error) as SubstackAPIError;
+    expect(error).toMatchObject({ statusCode: status, statusSource: "http", responseBodyIssue: undefined });
+    expect(error.message).toContain(`(${status})`);
+  });
+
+  it("distinguishes client errors from real HTTP 408/502", async () => {
+    expect(new TimeoutError(url, 10)).toMatchObject({ statusCode: 408, statusSource: "client" });
+    vi.stubGlobal("fetch", vi.fn(async () => new Response("invalid")));
+    await expect(requestJson(url)).rejects.toMatchObject({ statusCode: 502, statusSource: "client", code: "malformed_json" });
+  });
+
+  it.each([429, 503])("retains validated Retry-After for HTTP %s", async status => {
+    for (const value of ["30", "Mon, 07 Sep 2026 22:00:00 GMT", "private-invalid-value", "9".repeat(65)]) {
+      vi.stubGlobal("fetch", vi.fn(async () => new Response("unavailable", { status, headers: { "retry-after": value } })));
+      const error = await requestJson(url).catch(error => error) as SubstackAPIError;
+      if (value === "30" || value.startsWith("Mon,")) {
+        expect(error.retryAfter).toBe(value);
+        expect(error.message).toContain(`Retry-After: ${value}`);
+      } else {
+        expect(error.retryAfter).toBeUndefined();
+        expect(error.message).not.toContain(value);
+      }
+    }
+  });
+
+  it.each(["oversized", "stalled", "broken"])("preserves 503 and retry guidance with a %s body", async mode => {
+    const cancel = vi.fn(() => new Promise<void>(() => {}));
+    const body = new ReadableStream({
+      start(controller) { if (mode === "broken") controller.error(new Error("private body failure")); }, cancel,
+    });
+    vi.stubGlobal("fetch", vi.fn(async () => new Response(body, { status: 503, headers: {
+      "retry-after": "60", ...(mode === "oversized" ? { "content-length": "65537" } : {}),
+    } })));
+    const error = await requestJson(url, {}, 50).catch(error => error) as SubstackAPIError;
+    expect(error).toMatchObject({ statusCode: 503, statusSource: "http", retryAfter: "60",
+      responseBodyIssue: mode === "oversized" ? "response_too_large" : mode === "stalled" ? "timeout" : "body_read_failed" });
+    expect(error.message).toContain("Retry-After: 60");
+    expect(error.message).not.toContain("private body failure");
+    if (mode !== "broken") expect(cancel).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps the known HTTP failure when the caller cancels its stalled diagnostic body", async () => {
+    const controller = new AbortController();
+    const reason = new ResponseError("private-abort-endpoint", "response_too_large");
+    let bodyRead!: () => void;
+    const ready = new Promise<void>(resolve => { bodyRead = resolve; });
+    const cancel = vi.fn();
+    vi.stubGlobal("fetch", vi.fn(async () => new Response(new ReadableStream({
+      pull() { bodyRead(); }, cancel,
+    }, { highWaterMark: 0 }), { status: 503, headers: { "retry-after": "15" } })));
+    const operation = requestJson(url, { signal: controller.signal }).catch(error => error);
+    await ready;
+    controller.abort(reason);
+    const error = await operation as SubstackAPIError;
+    expect(error).toMatchObject({ statusCode: 503, statusSource: "http", retryAfter: "15", responseBodyIssue: "request_cancelled" });
+    expect(error.message).not.toContain("private-abort-endpoint");
+    expect(cancel).toHaveBeenCalledTimes(1);
+  });
+
+  it.each([200, 503])("preserves classified overflow if cleanup cancels HTTP %s", async status => {
+    const controller = new AbortController();
+    vi.stubGlobal("fetch", vi.fn(async () => new Response(new ReadableStream({
+      cancel() { controller.abort(new Error("private cleanup reason")); },
+    }), { status, headers: { "content-length": "20000000", "retry-after": "15" } })));
+    const error = await requestJson(url, { signal: controller.signal }).catch(error => error) as SubstackAPIError;
+    expect(error).toMatchObject(status === 200
+      ? { statusCode: 502, statusSource: "client", code: "response_too_large" }
+      : { statusCode: 503, statusSource: "http", responseBodyIssue: "response_too_large", retryAfter: "15" });
+    expect(error.message).not.toContain("private cleanup reason");
+  });
+
+  it.each([
+    new SubstackAPIError(503, "private reason", "private endpoint"),
+    new ResponseError("private endpoint", "response_too_large"),
+  ])("does not expose caller-supplied typed abort reasons", async reason => {
+    const fetchMock = vi.fn(); vi.stubGlobal("fetch", fetchMock);
+    const error = await requestJson(url, { signal: AbortSignal.abort(reason) }).catch(error => error) as SubstackAPIError;
+    expect(error).toMatchObject({ code: "request_cancelled", statusSource: "client", endpoint: url });
+    expect(error.message).not.toContain("private");
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("never automatically retries a failed write even with Retry-After", async () => {
+    let appliedWrites = 0;
+    const fetchMock = vi.fn(async () => { appliedWrites++; return new Response("unavailable", { status: 503, headers: { "retry-after": "0" } }); });
+    vi.stubGlobal("fetch", fetchMock);
+    await expect(requestJson(url, { method: "POST", body: "sample" })).rejects.toMatchObject({ statusCode: 503, retryAfter: "0" });
+    // A response failure cannot establish whether the originating write happened.
+    expect(appliedWrites).toBe(1);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it.each([0, -1, NaN, Infinity])("rejects invalid timeout %s before fetching", async timeout => {
+    const fetchMock = vi.fn(); vi.stubGlobal("fetch", fetchMock);
+    await expect(requestJson(url, {}, timeout)).rejects.toThrow("positive finite number");
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it.each([[0.5, 1], [5000.9, 5000], [3_000_000_000, 2_147_483_647]])("normalizes timeout %s to %s", async (input, expected) => {
+    const timeout = vi.spyOn(AbortSignal, "timeout").mockReturnValue(new AbortController().signal);
+    vi.spyOn(performance, "now").mockReturnValue(0);
+    vi.stubGlobal("fetch", vi.fn(async () => new Response("{}")));
+    await expect(requestJson(url, {}, input)).resolves.toEqual({});
+    expect(timeout).toHaveBeenCalledExactlyOnceWith(expected);
+  });
+});

--- a/src/__tests__/http-metadata.test.ts
+++ b/src/__tests__/http-metadata.test.ts
@@ -79,6 +79,41 @@ describe("HTTP failure metadata", () => {
     expect(error.message).not.toContain("private cleanup reason");
   });
 
+  it.each([200, 503])("retains first cancellation if the deadline fires during HTTP %s cleanup", async status => {
+    const caller = new AbortController(), deadline = new AbortController();
+    vi.spyOn(AbortSignal, "timeout").mockReturnValue(deadline.signal);
+    let bodyRead!: () => void;
+    const ready = new Promise<void>(resolve => { bodyRead = resolve; });
+    vi.stubGlobal("fetch", vi.fn(async () => new Response(new ReadableStream({
+      pull() { bodyRead(); },
+      cancel() { deadline.abort(new DOMException("expired", "TimeoutError")); },
+    }, { highWaterMark: 0 }), { status })));
+    const operation = requestJson(url, { signal: caller.signal }).catch(error => error);
+    await ready;
+    caller.abort(new Error("private caller reason"));
+    const error = await operation as SubstackAPIError;
+    expect(error).toMatchObject(status === 200
+      ? { statusSource: "client", code: "request_cancelled" }
+      : { statusCode: 503, statusSource: "http", responseBodyIssue: "request_cancelled" });
+    expect(deadline.signal.aborted).toBe(true);
+    expect(error.message).not.toContain("private caller reason");
+  });
+
+  it("retains deadline-first classification if cancellation follows during cleanup", async () => {
+    const caller = new AbortController(), deadline = new AbortController();
+    vi.spyOn(AbortSignal, "timeout").mockReturnValue(deadline.signal);
+    let bodyRead!: () => void;
+    const ready = new Promise<void>(resolve => { bodyRead = resolve; });
+    vi.stubGlobal("fetch", vi.fn(async () => new Response(new ReadableStream({
+      pull() { bodyRead(); }, cancel() { caller.abort(); },
+    }, { highWaterMark: 0 }), { status: 503 })));
+    const operation = requestJson(url, { signal: caller.signal }).catch(error => error);
+    await ready;
+    deadline.abort(new DOMException("expired", "TimeoutError"));
+    expect(await operation).toMatchObject({ statusCode: 503, statusSource: "http", responseBodyIssue: "timeout" });
+    expect(caller.signal.aborted).toBe(true);
+  });
+
   it.each([
     new SubstackAPIError(503, "private reason", "private endpoint"),
     new ResponseError("private endpoint", "response_too_large"),

--- a/src/api/request.ts
+++ b/src/api/request.ts
@@ -76,6 +76,8 @@ async function request(url: string, options: RequestInit, timeoutMs: number, for
   const expiresAt = performance.now() + timeoutMs;
   const deadline = AbortSignal.timeout(timeoutMs);
   const signal = options.signal ? AbortSignal.any([deadline, options.signal]) : deadline;
+  // AbortSignal.any preserves the first reason even if both sources later abort.
+  const callerCancelled = () => options.signal?.aborted && signal.reason === options.signal.reason;
   try {
     signal.throwIfAborted();
     let currentUrl = url, redirects = 0;
@@ -117,7 +119,7 @@ async function request(url: string, options: RequestInit, timeoutMs: number, for
       } catch (error) {
         // A known HTTP failure takes precedence over an unread diagnostic body.
         bodyIssue = error !== signal.reason && error instanceof ResponseError && error.code === "response_too_large" ? "response_too_large"
-          : options.signal?.aborted && !deadline.aborted ? "request_cancelled"
+          : callerCancelled() ? "request_cancelled"
           : deadline.aborted || isAbortError(error) ? "timeout" : "body_read_failed";
         detail = `HTTP error received; diagnostic body unavailable (${bodyIssue}); details were discarded`;
       }
@@ -140,7 +142,7 @@ async function request(url: string, options: RequestInit, timeoutMs: number, for
     // Preserve locally classified errors across cancellation during cleanup.
     // Caller-supplied abort reasons still receive static, credential-safe text.
     if (error instanceof SubstackAPIError && error !== signal.reason) throw error;
-    if (options.signal?.aborted && !deadline.aborted) throw new ResponseError(url, "request_cancelled");
+    if (callerCancelled()) throw new ResponseError(url, "request_cancelled");
     if (deadline.aborted || isAbortError(error)) throw new TimeoutError(url, timeoutMs);
     throw error;
   }

--- a/src/api/request.ts
+++ b/src/api/request.ts
@@ -1,4 +1,4 @@
-import { extractErrorDetail, isAbortError, mapHttpStatusToError, ResponseError, TimeoutError } from "../utils/errors.js";
+import { extractErrorDetail, isAbortError, mapHttpStatusToError, ResponseError, SubstackAPIError, TimeoutError, type ResponseBodyIssue } from "../utils/errors.js";
 
 export const MAX_JSON_BYTES = 10 * 1024 * 1024;
 export const MAX_HTML_BYTES = 2 * 1024 * 1024;
@@ -71,8 +71,10 @@ function redactDetail(detail: string, options: RequestInit): string {
 
 /** One deadline through headers/body. JSON calls never follow redirects or retry. */
 async function request(url: string, options: RequestInit, timeoutMs: number, format: "json" | "text", maxBytes: number): Promise<unknown> {
+  if (!Number.isFinite(timeoutMs) || timeoutMs <= 0) throw new Error("Request timeout must be a positive finite number.");
+  timeoutMs = Math.max(1, Math.min(2_147_483_647, Math.floor(timeoutMs)));
   const expiresAt = performance.now() + timeoutMs;
-  const deadline = AbortSignal.timeout(Math.max(1, Math.min(2_147_483_647, Math.floor(timeoutMs))));
+  const deadline = AbortSignal.timeout(timeoutMs);
   const signal = options.signal ? AbortSignal.any([deadline, options.signal]) : deadline;
   try {
     signal.throwIfAborted();
@@ -108,15 +110,18 @@ async function request(url: string, options: RequestInit, timeoutMs: number, for
     }
     if (!response.ok) {
       let detail: string;
+      let bodyIssue: ResponseBodyIssue | undefined;
       try {
         const text = await readBounded(response, MAX_ERROR_BYTES, signal, url, expiresAt);
         detail = extractErrorDetail(text, "unknown error", value => redactDetail(value, options));
       } catch (error) {
-        if (!(error instanceof ResponseError) || error.code !== "response_too_large") throw error;
-        // The HTTP failure is known even when its diagnostic body is oversized.
-        detail = "Error response exceeded the byte limit; details were discarded";
+        // A known HTTP failure takes precedence over an unread diagnostic body.
+        bodyIssue = error !== signal.reason && error instanceof ResponseError && error.code === "response_too_large" ? "response_too_large"
+          : options.signal?.aborted && !deadline.aborted ? "request_cancelled"
+          : deadline.aborted || isAbortError(error) ? "timeout" : "body_read_failed";
+        detail = `HTTP error received; diagnostic body unavailable (${bodyIssue}); details were discarded`;
       }
-      throw mapHttpStatusToError(response.status, detail, url);
+      throw mapHttpStatusToError(response.status, detail, url, retryAfter(response), bodyIssue);
     }
     if (format === "json" && /(?:text\/html|application\/xhtml\+xml)/i.test(response.headers.get("content-type") ?? "")) {
       discard(response);
@@ -132,6 +137,9 @@ async function request(url: string, options: RequestInit, timeoutMs: number, for
     // known complete result rather than manufacture an uncertain write outcome.
     return value;
   } catch (error) {
+    // Preserve locally classified errors across cancellation during cleanup.
+    // Caller-supplied abort reasons still receive static, credential-safe text.
+    if (error instanceof SubstackAPIError && error !== signal.reason) throw error;
     if (options.signal?.aborted && !deadline.aborted) throw new ResponseError(url, "request_cancelled");
     if (deadline.aborted || isAbortError(error)) throw new TimeoutError(url, timeoutMs);
     throw error;

--- a/src/utils/errors.ts
+++ b/src/utils/errors.ts
@@ -1,8 +1,12 @@
+export type ResponseBodyIssue = "response_too_large" | "timeout" | "request_cancelled" | "body_read_failed";
 export class SubstackAPIError extends Error {
+  responseBodyIssue?: ResponseBodyIssue;
   constructor(
     public statusCode: number,
     message: string,
     public endpoint: string,
+    public retryAfter?: string,
+    public statusSource: "http" | "client" = "http",
   ) {
     super(`Substack API error (${statusCode}) at ${endpoint}: ${message}`);
     this.name = "SubstackAPIError";
@@ -10,16 +14,16 @@ export class SubstackAPIError extends Error {
 }
 
 export class AuthenticationError extends SubstackAPIError {
-  constructor(endpoint: string) {
-    super(401, "Session token is invalid or expired. Get a fresh token from browser DevTools > Application > Cookies > connect.sid (or substack.sid on substack.com)", endpoint);
+  constructor(endpoint: string, status = 401) {
+    super(status, "Session token is invalid or expired. Get a fresh token from browser DevTools > Application > Cookies > connect.sid (or substack.sid on substack.com)", endpoint);
     this.name = "AuthenticationError";
   }
 }
 
 /** HTTP 429 — too many requests against the Substack API. */
 export class RateLimitError extends SubstackAPIError {
-  constructor(endpoint: string, detail: string, public retryAfter?: string) {
-    super(429, "Rate limited by Substack: " + detail + ". Slow down requests and try again shortly." + (retryAfter ? ` Retry-After: ${retryAfter}.` : ""), endpoint);
+  constructor(endpoint: string, detail: string, retryAfter?: string) {
+    super(429, "Rate limited by Substack: " + detail + ". Slow down requests and try again shortly." + (retryAfter ? ` Retry-After: ${retryAfter}.` : ""), endpoint, retryAfter);
     this.name = "RateLimitError";
   }
 }
@@ -42,8 +46,8 @@ export class NotFoundError extends SubstackAPIError {
 
 /** HTTP 5xx — failure on Substack's side. */
 export class ServerError extends SubstackAPIError {
-  constructor(endpoint: string, detail: string) {
-    super(500, "Server error: " + detail + ". Substack may be having issues — try again later.", endpoint);
+  constructor(endpoint: string, detail: string, status = 500, retryAfter?: string) {
+    super(status, "Server error: " + detail + ". Substack may be having issues — try again later." + (retryAfter ? ` Retry-After: ${retryAfter}.` : ""), endpoint, retryAfter);
     this.name = "ServerError";
   }
 }
@@ -65,6 +69,8 @@ export class TimeoutError extends SubstackAPIError {
         "or behind a proxy that drops packets instead of refusing the connection. " +
         "Set SUBSTACK_REQUEST_TIMEOUT_MS to raise the limit if the publication is just slow.",
       endpoint,
+      undefined,
+      "client",
     );
     this.name = "TimeoutError";
   }
@@ -93,19 +99,23 @@ export function isAbortError(err: unknown): boolean {
 /**
  * Maps an HTTP status code + error detail string to the appropriate typed
  * error. 401/403 route to AuthenticationError with `detail` intentionally
- * discarded — AuthenticationError's constructor takes only `endpoint` so its
+ * discarded — AuthenticationError's constructor keeps static guidance so its
  * message stays the exact hardcoded cookie-refresh guidance the existing
  * tests assert on verbatim; threading `detail` through would either change
  * that message or require duplicating it. Falls back to the base
  * `SubstackAPIError` for status codes outside the mapped classes.
  */
-export function mapHttpStatusToError(status: number, detail: string, endpoint: string, retryAfter?: string): SubstackAPIError {
-  if (status === 401 || status === 403) return new AuthenticationError(endpoint);
-  if (status === 429) return new RateLimitError(endpoint, detail, retryAfter);
-  if (status === 400) return new ValidationError(endpoint, detail);
-  if (status === 404) return new NotFoundError(endpoint, detail);
-  if (status >= 500) return new ServerError(endpoint, detail);
-  return new SubstackAPIError(status, detail, endpoint);
+export function mapHttpStatusToError(status: number, detail: string, endpoint: string, retryAfter?: string, bodyIssue?: ResponseBodyIssue): SubstackAPIError {
+  let error: SubstackAPIError;
+  if (status === 401 || status === 403) error = new AuthenticationError(endpoint, status);
+  else if (status === 429) error = new RateLimitError(endpoint, detail, retryAfter);
+  else if (status === 400) error = new ValidationError(endpoint, detail);
+  else if (status === 404) error = new NotFoundError(endpoint, detail);
+  else if (status >= 500) error = new ServerError(endpoint, detail, status, retryAfter);
+  else error = new SubstackAPIError(status, detail, endpoint);
+  error.retryAfter = retryAfter;
+  error.responseBodyIssue = bodyIssue;
+  return error;
 }
 
 /**
@@ -158,7 +168,7 @@ export class ResponseError extends SubstackAPIError {
       redirect_rejected: "Redirect rejected by the request policy. Configure the publication origin that serves the requested endpoint directly.",
       request_cancelled: "Request cancelled before completion.",
     };
-    super(502, messages[code], endpoint); // Synthetic status for a client-side failure.
+    super(502, messages[code], endpoint, undefined, "client");
     this.name = "ResponseError";
   }
 }


### PR DESCRIPTION
Preserve actual upstream HTTP statuses, including 403 and 503, and validated Retry-After guidance when an error body is oversized, stalled or unreadable. Error metadata distinguishes HTTP statuses from synthetic client errors and records diagnostic-body failures; classified failures survive cancellation during cleanup without exposing caller abort reasons.

Requests never retry writes automatically. An unsuccessful response does not establish whether the originating write took effect.

Closes #76. Part of #61 and #65.

Validation: TypeScript lint, 498 core tests, seven mutation controls and installed-package checks (both commands, handshake version, 22 tools). Authenticated Claude Opus and independent Muse Spark reviews completed at ce371eccad4fb6cd14fa63c122de8cc289ebfeb8 with no blockers; all four Linux/Windows Node 22/24 CI jobs passed. Review evidence and non-blocking follow-ups are recorded in the PR comments.
