### PR TITLE
Add shared operator read commands and offline status

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and the git tag history (`v0.1.0`–`v0.5.0`).
 
 ## [Unreleased]
 
+### Added
+- Shared-handler CLI reads: `drafts list/get`, `analytics post` and `subscribers count/get`, with explicit publication selection, versioned JSON envelopes and bounded output. `drafts export` aliases the existing export command. Offline `status` reports installed version, runtime and credential-safe configuration diagnostics.
+
 ## [0.9.0] - 2026-09-08
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -81,6 +81,32 @@ Both tools require `publication` when multiple publications are configured.
 
 ### Operator diagnostics
 
+The CLI also exposes read-only workflows through the same MCP handlers:
+
+```sh
+substack-mcp status --json
+substack-mcp drafts list --limit 10 --offset 0
+substack-mcp drafts get 42
+substack-mcp drafts export 42 --format json
+substack-mcp analytics post 42
+substack-mcp subscribers count
+substack-mcp subscribers get reader@example.com
+```
+
+Add `--publication key` when multiple publications are configured. Read commands
+return `{format_version: 1, ok, command, publication, data}` as JSON; `--json` is
+accepted explicitly. Exit 0 means a completed read, 1 means a configuration,
+upstream or output failure, and 2 means invalid arguments or selection. A missing
+analytics result or subscriber is still a completed read; inspect `data`. Counts
+retain their exact/approximate/unavailable precision. Output is capped at 4 MiB
+without partial printing. Draft and subscriber output is private.
+
+`status` reports installed version, Node/platform and the same offline
+configuration diagnostics as doctor. It never opens a browser or claims a
+verified user identity. `drafts export` is an alias of the existing `export`
+command and retains its bundle/overwrite contract. Draft plan/apply also retain
+their existing output and exit codes; these aliases do not rewrap saved plans.
+
 ```sh
 substack-mcp doctor --json
 substack-mcp doctor --json --check-auth

--- a/scripts/test-package.mjs
+++ b/scripts/test-package.mjs
@@ -69,6 +69,16 @@ try {
   assert.throws(() => execFileSync(process.execPath, [cli, 'drafts', 'apply'], { env, encoding: 'utf8', timeout: 10_000, stdio: 'pipe' }), error => error.status === 2);
   const doctorEnv = { ...env, SUBSTACK_PUBLICATION_URL: 'https://example.invalid', SUBSTACK_USER_ID: '1' };
   const diagnosis = JSON.parse(execFileSync(process.execPath, [cli, 'doctor', '--json'], { env: doctorEnv, encoding: 'utf8', timeout: 10_000 }));
+  const status = JSON.parse(execFileSync(process.execPath, [cli, 'status', '--json'], { env: doctorEnv, encoding: 'utf8', timeout: 10_000 }));
+  assert.equal(status.version, pkg.version);
+  assert.equal(status.mode, 'configuration_only');
+  assert.equal(status.publications[0].authentication, 'not_checked');
+  assert.ok(!JSON.stringify(status).includes(testSessionToken));
+  assert.match(execFileSync(process.execPath, [cli, 'drafts', 'export', '--help'], { env, encoding: 'utf8', timeout: 10_000 }), /source\.json/);
+  for (const args of [['drafts', 'list', '--help'], ['analytics', '--help'], ['subscribers', '--help']]) {
+    assert.match(execFileSync(process.execPath, [cli, ...args], { env, encoding: 'utf8', timeout: 10_000 }), /Read-only JSON/);
+  }
+  assert.throws(() => execFileSync(process.execPath, [cli, 'drafts', 'get', '-1'], { env, encoding: 'utf8', timeout: 10_000, stdio: 'pipe' }), error => error.status === 2);
   assert.equal(diagnosis.ok, true);
   assert.equal(diagnosis.mode, 'configuration_only');
   assert.equal(diagnosis.publications[0].authentication, 'not_checked');

--- a/src/__tests__/operator-cli.test.ts
+++ b/src/__tests__/operator-cli.test.ts
@@ -1,0 +1,95 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { runOperator, runStatus } from "../operator-cli.js";
+import packageMetadata from "../../package.json" with { type: "json" };
+import { SubstackClient } from "../api/client.js";
+
+const credentials = { key: "example", label: "Example", publicationUrl: "https://example.substack.com", sessionToken: "synthetic-private-token", userId: "1", source: "env" as const, missing: [] };
+const io = () => ({ out: vi.fn(), error: vi.fn() });
+afterEach(() => { vi.restoreAllMocks(); vi.unstubAllGlobals(); });
+
+describe("operator read commands", () => {
+  it("reports offline status without network, browser or identity claims", async () => {
+    const fetch = vi.fn(); vi.stubGlobal("fetch", fetch);
+    const output = io(); expect(await runStatus(["--json"], () => [credentials], output)).toBe(0);
+    const result = JSON.parse(output.out.mock.calls[0][0]);
+    expect(result).toMatchObject({ format_version: 1, command: "status", version: packageMetadata.version, ok: true, mode: "configuration_only", runtime: { node: process.version, platform: process.platform } });
+    expect(result.publications[0]).toMatchObject({ publication: "example", origin: credentials.publicationUrl, credential_source: "env", authentication: "not_checked", user_identity: "not_verified" });
+    expect(JSON.stringify(result)).not.toContain(credentials.sessionToken); expect(fetch).not.toHaveBeenCalled();
+    const bad = io(); expect(await runStatus([], () => [{ ...credentials, userId: "0" }], bad)).toBe(1);
+    expect(JSON.parse(bad.out.mock.calls[0][0]).ok).toBe(false);
+  });
+  it("retains exact-email lookup controls and uses no subscriber-write endpoint", async () => {
+    const fetch = vi.fn(async (_url: string | URL | Request, _init?: RequestInit) => Response.json({ count: 1, subscribers: [{ user_email_address: "reader@example.com", subscription_id: 9, subscription_interval: "free" }] }));
+    vi.stubGlobal("fetch", fetch);
+    const output = io(); expect(await runOperator(["subscribers", "get", "Reader@Example.com"], () => [credentials], output)).toBe(0);
+    expect(fetch).toHaveBeenCalledTimes(1);
+    expect(new URL(String(fetch.mock.calls[0][0])).pathname).toBe("/api/v1/subscriber-stats");
+    expect(JSON.parse(fetch.mock.calls[0][1]!.body as string)).toEqual({ filters: { user_email_address_string_is: "reader@example.com" }, offset: 0, limit: 2 });
+    expect(JSON.parse(output.out.mock.calls[0][0]).data).toMatchObject({ email: "reader@example.com", subscriber: { subscription_id: 9 } });
+    const mismatch = io(); expect(await runOperator(["subscribers", "get", "other@example.com"], () => [credentials], mismatch)).toBe(1);
+    expect(mismatch.out).not.toHaveBeenCalled();
+  });
+  it.each([
+    ["drafts", "get", "-1"], ["drafts", "get", "1.5"], ["drafts", "get", "9007199254740992"],
+    ["drafts", "list", "--limit", "0"], ["drafts", "list", "--limit", "51"],
+    ["drafts", "list", "--offset", "-1"], ["drafts", "list", "--json", "--json"],
+    ["subscribers", "get", "bad-email"], ["subscribers", "add", "reader@example.com"],
+    ["analytics", "post", "1", "--publish"],
+  ])("rejects invalid arguments without resolving credentials: %j", async (...args) => {
+    const output = io(), load = vi.fn();
+    expect(await runOperator(args, load, output)).toBe(2);
+    expect(load).not.toHaveBeenCalled(); expect(output.out).not.toHaveBeenCalled();
+    expect(JSON.parse(output.error.mock.calls[0][0])).toMatchObject({ format_version: 1, ok: false, code: "invalid_arguments" });
+  });
+  it("shows help offline", async () => {
+    const output = io(), load = vi.fn();
+    expect(await runOperator(["analytics", "--help"], load, output)).toBe(0);
+    expect(load).not.toHaveBeenCalled(); expect(output.out.mock.calls[0][0]).toContain("subscribers count");
+  });
+  it("requires an explicit existing selector for multiple publications", async () => {
+    const fetch = vi.fn(); vi.stubGlobal("fetch", fetch);
+    const load = () => [credentials, { ...credentials, key: "second", publicationUrl: "https://second.substack.com" }];
+    for (const args of [["drafts", "list"], ["drafts", "list", "--publication", "missing"]]) {
+      const output = io(); expect(await runOperator(args, load, output)).toBe(2);
+      expect(JSON.parse(output.error.mock.calls[0][0]).code).toBe("publication_required");
+    }
+    expect(fetch).not.toHaveBeenCalled();
+  });
+  it("routes one bounded list page to the selected publication and uses the MCP projection", async () => {
+    const fetch = vi.fn(async (_url: string | URL | Request, _init?: RequestInit) => Response.json({ posts: [{ id: 42, draft_title: "Draft title", draft_body: "private body not in list", audience: "everyone" }] }));
+    vi.stubGlobal("fetch", fetch);
+    const output = io(), load = () => [credentials, { ...credentials, key: "second", publicationUrl: "https://second.substack.com" }];
+    expect(await runOperator(["drafts", "list", "--offset", "2", "--limit", "3", "--publication", "second"], load, output)).toBe(0);
+    expect(fetch).toHaveBeenCalledTimes(1);
+    const url = new URL(String(fetch.mock.calls[0][0]));
+    expect(url.origin).toBe("https://second.substack.com"); expect(url.searchParams.get("offset")).toBe("2"); expect(url.searchParams.get("limit")).toBe("3");
+    expect(JSON.parse(output.out.mock.calls[0][0])).toEqual({ format_version: 1, ok: true, command: "drafts list", publication: "second", data: [{ id: 42, title: "Draft title", audience: "everyone" }] });
+    expect(output.out.mock.calls[0][0]).not.toContain("private body");
+  });
+  it("returns full draft data through the shared handler", async () => {
+    const read = vi.spyOn(SubstackClient.prototype, "getDraft").mockResolvedValue({ id: 42, draft_title: "Title", draft_body: "Body" } as never);
+    const output = io(); expect(await runOperator(["drafts", "get", "42", "--json"], () => [credentials], output)).toBe(0);
+    expect(read).toHaveBeenCalledExactlyOnceWith(42);
+    expect(JSON.parse(output.out.mock.calls[0][0]).data).toEqual({ id: 42, title: "Title", body: "Body" });
+  });
+  it("preserves missing analytics and approximate subscriber-count semantics", async () => {
+    vi.spyOn(SubstackClient.prototype, "getPostAnalytics").mockResolvedValue(null);
+    vi.spyOn(SubstackClient.prototype, "getSubscriberCount").mockResolvedValue({ count: 1000, precision: "approximate" } as never);
+    const analytics = io(); expect(await runOperator(["analytics", "post", "42"], () => [credentials], analytics)).toBe(0);
+    expect(JSON.parse(analytics.out.mock.calls[0][0]).data).toMatchObject({ found: false, post_id: 42 });
+    const count = io(); expect(await runOperator(["subscribers", "count"], () => [credentials], count)).toBe(0);
+    expect(JSON.parse(count.out.mock.calls[0][0]).data).toEqual({ count: 1000, precision: "approximate" });
+  });
+  it("does not print upstream errors or credential values", async () => {
+    vi.spyOn(SubstackClient.prototype, "getDraft").mockRejectedValue(new Error("synthetic-private-token private-body-marker"));
+    const output = io(); expect(await runOperator(["drafts", "get", "42"], () => [credentials], output)).toBe(1);
+    expect(output.out).not.toHaveBeenCalled();
+    expect(JSON.parse(output.error.mock.calls[0][0]).code).toBe("read_failed");
+    expect(output.error.mock.calls[0][0]).not.toMatch(/synthetic-private-token|private-body-marker/);
+  });
+  it("rejects oversized output without printing a partial private result", async () => {
+    vi.spyOn(SubstackClient.prototype, "getDraft").mockResolvedValue({ id: 42, draft_body: "x".repeat(4 * 1024 * 1024) } as never);
+    const output = io(); expect(await runOperator(["drafts", "get", "42"], () => [credentials], output)).toBe(1);
+    expect(output.out).not.toHaveBeenCalled();
+  });
+});

--- a/src/draft-cli.ts
+++ b/src/draft-cli.ts
@@ -4,7 +4,7 @@ import { resolvePublications } from "./auth/resolve-publications.js";
 import { SubstackClient } from "./api/client.js";
 import { planDraftUpdate, applyDraftUpdate, draftChangesInput, draftPlanOutput, DraftChangeError } from "./api/draft-changes.js";
 
-const usage = "Usage: substack-mcp drafts plan --input changes.json [--publication key]\n       substack-mcp drafts apply --input changes.json --plan plan.json [--publication key]\nplan reads only and prints a review plan as JSON. apply requires the saved plan and identical changes; it can update an unpublished draft. Inspect the plan and Substack before applying. No automatic retries. Changes JSON: draft_id plus title, subtitle, body (Markdown), audience and optional allow_unsupported. Redirect stdout to retain a plan privately.";
+const usage = "Usage: substack-mcp drafts list/get/export (run each with --help)\n       substack-mcp drafts plan --input changes.json [--publication key]\n       substack-mcp drafts apply --input changes.json --plan plan.json [--publication key]\nplan reads only and prints a review plan as JSON. apply requires the saved plan and identical changes; it can update an unpublished draft. Inspect the plan and Substack before applying. No automatic retries. Changes JSON: draft_id plus title, subtitle, body (Markdown), audience and optional allow_unsupported. Redirect stdout to retain a plan privately.";
 const MAX_INPUT_BYTES = 1024 * 1024;
 
 /** Read a bounded regular file, including a bound if it grows after stat. */

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,7 +10,7 @@ import { startHttpServer, type HttpTransportOptions } from "./transport/http.js"
  * Wire every way this process can be asked to stop to one clean shutdown.
  *
  * SIGTERM/SIGINT: nothing installs a handler by default, and the kernel ignores
- * default-disposition signals for PID 1 â€” so in a container `docker stop` waits
+ * default-disposition signals for PID 1 — so in a container `docker stop` waits
  * out its full 10s grace period and then SIGKILLs. Handling the signal
  * in-process keeps the image free of an init wrapper.
  *
@@ -19,7 +19,7 @@ import { startHttpServer, type HttpTransportOptions } from "./transport/http.js"
  * loop drains, which any still-pending request can hold open for the length
  * of its network timeout. Closing explicitly makes the ordinary shutdown
  * immediate either way. The HTTP transport has no stdin session to end, so
- * `watchStdin` is left off there â€” SIGTERM/SIGINT are its only stop signal.
+ * `watchStdin` is left off there — SIGTERM/SIGINT are its only stop signal.
  *
  * Idempotent by design: a second trigger arriving mid-shutdown is dropped, and
  * a `close()` that never settles is capped by a forced exit.
@@ -57,7 +57,7 @@ function resolveTimeoutMs(raw: string | undefined): number | undefined {
   if (raw === undefined || raw === "") return undefined;
   const parsed = Number(raw);
   if (!Number.isFinite(parsed) || parsed <= 0) {
-    console.error(`Warning: ignoring invalid SUBSTACK_REQUEST_TIMEOUT_MS="${raw}" â€” using the default.`);
+    console.error(`Warning: ignoring invalid SUBSTACK_REQUEST_TIMEOUT_MS="${raw}" — using the default.`);
     return undefined;
   }
   return parsed;
@@ -76,7 +76,7 @@ function parseList(raw: string | undefined): string[] | undefined {
 /**
  * Translate the `MCP_HTTP_*` env vars into a transport policy.
  *
- * Unset means the transport's own loopback-only defaults apply â€” the listener
+ * Unset means the transport's own loopback-only defaults apply — the listener
  * fails closed, and reaching it under any other name is an explicit act
  * (`MCP_HTTP_ALLOWED_HOSTS`), not something a default hands out.
  */
@@ -90,7 +90,7 @@ export function resolveHttpOptions(port: number, env: NodeJS.ProcessEnv = proces
     } else {
       // Same policy as SUBSTACK_REQUEST_TIMEOUT_MS: garbage warns and falls
       // back rather than silently removing the limit.
-      console.error(`Warning: ignoring invalid MCP_HTTP_MAX_BODY_BYTES="${rawMax}" â€” using the default.`);
+      console.error(`Warning: ignoring invalid MCP_HTTP_MAX_BODY_BYTES="${rawMax}" — using the default.`);
     }
   }
 
@@ -140,7 +140,7 @@ async function main() {
     const port = Number(process.env.MCP_HTTP_PORT) || 8080;
     const host = process.env.MCP_HTTP_HOST ?? "0.0.0.0";
     // Stateless: each request gets its own McpServer, so there's no single
-    // instance to close on shutdown â€” only the underlying http.Server.
+    // instance to close on shutdown — only the underlying http.Server.
     const httpServer = startHttpServer(() => createServer(publications), port, host, resolveHttpOptions(port));
     installShutdownHandlers(() => new Promise((resolve) => httpServer.close(() => resolve())), false);
   } else {

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,7 +10,7 @@ import { startHttpServer, type HttpTransportOptions } from "./transport/http.js"
  * Wire every way this process can be asked to stop to one clean shutdown.
  *
  * SIGTERM/SIGINT: nothing installs a handler by default, and the kernel ignores
- * default-disposition signals for PID 1 — so in a container `docker stop` waits
+ * default-disposition signals for PID 1 â€” so in a container `docker stop` waits
  * out its full 10s grace period and then SIGKILLs. Handling the signal
  * in-process keeps the image free of an init wrapper.
  *
@@ -19,7 +19,7 @@ import { startHttpServer, type HttpTransportOptions } from "./transport/http.js"
  * loop drains, which any still-pending request can hold open for the length
  * of its network timeout. Closing explicitly makes the ordinary shutdown
  * immediate either way. The HTTP transport has no stdin session to end, so
- * `watchStdin` is left off there — SIGTERM/SIGINT are its only stop signal.
+ * `watchStdin` is left off there â€” SIGTERM/SIGINT are its only stop signal.
  *
  * Idempotent by design: a second trigger arriving mid-shutdown is dropped, and
  * a `close()` that never settles is capped by a forced exit.
@@ -57,7 +57,7 @@ function resolveTimeoutMs(raw: string | undefined): number | undefined {
   if (raw === undefined || raw === "") return undefined;
   const parsed = Number(raw);
   if (!Number.isFinite(parsed) || parsed <= 0) {
-    console.error(`Warning: ignoring invalid SUBSTACK_REQUEST_TIMEOUT_MS="${raw}" — using the default.`);
+    console.error(`Warning: ignoring invalid SUBSTACK_REQUEST_TIMEOUT_MS="${raw}" â€” using the default.`);
     return undefined;
   }
   return parsed;
@@ -76,7 +76,7 @@ function parseList(raw: string | undefined): string[] | undefined {
 /**
  * Translate the `MCP_HTTP_*` env vars into a transport policy.
  *
- * Unset means the transport's own loopback-only defaults apply — the listener
+ * Unset means the transport's own loopback-only defaults apply â€” the listener
  * fails closed, and reaching it under any other name is an explicit act
  * (`MCP_HTTP_ALLOWED_HOSTS`), not something a default hands out.
  */
@@ -90,7 +90,7 @@ export function resolveHttpOptions(port: number, env: NodeJS.ProcessEnv = proces
     } else {
       // Same policy as SUBSTACK_REQUEST_TIMEOUT_MS: garbage warns and falls
       // back rather than silently removing the limit.
-      console.error(`Warning: ignoring invalid MCP_HTTP_MAX_BODY_BYTES="${rawMax}" — using the default.`);
+      console.error(`Warning: ignoring invalid MCP_HTTP_MAX_BODY_BYTES="${rawMax}" â€” using the default.`);
     }
   }
 
@@ -140,7 +140,7 @@ async function main() {
     const port = Number(process.env.MCP_HTTP_PORT) || 8080;
     const host = process.env.MCP_HTTP_HOST ?? "0.0.0.0";
     // Stateless: each request gets its own McpServer, so there's no single
-    // instance to close on shutdown — only the underlying http.Server.
+    // instance to close on shutdown â€” only the underlying http.Server.
     const httpServer = startHttpServer(() => createServer(publications), port, host, resolveHttpOptions(port));
     installShutdownHandlers(() => new Promise((resolve) => httpServer.close(() => resolve())), false);
   } else {
@@ -176,6 +176,21 @@ async function main() {
 
 async function run() {
   const args = process.argv.slice(2);
+  if (args[0] === "status") {
+    const { runStatus } = await import("./operator-cli.js");
+    process.exitCode = await runStatus(args.slice(1));
+    return;
+  }
+  if (["analytics", "subscribers"].includes(args[0]) || (args[0] === "drafts" && ["list", "get"].includes(args[1]))) {
+    const { runOperator } = await import("./operator-cli.js");
+    process.exitCode = await runOperator(args);
+    return;
+  }
+  if (args[0] === "drafts" && args[1] === "export") {
+    const { runExport } = await import("./export-cli.js");
+    process.exitCode = await runExport(args.slice(2));
+    return;
+  }
   if (args[0] === "drafts") {
     const { runDrafts } = await import("./draft-cli.js");
     process.exitCode = await runDrafts(args.slice(1));
@@ -191,7 +206,7 @@ async function run() {
     return runDoctor(args.slice(1));
   }
   if (args.length === 1 && ["--help", "-h"].includes(args[0])) {
-    console.log("Usage: substack-mcp [serve | doctor [--json] [--check-auth] | export <draft-id> [options] | drafts plan/apply [options]]\nWith no command, starts the MCP server. doctor checks configuration without network access; --check-auth adds a bounded read per publication. export saves Markdown and original JSON without changing Substack; run export --help. For reviewed updates, run drafts --help. Login: substack-mcp-login.");
+    console.log("Usage: substack-mcp [serve | status [--json] | doctor [--json] [--check-auth] | export <draft-id> [options] | drafts list/get/export/plan/apply [options] | analytics post <id> | subscribers count/get]\nWith no command, starts the MCP server. doctor checks configuration without network access; --check-auth adds a bounded read per publication. export saves Markdown and original JSON without changing Substack; run export --help. For reviewed updates, run drafts --help. Read commands: drafts list/get, analytics post, subscribers count/get; add --publication when needed. status is offline. Login: substack-mcp-login.");
     return;
   }
   if (args.length && !(args.length === 1 && args[0] === "serve")) {

--- a/src/operator-cli.ts
+++ b/src/operator-cli.ts
@@ -1,0 +1,94 @@
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+import { z } from "zod";
+import { createServer } from "./server.js";
+import { SubstackClient } from "./api/client.js";
+import { resolvePublications } from "./auth/resolve-publications.js";
+import { doctor } from "./doctor.js";
+import packageMetadata from "../package.json" with { type: "json" };
+
+export async function runStatus(args: string[], load = resolvePublications,
+  io = { out: (text: string) => console.log(text), error: (text: string) => console.error(text) }): Promise<number> {
+  if (args.length === 1 && ["--help", "-h"].includes(args[0])) {
+    io.out("Usage: substack-mcp status [--json]\nOffline configuration status; never launches a browser or checks remote authentication. Use doctor --json --check-auth for an opt-in authenticated read."); return 0;
+  }
+  if (args.length > 1 || (args.length === 1 && args[0] !== "--json")) {
+    io.error(JSON.stringify({ format_version: 1, ok: false, command: "status", code: "invalid_arguments", message: "Usage: substack-mcp status [--json]" })); return 2;
+  }
+  const result = await doctor(false, load);
+  io.out(JSON.stringify({ format_version: 1, command: "status", ...result, runtime: { node: process.version, platform: process.platform }, version: packageMetadata.version }));
+  return result.ok ? 0 : 1;
+}
+
+const usage = `Usage: substack-mcp drafts list [--offset n] [--limit 1-50] [--publication key]
+       substack-mcp drafts get <draft-id> [--publication key]
+       substack-mcp analytics post <post-id> [--publication key]
+       substack-mcp subscribers count [--publication key]
+       substack-mcp subscribers get <email> [--publication key]
+Read-only JSON output. --json is accepted explicitly. Pagination performs one bounded page, not an automatic full export.
+Subscriber and draft results are private; protect redirected output. Analytics uses the same bounded recent-post scan as MCP.`;
+
+function integer(value: string | undefined, minimum: number, maximum = Number.MAX_SAFE_INTEGER) {
+  if (!value || !/^\d+$/.test(value)) throw new Error("invalid argument");
+  const number = Number(value);
+  if (!Number.isSafeInteger(number) || number < minimum || number > maximum) throw new Error("invalid argument");
+  return number;
+}
+
+function parse(args: string[]) {
+  const command = args.slice(0, 2).join(" ");
+  const tools: Record<string, string> = { "drafts list": "list_drafts", "drafts get": "get_draft", "analytics post": "get_post_analytics", "subscribers count": "get_subscriber_count", "subscribers get": "get_subscriber" };
+  const tool = tools[command];
+  if (!tool) throw new Error("invalid command");
+  const input: Record<string, unknown> = {};
+  let index = 2;
+  if (command === "drafts get") input.draft_id = integer(args[index++], 1);
+  if (command === "analytics post") input.post_id = integer(args[index++], 1);
+  if (command === "subscribers get") input.email = z.string().trim().email().max(254).parse(args[index++]);
+  let publication: string | undefined;
+  const seen = new Set<string>();
+  while (index < args.length) {
+    const flag = args[index++];
+    if (seen.has(flag)) throw new Error("duplicate option");
+    seen.add(flag);
+    if (flag === "--json") continue;
+    const value = args[index++];
+    if (flag === "--publication") {
+      if (!value || value.startsWith("--") || value.length > 128) throw new Error("invalid selection");
+      publication = value;
+    } else if (command === "drafts list" && flag === "--offset") input.offset = integer(value, 0);
+    else if (command === "drafts list" && flag === "--limit") input.limit = integer(value, 1, 50);
+    else throw new Error("unknown option");
+  }
+  return { command, tool, input, publication };
+}
+
+/** Uses the real MCP handlers so projection, pagination and read semantics stay shared. */
+export async function runOperator(args: string[], load = resolvePublications,
+  io = { out: (text: string) => console.log(text), error: (text: string) => console.error(text) }): Promise<number> {
+  if (args.length >= 2 && ["--help", "-h"].includes(args.at(-1)!) && args.length <= 3) { io.out(usage); return 0; }
+  let options: ReturnType<typeof parse>;
+  try { options = parse(args); }
+  catch { io.error(JSON.stringify({ format_version: 1, ok: false, code: "invalid_arguments", message: usage })); return 2; }
+  let server: ReturnType<typeof createServer> | undefined;
+  const client = new Client({ name: "substack-operator-cli", version: "1" });
+  try {
+    const publications = load();
+    const selected = options.publication ? publications.find(p => p.key === options.publication) : publications.length === 1 ? publications[0] : undefined;
+    if (!selected) {
+      io.error(JSON.stringify({ format_version: 1, ok: false, command: options.command, code: "publication_required", message: "Select a configured --publication key; required when multiple publications are configured." })); return 2;
+    }
+    server = createServer([{ key: selected.key, label: selected.label, client: new SubstackClient(selected.publicationUrl, selected.sessionToken, selected.userId, process.env.SUBSTACK_USER_AGENT, Number(process.env.SUBSTACK_REQUEST_TIMEOUT_MS) || undefined) }]);
+    const [ct, st] = InMemoryTransport.createLinkedPair();
+    await Promise.all([client.connect(ct), server.connect(st)]);
+    const reply = await client.callTool({ name: options.tool, arguments: options.input });
+    if (reply.isError) throw new Error("read failed");
+    const content = reply.content as { type: string; text?: string }[];
+    if (content.length !== 1 || content[0].type !== "text" || !content[0].text) throw new Error("unexpected output");
+    const output = JSON.stringify({ format_version: 1, ok: true, command: options.command, publication: selected.key, data: JSON.parse(content[0].text) });
+    if (Buffer.byteLength(output, "utf8") > 4 * 1024 * 1024) throw new Error("output limit");
+    io.out(output); return 0;
+  } catch {
+    io.error(JSON.stringify({ format_version: 1, ok: false, command: options.command, code: "read_failed", message: "The read could not be completed within its response bounds. Check configuration and authentication with doctor --json --check-auth. No writes were attempted." })); return 1;
+  } finally { await client.close(); await server?.close(); }
+}


### PR DESCRIPTION
﻿Add the missing operator read commands through the existing MCP handlers: drafts list/get, analytics post and subscribers count/get. This keeps projections, count precision, exact-email filtering and bounded scans shared. Add offline status and the drafts export alias while preserving bare MCP startup and existing plan/export formats.

Read commands use a versioned JSON envelope, validate IDs/options before loading credentials, require an explicit multi-publication selector and cap output at4MiB without partial printing. Errors do not echo upstream private bodies or credentials.

Validation: lint;724 core tests passed with one local Windows symlink-privilege skip;70-file clean package install, both binaries and all24 tools;19 focused command tests. Negative controls verify the output cap and publication-selection checks. Exact-SHA reviews and CI pending.

Part of #53/#62. Named profiles, login corrections and broader1.0 contracts remain separate work; this PR does not complete those issues.
