### PR TITLE
Add explicit publication profiles and verified-read login

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and the git tag history (`v0.1.0`–`v0.5.0`).
 ## [Unreleased]
 
 ### Added
+- Explicit named session profiles, exclusive creation and legacy migration with rollback. `substack-mcp login` retains the legacy login binary, captures only publication-scoped cookies and checks authenticated read access before saving. Login requires a supplied account user ID rather than inferring one from a post byline.
 - Shared-handler CLI reads: `drafts list/get`, `analytics post` and `subscribers count/get`, with explicit publication selection, versioned JSON envelopes and bounded output. `drafts export` aliases the existing export command. Offline `status` reports installed version, runtime and credential-safe configuration diagnostics.
 
 ## [0.9.0] - 2026-09-08

--- a/README.md
+++ b/README.md
@@ -278,8 +278,16 @@ npx substack-mcp profiles migrate --name personal
 
 Keys start with a lowercase ASCII letter and contain only lowercase letters,
 digits and hyphens, up to 64 characters. Existing profiles require explicit
-`--force` to replace. List output contains keys, publication origins and save
-times; it excludes cookies and user IDs.
+`--force` to replace. List output contains keys, readability status, publication origins and file save
+times; it excludes cookies and user IDs. Unreadable profiles remain visible but
+cannot be selected. Save time records local persistence, including migration; it
+is not token issuance or expiration time. Listing is bounded to 32 profiles.
+
+Profile storage requires a local filesystem supporting hard links (such as NTFS
+or a typical Linux filesystem), so creation can install a complete encrypted file
+without overwriting an existing name. FAT/exFAT and some network mounts are not
+supported: set `SUBSTACK_MCP_HOME` to a suitable local directory. Do not use
+`--force` to work around an unsupported filesystem.
 
 Set `SUBSTACK_PROFILES=work,personal` in your MCP client's environment to select
 up to 32 distinct profiles. Remove all publication credential variables first:

--- a/README.md
+++ b/README.md
@@ -165,7 +165,7 @@ Exit codes: 0 = requested checks passed; 1 = configuration/authentication check
 failed; 2 = invalid command arguments. Without `--check-auth`, a 0 exit code
 does not mean the session is unexpired. Bare `substack-mcp` still starts the
 MCP server; `substack-mcp serve` is an explicit alias. `--help` does not connect
-to Substack. Browser login remains `substack-mcp-login`.
+to Substack. Browser login is `substack-mcp login`; `substack-mcp-login` remains an alias.
 
 ### Write (private drafts; image upload returns a public URL)
 
@@ -241,33 +241,66 @@ optional **browser login** which captures and stores them for you.
 
 ### Option A — Browser login (optional, no manual cookie copying)
 
-Removes the DevTools cookie hunt and the ~90-day re-copy. Playwright is **not**
-bundled (it's large), so install it once, then sign in:
+Install the server and optional Playwright dependency together in a local tools
+directory, then sign in:
 
 ```bash
-npm i -g playwright && npx playwright install chromium
-npx --package @conorbronsdon/substack-mcp substack-mcp-login https://yourblog.substack.com
+npm install @conorbronsdon/substack-mcp playwright
+npx playwright install chromium
+npx substack-mcp login https://yourblog.substack.com --user-id 12345
 ```
 
-A browser opens; sign in to Substack (CAPTCHA included). The tool captures your
-session cookie, auto-resolves your user id, and writes them to
-`~/.substack-mcp/session.json` (override the directory with `SUBSTACK_MCP_HOME`).
-The MCP server reads that file automatically whenever the `SUBSTACK_*` env vars
-are unset — so with browser login you can omit the `env` block entirely.
+`substack-mcp-login` remains a supported alias. Missing publication URL and user
+ID are prompted. Supply your own account's user ID; a post author's byline does
+not verify your identity. The browser opens for sign-in, including any CAPTCHA.
+Only a cookie applicable to the publication API is captured, and a bounded
+authenticated read must succeed before saving. This verifies read access, not
+the configured user ID or permission to write.
 
-**Storage & security:** the file is written `0600` and encrypted with AES-256-GCM
-under a key derived from this OS account + machine (never stored). A copied file
-is useless elsewhere and casual disk/backup reads see only ciphertext. This is
-machine-binding + obfuscation, **not** a secret vault — code running as you on
-this machine can re-derive the key (the same caveat as the plaintext env-var
-path). If you prefer, use Option B and let your MCP client handle the secret.
+Without `--profile`, login saves `~/.substack-mcp/session.json` (directory override:
+`SUBSTACK_MCP_HOME`). The server uses this legacy session when publication
+credential environment variables and `SUBSTACK_PROFILES` are unset.
+
+**Storage:** sessions use AES-256-GCM with a key derived from the OS account and
+machine. File permissions request `0600`; Windows access also depends on directory
+ACLs. This is a machine-bound file, not an OS keychain or secret vault. Code
+running as your OS user can derive the key. Use environment credentials if your
+MCP client manages secrets for you.
+
+#### Named profiles and migration
+
+```bash
+npx substack-mcp login https://yourblog.substack.com --user-id 12345 --profile work
+npx substack-mcp profiles list
+# Copy an existing legacy session without changing its file:
+npx substack-mcp profiles migrate --name personal
+```
+
+Keys start with a lowercase ASCII letter and contain only lowercase letters,
+digits and hyphens, up to 64 characters. Existing profiles require explicit
+`--force` to replace. List output contains keys, publication origins and save
+times; it excludes cookies and user IDs.
+
+Set `SUBSTACK_PROFILES=work,personal` in your MCP client's environment to select
+up to 32 distinct profiles. Remove all publication credential variables first:
+combining profile selection with legacy or named credential variables is an
+error, including empty variables. Missing, corrupt or invalid selected profiles
+stop startup; they never fall back to another account. Profiles on disk are
+never activated by discovery. With multiple profiles, tools require an explicit
+publication key and CLI reads require `--publication`.
+
+To roll back, unset `SUBSTACK_PROFILES` and restore your previous environment
+configuration. Migration preserves the legacy session byte-for-byte. These files
+use the existing encryption format; an OS keychain is not currently supported.
+Run `substack-mcp status --json` for offline configuration diagnostics or
+`substack-mcp doctor --check-auth --json` for a bounded read per selected account.
 
 ### Option B — Get your credentials manually
 
 Open your Substack in a browser, then:
 
 1. **Session token:** Navigate to your publication, open DevTools → Application → Cookies → copy the value of `connect.sid` (URL-encoded string starting with `s%3A`)
-2. **User ID:** In DevTools Console, run: `fetch('/api/v1/archive?sort=new&limit=1').then(r=>r.json()).then(d=>console.log(d[0]?.publishedBylines?.[0]?.id))`
+2. **User ID:** Use the numeric ID of your signed-in Substack account from your authenticated account data. Do not use a publication post's byline ID: publications can have multiple authors. This server does not independently verify the supplied ID.
 3. **Publication URL:** Your Substack URL, including custom domain if you have one (e.g., `https://newsletter.yourdomain.com` or `https://yourblog.substack.com`)
 
 ### 2. Configure your MCP client
@@ -341,7 +374,7 @@ With two or more publications configured, every tool gains a **required** `publi
 
 Don't mix the two styles: if any `SUBSTACK_PUB_<KEY>_*` var is set, the plain `SUBSTACK_*` vars are ignored (with a startup warning) rather than treated as an unnamed extra publication.
 
-`SUBSTACK_USER_AGENT` and `SUBSTACK_REQUEST_TIMEOUT_MS` apply to every configured publication — they are not per-publication. The browser-login flow (`substack-mcp-login`) is single-publication only; multiple publications require the env-var scheme above.
+`SUBSTACK_USER_AGENT` and `SUBSTACK_REQUEST_TIMEOUT_MS` apply to every configured publication — they are not per-publication. Browser login also supports explicit named profiles; see [Named profiles and migration](#named-profiles-and-migration).
 
 ## Token expiration
 

--- a/scripts/test-package.mjs
+++ b/scripts/test-package.mjs
@@ -67,6 +67,10 @@ try {
   assert.throws(() => execFileSync(process.execPath, [cli, 'export', '-1'], { env, encoding: 'utf8', timeout: 10_000, stdio: 'pipe' }), error => error.status === 2);
   assert.match(execFileSync(process.execPath, [cli, 'drafts', '--help'], { env, encoding: 'utf8', timeout: 10_000 }), /drafts apply/);
   assert.throws(() => execFileSync(process.execPath, [cli, 'drafts', 'apply'], { env, encoding: 'utf8', timeout: 10_000, stdio: 'pipe' }), error => error.status === 2);
+  assert.match(execFileSync(process.execPath, [cli, 'login', '--help'], { env, encoding: 'utf8', timeout: 10_000 }), /--profile/);
+  assert.match(execFileSync(process.execPath, [cli, 'profiles', '--help'], { env, encoding: 'utf8', timeout: 10_000 }), /SUBSTACK_PROFILES/);
+  assert.deepEqual(JSON.parse(execFileSync(process.execPath, [cli, 'profiles', 'list'], { env, encoding: 'utf8', timeout: 10_000 })).profiles, []);
+  assert.throws(() => execFileSync(process.execPath, [cli, 'status', '--json'], { env: { ...env, SUBSTACK_PROFILES: 'missing' }, encoding: 'utf8', timeout: 10_000, stdio: 'pipe' }), error => error.status === 1);
   const doctorEnv = { ...env, SUBSTACK_PUBLICATION_URL: 'https://example.invalid', SUBSTACK_USER_ID: '1' };
   const diagnosis = JSON.parse(execFileSync(process.execPath, [cli, 'doctor', '--json'], { env: doctorEnv, encoding: 'utf8', timeout: 10_000 }));
   const status = JSON.parse(execFileSync(process.execPath, [cli, 'status', '--json'], { env: doctorEnv, encoding: 'utf8', timeout: 10_000 }));

--- a/src/__tests__/login.test.ts
+++ b/src/__tests__/login.test.ts
@@ -45,8 +45,10 @@ describe("browser login contract", () => {
     const args = ["https://example.com", "--user-id", "43", "--profile", "work"];
     expect(await runLogin(args, f.deps)).toBe(0);
     const before = loadProfile("work");
+    f.deps.loadChromium.mockClear(); f.fetch.mockClear();
     expect(await runLogin(["https://example.com", "--user-id", "44", "--profile", "work"], f.deps)).toBe(1);
     expect(loadProfile("work")).toEqual(before);
+    expect(f.deps.loadChromium).not.toHaveBeenCalled(); expect(f.fetch).not.toHaveBeenCalled();
     expect(await runLogin(["https://example.com", "--user-id", "44", "--profile", "work", "--force"], f.deps)).toBe(0);
     expect(loadProfile("work").userId).toBe("44");
     expect(loadSession()?.userId).toBe("42");

--- a/src/__tests__/login.test.ts
+++ b/src/__tests__/login.test.ts
@@ -1,0 +1,67 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { mkdtempSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { parseLoginArguments, readSessionCookie, runLogin } from "../login.js";
+import { loadProfile } from "../auth/profiles.js";
+import { loadSession } from "../auth/session-store.js";
+let dir: string;
+beforeEach(() => { dir = mkdtempSync(join(tmpdir(), "substack-login-test-")); vi.stubEnv("SUBSTACK_MCP_HOME", dir); });
+afterEach(() => { vi.restoreAllMocks(); vi.unstubAllGlobals(); vi.unstubAllEnvs(); expect(dir.startsWith(join(tmpdir(), "substack-login-test-"))).toBe(true); rmSync(dir, { recursive: true, force: true }); });
+function fixture(publicationCookie = true, auth = true) {
+  const cookies = vi.fn(async (url: string) => url === "https://substack.com" ? [{ name: "substack.sid", value: "substack-test-token" }] : publicationCookie ? [{ name: "connect.sid", value: "publication-test-token" }] : []);
+  const goto = vi.fn(), close = vi.fn(async () => {});
+  const launch = vi.fn(async () => ({ newContext: async () => ({ cookies, newPage: async () => ({ goto }) }), close }));
+  const deps = { ask: vi.fn(async () => ""), loadChromium: vi.fn(async () => ({ launch })), out: vi.fn(), error: vi.fn() };
+  const fetch = vi.fn(async () => auth ? Response.json({ posts: [] }) : new Response("private-failure-token", { status: 403 })); vi.stubGlobal("fetch", fetch);
+  return { deps, cookies, goto, close, launch, fetch };
+}
+describe("browser login contract", () => {
+  it.each([
+    ["https://example.com/path"], ["http://example.com"], ["https://u:p@example.com"],
+    ["--user-id", "0"], ["--user-id", "1abc"], ["--profile", "../x"], ["--force"],
+    ["--user-id", "1", "--user-id", "2"], ["--unknown"],
+  ])("rejects invalid input before browser loading: %j", async (...args) => {
+    expect(() => parseLoginArguments(args)).toThrow(); const f = fixture();
+    expect(await runLogin(args, f.deps)).toBe(2); expect(f.deps.loadChromium).not.toHaveBeenCalled(); expect(f.fetch).not.toHaveBeenCalled();
+  });
+  it("prints help without loading a browser or resolving credentials", async () => {
+    const f = fixture(); expect(await runLogin(["--help"], f.deps)).toBe(0);
+    expect(f.deps.loadChromium).not.toHaveBeenCalled(); expect(f.deps.ask).not.toHaveBeenCalled(); expect(f.fetch).not.toHaveBeenCalled();
+  });
+  it("uses only a cookie scoped to the publication API and never infers a byline ID", async () => {
+    const f = fixture(); expect(await runLogin(["https://example.com", "--user-id", "42", "--profile", "work"], f.deps)).toBe(0);
+    expect(f.cookies.mock.calls.map(call => call[0])).toEqual(["https://substack.com", "https://example.com/api/v1/post_management/drafts"]);
+    expect(f.goto.mock.calls.map(call => call[0])).toEqual(["https://substack.com/sign-in", "https://example.com"]);
+    expect(loadProfile("work")).toMatchObject({ publicationUrl: "https://example.com", sessionToken: "publication-test-token", userId: "42" });
+    expect(loadSession()).toBeNull(); expect(f.fetch).toHaveBeenCalledTimes(1); expect(f.close).toHaveBeenCalledOnce();
+    const output = f.deps.out.mock.calls.map(call => call[0]).join("\n");
+    expect(output).toContain('"user_identity":"not_verified"'); expect(output).not.toContain("publication-test-token");
+  });
+  it("preserves the legacy login path and requires force to replace a named profile", async () => {
+    const f = fixture();
+    expect(await runLogin(["https://example.com", "--user-id", "42"], f.deps)).toBe(0);
+    expect(loadSession()).toMatchObject({ userId: "42", sessionToken: "publication-test-token" });
+    const args = ["https://example.com", "--user-id", "43", "--profile", "work"];
+    expect(await runLogin(args, f.deps)).toBe(0);
+    const before = loadProfile("work");
+    expect(await runLogin(["https://example.com", "--user-id", "44", "--profile", "work"], f.deps)).toBe(1);
+    expect(loadProfile("work")).toEqual(before);
+    expect(await runLogin(["https://example.com", "--user-id", "44", "--profile", "work", "--force"], f.deps)).toBe(0);
+    expect(loadProfile("work").userId).toBe("44");
+    expect(loadSession()?.userId).toBe("42");
+  });
+  it("never falls back to the general Substack cookie when the publication cookie is absent", async () => {
+    const f = fixture(false); expect(await runLogin(["https://example.com", "--user-id", "42"], f.deps)).toBe(1);
+    expect(loadSession()).toBeNull(); expect(f.fetch).not.toHaveBeenCalled(); expect(f.close).toHaveBeenCalledOnce();
+  });
+  it("requires a successful authenticated read before saving", async () => {
+    const f = fixture(true, false); expect(await runLogin(["https://example.com", "--user-id", "42"], f.deps)).toBe(1);
+    expect(loadSession()).toBeNull(); expect(JSON.stringify(f.deps.error.mock.calls)).not.toContain("private-failure-token"); expect(f.close).toHaveBeenCalledOnce();
+  });
+  it("rejects ambiguous same-name cookies", async () => {
+    const context = { cookies: vi.fn(async () => [{ name: "connect.sid", value: "one" }, { name: "connect.sid", value: "two" }]) };
+    await expect(readSessionCookie(context, "https://example.com")).rejects.toThrow("Ambiguous");
+    expect(context.cookies).toHaveBeenCalledExactlyOnceWith("https://example.com");
+  });
+});

--- a/src/__tests__/profiles.test.ts
+++ b/src/__tests__/profiles.test.ts
@@ -1,16 +1,21 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { mkdtempSync, readFileSync, writeFileSync, rmSync, readdirSync, mkdirSync } from "node:fs";
 import { join } from "node:path";
+import * as fs from "node:fs";
 import { tmpdir } from "node:os";
 import { loadProfile, saveProfile, migrateProfile, listProfiles, profileKey } from "../auth/profiles.js";
 import { loadSession, saveSession } from "../auth/session-store.js";
 import { resolvePublications } from "../auth/resolve-publications.js";
 import { runProfiles } from "../profiles-cli.js";
 
+vi.mock("node:fs", async importOriginal => {
+  const actual = await importOriginal<typeof import("node:fs")>();
+  return { ...actual, linkSync: vi.fn(actual.linkSync) };
+});
 let dir: string;
 const sample = { publicationUrl: "https://example.substack.com", sessionToken: "private-test-token", userId: "42" };
 beforeEach(() => { dir = mkdtempSync(join(tmpdir(), "substack-profile-test-")); vi.stubEnv("SUBSTACK_MCP_HOME", dir); });
-afterEach(() => { vi.unstubAllEnvs(); expect(dir.startsWith(join(tmpdir(), "substack-profile-test-"))).toBe(true); rmSync(dir, { recursive: true, force: true }); });
+afterEach(() => { vi.restoreAllMocks(); vi.unstubAllEnvs(); expect(dir.startsWith(join(tmpdir(), "substack-profile-test-"))).toBe(true); rmSync(dir, { recursive: true, force: true }); });
 describe("named profile storage", () => {
   it("round-trips encrypted profiles without changing legacy storage", () => {
     saveSession(sample); const original = readFileSync(join(dir, "session.json"));
@@ -18,7 +23,7 @@ describe("named profile storage", () => {
     expect(loadProfile("work")).toMatchObject(sample);
     expect(readFileSync(join(dir, "session.json"))).toEqual(original);
     const raw = readFileSync(join(dir, "profile-work.json"), "utf8"); expect(raw).not.toContain(sample.sessionToken); expect(raw).not.toContain(sample.publicationUrl);
-    expect(listProfiles()).toEqual([{ key: "work", origin: sample.publicationUrl, saved_at: loadProfile("work").savedAt }]);
+    expect(listProfiles()).toEqual([{ key: "work", status: "readable", origin: sample.publicationUrl, saved_at: loadProfile("work").savedAt }]);
     expect(JSON.stringify(listProfiles())).not.toContain(sample.sessionToken);
   });
   it("requires explicit replacement and preserves complete files on rejection", () => {
@@ -27,6 +32,16 @@ describe("named profile storage", () => {
     expect(() => saveProfile("work", updated)).toThrow();
     expect(readFileSync(join(dir, "profile-work.json"))).toEqual(original);
     saveProfile("work", updated, true); expect(loadProfile("work").userId).toBe("43");
+    expect(readdirSync(dir).some(name => name.endsWith(".tmp"))).toBe(false);
+  });
+  it("never overwrites a profile created after the early availability check", async () => {
+    const original = (await vi.importActual<typeof import("node:fs")>("node:fs")).linkSync;
+    vi.mocked(fs.linkSync).mockImplementationOnce((source, target) => {
+      writeFileSync(target, "concurrent-profile-bytes");
+      original(source, target);
+    });
+    expect(() => saveProfile("work", sample)).toThrow();
+    expect(readFileSync(join(dir, "profile-work.json"), "utf8")).toBe("concurrent-profile-bytes");
     expect(readdirSync(dir).some(name => name.endsWith(".tmp"))).toBe(false);
   });
   it.each(["../work", "WORK", "", "x/y", "x\\y", "x.y", "a".repeat(65), "work,other", " work"])("rejects unsafe profile key %s", key => {
@@ -40,6 +55,11 @@ describe("named profile storage", () => {
     writeFileSync(path, JSON.stringify(envelope)); expect(() => loadProfile("work")).toThrow(/no fallback/);
     writeFileSync(path, "x".repeat(128 * 1024 + 1)); expect(() => loadProfile("work")).toThrow(/no fallback/);
     mkdirSync(join(dir, "profile-directory.json")); expect(() => loadProfile("directory")).toThrow(/no fallback/);
+  });
+  it("lists healthy and unreadable profiles without activating either", () => {
+    saveProfile("work", sample); writeFileSync(join(dir, "profile-broken.json"), "invalid");
+    expect(listProfiles()).toEqual([{ key: "broken", status: "unreadable" }, { key: "work", status: "readable", origin: sample.publicationUrl, saved_at: loadProfile("work").savedAt }]);
+    expect(() => resolvePublications({ SUBSTACK_PROFILES: "broken" })).toThrow();
   });
   it("validates credentials before creating a profile", () => {
     expect(() => saveProfile("work", { ...sample, userId: "0" })).toThrow();

--- a/src/__tests__/profiles.test.ts
+++ b/src/__tests__/profiles.test.ts
@@ -1,0 +1,70 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { mkdtempSync, readFileSync, writeFileSync, rmSync, readdirSync, mkdirSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { loadProfile, saveProfile, migrateProfile, listProfiles, profileKey } from "../auth/profiles.js";
+import { loadSession, saveSession } from "../auth/session-store.js";
+import { resolvePublications } from "../auth/resolve-publications.js";
+import { runProfiles } from "../profiles-cli.js";
+
+let dir: string;
+const sample = { publicationUrl: "https://example.substack.com", sessionToken: "private-test-token", userId: "42" };
+beforeEach(() => { dir = mkdtempSync(join(tmpdir(), "substack-profile-test-")); vi.stubEnv("SUBSTACK_MCP_HOME", dir); });
+afterEach(() => { vi.unstubAllEnvs(); expect(dir.startsWith(join(tmpdir(), "substack-profile-test-"))).toBe(true); rmSync(dir, { recursive: true, force: true }); });
+describe("named profile storage", () => {
+  it("round-trips encrypted profiles without changing legacy storage", () => {
+    saveSession(sample); const original = readFileSync(join(dir, "session.json"));
+    migrateProfile("work");
+    expect(loadProfile("work")).toMatchObject(sample);
+    expect(readFileSync(join(dir, "session.json"))).toEqual(original);
+    const raw = readFileSync(join(dir, "profile-work.json"), "utf8"); expect(raw).not.toContain(sample.sessionToken); expect(raw).not.toContain(sample.publicationUrl);
+    expect(listProfiles()).toEqual([{ key: "work", origin: sample.publicationUrl, saved_at: loadProfile("work").savedAt }]);
+    expect(JSON.stringify(listProfiles())).not.toContain(sample.sessionToken);
+  });
+  it("requires explicit replacement and preserves complete files on rejection", () => {
+    saveProfile("work", sample); const original = readFileSync(join(dir, "profile-work.json"));
+    const updated = { ...sample, userId: "43" };
+    expect(() => saveProfile("work", updated)).toThrow();
+    expect(readFileSync(join(dir, "profile-work.json"))).toEqual(original);
+    saveProfile("work", updated, true); expect(loadProfile("work").userId).toBe("43");
+    expect(readdirSync(dir).some(name => name.endsWith(".tmp"))).toBe(false);
+  });
+  it.each(["../work", "WORK", "", "x/y", "x\\y", "x.y", "a".repeat(65), "work,other", " work"])("rejects unsafe profile key %s", key => {
+    expect(() => profileKey(key)).toThrow(); expect(() => saveProfile(key, sample)).toThrow(); expect(readdirSync(dir)).toEqual([]);
+  });
+  it("fails closed on missing, tampered, oversized or non-file profiles", () => {
+    expect(() => loadProfile("missing")).toThrow(/no fallback/);
+    saveProfile("work", sample);
+    const path = join(dir, "profile-work.json"), envelope = JSON.parse(readFileSync(path, "utf8"));
+    const bytes = Buffer.from(envelope.data, "base64"); bytes[0] ^= 255; envelope.data = bytes.toString("base64");
+    writeFileSync(path, JSON.stringify(envelope)); expect(() => loadProfile("work")).toThrow(/no fallback/);
+    writeFileSync(path, "x".repeat(128 * 1024 + 1)); expect(() => loadProfile("work")).toThrow(/no fallback/);
+    mkdirSync(join(dir, "profile-directory.json")); expect(() => loadProfile("directory")).toThrow(/no fallback/);
+  });
+  it("validates credentials before creating a profile", () => {
+    expect(() => saveProfile("work", { ...sample, userId: "0" })).toThrow();
+    expect(() => saveProfile("work", { ...sample, publicationUrl: "http://example.com" })).toThrow();
+    expect(readdirSync(dir)).toEqual([]);
+  });
+  it("selects profiles explicitly and can return to the untouched legacy session", () => {
+    saveSession(sample); migrateProfile("work"); saveProfile("other", { ...sample, publicationUrl: "https://other.substack.com" });
+    expect(resolvePublications({ SUBSTACK_PROFILES: "work,other" }).map(p => [p.key, p.publicationUrl])).toEqual([["work", sample.publicationUrl], ["other", "https://other.substack.com"]]);
+    expect(resolvePublications({})[0]).toMatchObject({ key: "default", ...sample }); expect(loadSession()).toMatchObject(sample);
+  });
+  it.each([
+    { SUBSTACK_PROFILES: "" }, { SUBSTACK_PROFILES: "work,work" }, { SUBSTACK_PROFILES: "work, other" },
+    { SUBSTACK_PROFILES: "missing" }, { SUBSTACK_PROFILES: "work", SUBSTACK_PUBLICATION_URL: "" },
+    { SUBSTACK_PROFILES: "work", SUBSTACK_PUB_OTHER_USER_ID: "1" },
+  ])("never falls back or combines explicit profile mode with credential env vars: %j", env => {
+    saveProfile("work", sample); const legacy = vi.fn(() => ({ ...sample, savedAt: new Date().toISOString() }));
+    expect(() => resolvePublications(env, legacy)).toThrow(); expect(legacy).not.toHaveBeenCalled();
+  });
+  it("migrates through the CLI with a credential-safe result and refuses overwrite", async () => {
+    saveSession(sample); const io = { out: vi.fn(), error: vi.fn() };
+    expect(await runProfiles(["migrate", "--name", "work"], io)).toBe(0);
+    expect(JSON.parse(io.out.mock.calls[0][0])).toMatchObject({ profile: "work", legacy_session_retained: true });
+    expect(await runProfiles(["migrate", "--name", "work"], io)).toBe(1);
+    expect(JSON.parse(io.error.mock.calls[0][0]).code).toBe("profile_exists");
+    expect(JSON.stringify(io.out.mock.calls)).not.toContain(sample.sessionToken);
+  });
+});

--- a/src/auth/profiles.ts
+++ b/src/auth/profiles.ts
@@ -1,0 +1,75 @@
+import { constants, closeSync, fstatSync, fsyncSync, linkSync, lstatSync, mkdirSync, openSync, readSync, readdirSync, renameSync, unlinkSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { randomUUID } from "node:crypto";
+import { decodeSession, encodeSession, loadSession, sessionDir, type StoredSession } from "./session-store.js";
+import { validateCredentials } from "./validate-credentials.js";
+
+const MAX_BYTES = 128 * 1024;
+export function profileKey(key: string): string {
+  if (!/^[a-z][a-z0-9-]{0,63}$/.test(key)) throw new Error("Profile keys must be lowercase ASCII letters, digits or hyphens, starting with a letter, at most 64 characters.");
+  return key;
+}
+const fileFor = (key: string) => join(sessionDir(), `profile-${profileKey(key)}.json`);
+function valid(session: StoredSession | null): StoredSession {
+  if (!session || session.sessionToken.length > 16_384 || session.publicationUrl.length > 2048 || !Number.isFinite(Date.parse(session.savedAt))) throw new Error("Invalid profile credentials.");
+  validateCredentials(session.publicationUrl, session.sessionToken, session.userId);
+  return session;
+}
+
+/** Explicit selection never falls back to another session when a profile fails. */
+export function loadProfile(key: string): StoredSession {
+  const path = fileFor(key);
+  let fd: number | undefined;
+  try {
+    if (!lstatSync(path).isFile()) throw new Error();
+    fd = openSync(path, constants.O_RDONLY | constants.O_NONBLOCK | (constants.O_NOFOLLOW ?? 0));
+    const stat = fstatSync(fd);
+    if (!stat.isFile() || stat.size > MAX_BYTES) throw new Error();
+    const bytes = Buffer.alloc(MAX_BYTES + 1); let count = 0;
+    while (count < bytes.length) {
+      const size = readSync(fd, bytes, count, bytes.length - count, null);
+      if (!size) break; count += size;
+    }
+    if (count > MAX_BYTES) throw new Error();
+    return valid(decodeSession(new TextDecoder("utf-8", { fatal: true }).decode(bytes.subarray(0, count))));
+  } catch { throw new Error(`Profile "${key}" is missing, invalid or unreadable. Recreate it; no fallback session was selected.`); }
+  finally { if (fd !== undefined) closeSync(fd); }
+}
+
+/** Complete encrypted file, exclusive by default. Existing profiles require force. */
+export function saveProfile(key: string, session: Omit<StoredSession, "savedAt">, force = false): void {
+  const target = fileFor(key);
+  valid({ ...session, savedAt: new Date().toISOString() });
+  const encoded = encodeSession(session);
+  if (Buffer.byteLength(encoded) > MAX_BYTES) throw new Error("Profile exceeds storage bounds.");
+  mkdirSync(sessionDir(), { recursive: true, mode: 0o700 });
+  const temporary = join(sessionDir(), `.profile-${randomUUID()}.tmp`);
+  let fd: number | undefined;
+  try {
+    fd = openSync(temporary, constants.O_WRONLY | constants.O_CREAT | constants.O_EXCL, 0o600);
+    writeFileSync(fd, encoded); fsyncSync(fd); closeSync(fd); fd = undefined;
+    if (force) {
+      try { if (!lstatSync(target).isFile()) throw new Error("Existing profile must be a regular file."); }
+      catch (error) { if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error; }
+      renameSync(temporary, target);
+    } else linkSync(temporary, target);
+  } finally {
+    if (fd !== undefined) closeSync(fd);
+    try { unlinkSync(temporary); } catch (error) { if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw new Error("Profile cleanup failed. Inspect local profile storage before retrying; the save may have completed."); }
+  }
+}
+
+export function migrateProfile(key: string, force = false): void {
+  profileKey(key);
+  const session = valid(loadSession());
+  saveProfile(key, session, force);
+}
+
+export function listProfiles(): { key: string; origin: string; saved_at: string }[] {
+  let names: string[];
+  try { names = readdirSync(sessionDir()); }
+  catch (error) { if ((error as NodeJS.ErrnoException).code === "ENOENT") return []; throw new Error("Profile directory is unreadable."); }
+  const keys = names.filter(name => /^profile-[a-z][a-z0-9-]{0,63}\.json$/.test(name)).map(name => name.slice(8, -5)).sort();
+  if (keys.length > 32) throw new Error("At most 32 profiles can be listed at once.");
+  return keys.map(key => { const session = loadProfile(key); return { key, origin: new URL(session.publicationUrl).origin, saved_at: session.savedAt }; });
+}

--- a/src/auth/profiles.ts
+++ b/src/auth/profiles.ts
@@ -32,13 +32,23 @@ export function loadProfile(key: string): StoredSession {
     }
     if (count > MAX_BYTES) throw new Error();
     return valid(decodeSession(new TextDecoder("utf-8", { fatal: true }).decode(bytes.subarray(0, count))));
-  } catch { throw new Error(`Profile "${key}" is missing, invalid or unreadable. Recreate it; no fallback session was selected.`); }
+  } catch { throw new Error(`Profile "${key}" is missing, invalid or unreadable. Check local storage and permissions; no fallback session was selected.`); }
   finally { if (fd !== undefined) closeSync(fd); }
+}
+
+/** Early usability check only; exclusive creation still enforces the race boundary. */
+export function assertProfileAvailable(key: string, force = false): void {
+  try {
+    const stat = lstatSync(fileFor(key));
+    if (!force) throw Object.assign(new Error("Profile already exists; choose another key or use --force."), { code: "EEXIST" });
+    if (!stat.isFile()) throw new Error("Existing profile must be a regular file.");
+  } catch (error) { if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error; }
 }
 
 /** Complete encrypted file, exclusive by default. Existing profiles require force. */
 export function saveProfile(key: string, session: Omit<StoredSession, "savedAt">, force = false): void {
   const target = fileFor(key);
+  assertProfileAvailable(key, force);
   valid({ ...session, savedAt: new Date().toISOString() });
   const encoded = encodeSession(session);
   if (Buffer.byteLength(encoded) > MAX_BYTES) throw new Error("Profile exceeds storage bounds.");
@@ -65,11 +75,14 @@ export function migrateProfile(key: string, force = false): void {
   saveProfile(key, session, force);
 }
 
-export function listProfiles(): { key: string; origin: string; saved_at: string }[] {
+export function listProfiles(): { key: string; status: "readable" | "unreadable"; origin?: string; saved_at?: string }[] {
   let names: string[];
   try { names = readdirSync(sessionDir()); }
   catch (error) { if ((error as NodeJS.ErrnoException).code === "ENOENT") return []; throw new Error("Profile directory is unreadable."); }
   const keys = names.filter(name => /^profile-[a-z][a-z0-9-]{0,63}\.json$/.test(name)).map(name => name.slice(8, -5)).sort();
   if (keys.length > 32) throw new Error("At most 32 profiles can be listed at once.");
-  return keys.map(key => { const session = loadProfile(key); return { key, origin: new URL(session.publicationUrl).origin, saved_at: session.savedAt }; });
+  return keys.map(key => {
+    try { const session = loadProfile(key); return { key, status: "readable" as const, origin: new URL(session.publicationUrl).origin, saved_at: session.savedAt }; }
+    catch { return { key, status: "unreadable" as const }; }
+  });
 }

--- a/src/auth/resolve-publications.ts
+++ b/src/auth/resolve-publications.ts
@@ -39,8 +39,9 @@
  * pair one publication's URL with another's session cookie, per field, in
  * whatever order the environment happens to enumerate.
  *
- * Browser-login sessions stay out of scope for named publications: only the
- * single-publication fallback above can ever pull from a stored session.
+ * SUBSTACK_PROFILES explicitly selects stored named sessions and rejects any
+ * simultaneous publication credential variables. Missing or invalid selected
+ * profiles fail closed; stored profiles are never activated by discovery.
  */
 import { resolveCredentials, type ResolvedCredentials } from "./resolve-credentials.js";
 import { loadSession, type StoredSession } from "./session-store.js";

--- a/src/auth/resolve-publications.ts
+++ b/src/auth/resolve-publications.ts
@@ -44,6 +44,7 @@
  */
 import { resolveCredentials, type ResolvedCredentials } from "./resolve-credentials.js";
 import { loadSession, type StoredSession } from "./session-store.js";
+import { loadProfile, profileKey } from "./profiles.js";
 
 export interface PublicationCredentials {
   /** Tool-facing `publication` enum value, e.g. "kevin-muldoon". Never surfaced when only one publication is configured. */
@@ -106,7 +107,17 @@ function labelFromKey(key: string): string {
 export function resolvePublications(
   env: NodeJS.ProcessEnv = process.env,
   loader: () => StoredSession | null = loadSession,
+  profileLoader: (key: string) => StoredSession = loadProfile,
 ): PublicationCredentials[] {
+  if (env.SUBSTACK_PROFILES !== undefined) {
+    const keys = env.SUBSTACK_PROFILES.split(",");
+    if (keys.length > 32 || new Set(keys).size !== keys.length) throw new Error("Select at most 32 distinct profile keys.");
+    keys.forEach(profileKey);
+    if (Object.keys(env).some(key => PUB_PREFIX_RE.test(key) || ["SUBSTACK_PUBLICATION_URL", "SUBSTACK_SESSION_TOKEN", "SUBSTACK_USER_ID"].includes(key))) {
+      throw new Error("SUBSTACK_PROFILES cannot be combined with publication credential environment variables. Choose one configuration source.");
+    }
+    return keys.map(key => ({ key, label: labelFromKey(key), ...profileLoader(key), source: "stored" as const, missing: [] }));
+  }
   const groups = new Map<string, Group>();
   const malformed: string[] = [];
 

--- a/src/auth/session-store.ts
+++ b/src/auth/session-store.ts
@@ -70,11 +70,8 @@ function deriveKey(salt: Buffer): Buffer {
   return scryptSync(identity, salt, 32);
 }
 
-/** Encrypt and write the session `0600`. Returns the file path. */
-export function saveSession(session: Omit<StoredSession, "savedAt">): string {
-  const dir = sessionDir();
-  mkdirSync(dir, { recursive: true });
-
+/** Existing machine-bound format, shared by legacy sessions and named profiles. */
+export function encodeSession(session: Omit<StoredSession, "savedAt">): string {
   const salt = randomBytes(16);
   const iv = randomBytes(12);
   const key = deriveKey(salt);
@@ -99,8 +96,14 @@ export function saveSession(session: Omit<StoredSession, "savedAt">): string {
     data: data.toString("base64"),
   };
 
+  return JSON.stringify(envelope);
+}
+
+/** Encrypt and write the session `0600`. Returns the file path. */
+export function saveSession(session: Omit<StoredSession, "savedAt">): string {
+  mkdirSync(sessionDir(), { recursive: true });
   const file = sessionFile();
-  writeFileSync(file, JSON.stringify(envelope), { mode: 0o600 });
+  writeFileSync(file, encodeSession(session), { mode: 0o600 });
   // writeFileSync's mode is ignored if the file already existed; force it.
   try {
     chmodSync(file, 0o600);
@@ -119,9 +122,12 @@ export function saveSession(session: Omit<StoredSession, "savedAt">): string {
 export function loadSession(): StoredSession | null {
   const file = sessionFile();
   if (!existsSync(file)) return null;
+  try { return decodeSession(readFileSync(file, "utf8")); } catch { return null; }
+}
 
+export function decodeSession(text: string): StoredSession | null {
   try {
-    const envelope = JSON.parse(readFileSync(file, "utf8")) as Envelope;
+    const envelope = JSON.parse(text) as Envelope;
     if (envelope.v !== 1) return null;
 
     const salt = Buffer.from(envelope.salt, "base64");

--- a/src/doctor.ts
+++ b/src/doctor.ts
@@ -6,7 +6,7 @@ import { publicationOrigin, validateCredentials } from "./auth/validate-credenti
 export async function doctor(checkAuth = false, resolve = resolvePublications) {
   let publications: ReturnType<typeof resolvePublications>;
   try { publications = resolve(); }
-  catch { return { ok: false, code: "invalid_configuration", publications: [], guidance: "Check named publication triplets and duplicate publication keys. No credential values are printed." }; }
+  catch { return { ok: false, code: "invalid_configuration", publications: [], guidance: "Check publication triplets, duplicate keys and selected profiles. SUBSTACK_PROFILES cannot be combined with publication credential variables. No credential values are printed." }; }
   const reports = [];
   for (const p of publications) {
     const origin = publicationOrigin(p.publicationUrl);
@@ -38,7 +38,7 @@ export async function doctor(checkAuth = false, resolve = resolvePublications) {
   }
   return { ok: reports.every(p => p.configuration === "valid" && (!checkAuth || p.authentication === "authenticated_read_succeeded")),
     mode: checkAuth ? "authenticated_read" : "configuration_only", publications: reports,
-    guidance: "Use an HTTPS publication origin and a positive numeric user ID. For expired sessions run substack-mcp-login. Authenticated reads do not verify the configured user ID or write permissions." };
+    guidance: "Use an HTTPS publication origin and a positive numeric user ID. For expired sessions run substack-mcp login; use --profile for a named session. Authenticated reads do not verify the configured user ID or write permissions." };
 }
 
 export async function runDoctor(args: string[]) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -176,6 +176,11 @@ async function main() {
 
 async function run() {
   const args = process.argv.slice(2);
+  if (args[0] === "login") {
+    const { runLogin } = await import("./login.js");
+    process.exitCode = await runLogin(args.slice(1));
+    return;
+  }
   if (args[0] === "profiles") {
     const { runProfiles } = await import("./profiles-cli.js");
     process.exitCode = await runProfiles(args.slice(1));
@@ -211,7 +216,7 @@ async function run() {
     return runDoctor(args.slice(1));
   }
   if (args.length === 1 && ["--help", "-h"].includes(args[0])) {
-    console.log("Usage: substack-mcp [serve | status [--json] | doctor [--json] [--check-auth] | export <draft-id> [options] | drafts list/get/export/plan/apply [options] | analytics post <id> | subscribers count/get]\nWith no command, starts the MCP server. doctor checks configuration without network access; --check-auth adds a bounded read per publication. export saves Markdown and original JSON without changing Substack; run export --help. For reviewed updates, run drafts --help. Read commands: drafts list/get, analytics post, subscribers count/get; add --publication when needed. status is offline. Login: substack-mcp-login.");
+    console.log("Usage: substack-mcp [serve | login [options] | profiles list/migrate [options] | status [--json] | doctor [--json] [--check-auth] | export <draft-id> [options] | drafts list/get/export/plan/apply [options] | analytics post <id> | subscribers count/get]\nWith no command, starts the MCP server. doctor checks configuration without network access; --check-auth adds a bounded read per publication. export saves Markdown and original JSON without changing Substack; run export --help. For reviewed updates, run drafts --help. Read commands: drafts list/get, analytics post, subscribers count/get; add --publication when needed. status is offline. Login: substack-mcp login (substack-mcp-login remains an alias). Named sessions: profiles --help.");
     return;
   }
   if (args.length && !(args.length === 1 && args[0] === "serve")) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -176,6 +176,11 @@ async function main() {
 
 async function run() {
   const args = process.argv.slice(2);
+  if (args[0] === "profiles") {
+    const { runProfiles } = await import("./profiles-cli.js");
+    process.exitCode = await runProfiles(args.slice(1));
+    return;
+  }
   if (args[0] === "drafts") {
     const { runDrafts } = await import("./draft-cli.js");
     process.exitCode = await runDrafts(args.slice(1));

--- a/src/login.ts
+++ b/src/login.ts
@@ -4,7 +4,7 @@ import { createInterface } from "node:readline/promises";
 import { stdin, stdout } from "node:process";
 import { pathToFileURL } from "node:url";
 import { saveSession } from "./auth/session-store.js";
-import { profileKey, saveProfile } from "./auth/profiles.js";
+import { profileKey, saveProfile, assertProfileAvailable } from "./auth/profiles.js";
 import { publicationOrigin, validateCredentials } from "./auth/validate-credentials.js";
 import { doctor } from "./doctor.js";
 
@@ -56,6 +56,10 @@ export async function runLogin(args: string[], deps = defaults): Promise<number>
   if (args.length === 1 && ["--help", "-h"].includes(args[0])) { deps.out(usage); return 0; }
   let options: ReturnType<typeof parseLoginArguments>;
   try { options = parseLoginArguments(args); } catch { deps.error(usage); return 2; }
+  if (options.profile) {
+    try { assertProfileAvailable(options.profile, options.force); }
+    catch { deps.error("Profile already exists or cannot be replaced. Choose another key, inspect storage, or explicitly use --force for an existing regular profile."); return 1; }
+  }
   let browser: LoginBrowser | undefined;
   try {
     const publicationUrl = options.publicationUrl ?? publicationOrigin(await deps.ask("Publication HTTPS origin: "));

--- a/src/login.ts
+++ b/src/login.ts
@@ -1,153 +1,96 @@
 #!/usr/bin/env node
-/**
- * `substack-mcp-login` — a one-time browser login that captures your Substack
- * session and stores it locally (encrypted, machine-bound) so the MCP server
- * can run without pasting a session token into your client config.
- *
- * Playwright is NOT a dependency of this package (it is large and downloads
- * browsers). It is imported lazily and indirectly below; if it isn't
- * installed, this prints install instructions and exits. This keeps
- * `npx @conorbronsdon/substack-mcp` small for the common env-var path.
- *
- * NOTE: The browser-automation portion talks to Substack's live login UI,
- * which changes over time and can present a CAPTCHA. It cannot be covered by
- * automated tests. The encrypted store and credential resolution it feeds ARE
- * unit-tested (see src/__tests__).
- */
+/** Browser login is interactive; the legacy binary remains a supported alias. */
 import { createInterface } from "node:readline/promises";
 import { stdin, stdout } from "node:process";
+import { pathToFileURL } from "node:url";
 import { saveSession } from "./auth/session-store.js";
+import { profileKey, saveProfile } from "./auth/profiles.js";
+import { publicationOrigin, validateCredentials } from "./auth/validate-credentials.js";
+import { doctor } from "./doctor.js";
 
-const SESSION_COOKIE_NAMES = ["connect.sid", "substack.sid"];
-const LOGIN_TIMEOUT_MS = 5 * 60 * 1000;
+const usage = "Usage: substack-mcp-login [publication-url] [--user-id id] [--profile key] [--force]\nAlias: substack-mcp login [same options]\nInteractive browser sign-in. Missing URL/user ID are prompted. User ID must be your own configured Substack ID; a post byline is not identity verification. --profile stores a named session; existing profiles require --force. Requires Playwright. --help is offline.";
+const COOKIE_NAMES = ["connect.sid", "substack.sid"];
+interface CookieContext { cookies(url: string): Promise<{ name: string; value: string }[]> }
+interface LoginBrowser { newContext(): Promise<CookieContext & { newPage(): Promise<{ goto(url: string, options?: { waitUntil: "domcontentloaded" }): Promise<unknown> }> }>; close(): Promise<void> }
+interface Chromium { launch(options: { headless: boolean }): Promise<LoginBrowser> }
 
+export function parseLoginArguments(args: string[]) {
+  let publicationUrl: string | undefined, userId: string | undefined, profile: string | undefined;
+  let force = false;
+  const seen = new Set<string>();
+  for (let i = 0; i < args.length; i++) {
+    const arg = args[i];
+    if (!arg.startsWith("--") && i === 0) { publicationUrl = publicationOrigin(arg) ?? undefined; if (!publicationUrl) throw new Error("Invalid publication URL."); continue; }
+    if (seen.has(arg)) throw new Error("Duplicate login option."); seen.add(arg);
+    if (arg === "--force") { force = true; continue; }
+    if (!["--user-id", "--profile"].includes(arg) || !args[i + 1]) throw new Error("Unknown or incomplete login option.");
+    const value = args[++i];
+    if (arg === "--profile") profile = profileKey(value);
+    else { validateCredentials("https://example.invalid", "validation-only", value); userId = value; }
+  }
+  if (force && !profile) throw new Error("--force requires --profile.");
+  return { publicationUrl, userId, profile, force };
+}
+
+/** Only inspect cookies that apply to the requested URL; never pick another host's session. */
+export async function readSessionCookie(context: CookieContext, url: string): Promise<string> {
+  const cookies = await context.cookies(url);
+  for (const name of COOKIE_NAMES) {
+    const values = [...new Set(cookies.filter(c => c.name === name && c.value).map(c => c.value))];
+    if (values.length > 1) throw new Error("Ambiguous session cookies; sign in with a fresh browser context.");
+    if (values.length === 1) return values[0];
+  }
+  return "";
+}
 async function ask(question: string): Promise<string> {
   const rl = createInterface({ input: stdin, output: stdout });
-  try {
-    return (await rl.question(question)).trim();
-  } finally {
-    rl.close();
-  }
+  try { return (await rl.question(question)).trim(); } finally { rl.close(); }
 }
-
-/** Read the first present Substack session cookie from the browser context. */
-async function readSessionCookie(context: any): Promise<string> {
-  const cookies = await context.cookies();
-  for (const name of SESSION_COOKIE_NAMES) {
-    const hit = cookies.find((c: any) => c.name === name && c.value);
-    if (hit) return hit.value;
-  }
-  return "";
+async function loadChromium(): Promise<Chromium> {
+  const moduleName = "playwright";
+  try { return (await import(moduleName)).chromium; }
+  catch { throw new Error("Install the package and Playwright together in a local tools directory: npm install @conorbronsdon/substack-mcp playwright; then npx playwright install chromium; then npx substack-mcp login."); }
 }
-
-/** Poll the context until a session cookie appears or the timeout elapses. */
-async function waitForSessionCookie(context: any): Promise<string> {
-  const deadline = Date.now() + LOGIN_TIMEOUT_MS;
-  while (Date.now() < deadline) {
-    const token = await readSessionCookie(context);
-    if (token) return token;
-    await new Promise((r) => setTimeout(r, 1500));
-  }
-  return "";
-}
-
-async function main(): Promise<void> {
-  if (process.argv.includes("--help") || process.argv.includes("-h")) {
-    console.log("Usage: substack-mcp-login [publication-url]\nOpens a browser to sign in and stores a local session. Requires Playwright.");
-    return;
-  }
-  console.log("substack-mcp browser login\n");
-
-  // Lazy + indirect import so tsc never needs the playwright types and the
-  // package never hard-depends on it.
-  let chromium: any;
+const defaults = { ask, loadChromium, out: (text: string) => console.log(text), error: (text: string) => console.error(text) };
+export async function runLogin(args: string[], deps = defaults): Promise<number> {
+  if (args.length === 1 && ["--help", "-h"].includes(args[0])) { deps.out(usage); return 0; }
+  let options: ReturnType<typeof parseLoginArguments>;
+  try { options = parseLoginArguments(args); } catch { deps.error(usage); return 2; }
+  let browser: LoginBrowser | undefined;
   try {
-    const moduleName = "playwright";
-    ({ chromium } = await import(moduleName));
-  } catch {
-    console.error(
-      "This login flow needs Playwright, which is not bundled with substack-mcp.\n" +
-        "Install it once, then re-run:\n\n" +
-        "  npm i -g playwright && npx playwright install chromium\n" +
-        "  npx --package @conorbronsdon/substack-mcp substack-mcp-login\n",
-    );
-    process.exit(1);
-    return;
-  }
-
-  const publicationUrl = (
-    process.argv[2] ||
-    (await ask("Publication URL (e.g. https://yourblog.substack.com): "))
-  ).replace(/\/+$/, "");
-
-  if (!/^https?:\/\//.test(publicationUrl)) {
-    console.error("That doesn't look like a URL (needs http/https). Aborting.");
-    process.exit(1);
-    return;
-  }
-
-  const browser = await chromium.launch({ headless: false });
-  try {
-    const context = await browser.newContext();
-    const page = await context.newPage();
-
-    console.log(
-      "\nA browser window opened. Sign in to Substack there (including any CAPTCHA).",
-    );
-    console.log("Waiting for sign-in to complete (up to 5 minutes)...\n");
+    const publicationUrl = options.publicationUrl ?? publicationOrigin(await deps.ask("Publication HTTPS origin: "));
+    const userId = options.userId ?? await deps.ask("Your Substack user ID (not a publication author's byline ID): ");
+    if (!publicationUrl) { deps.error("Use a direct HTTPS publication origin."); return 2; }
+    try { validateCredentials(publicationUrl, "validation-only", userId); } catch { deps.error("Use your positive numeric Substack user ID."); return 2; }
+    let chromium: Chromium;
+    try { chromium = await deps.loadChromium(); } catch { deps.error("Browser login needs Playwright. In a local tools directory run npm install @conorbronsdon/substack-mcp playwright, then npx playwright install chromium, then npx substack-mcp login."); return 1; }
+    browser = await chromium.launch({ headless: false });
+    const context = await browser.newContext(), page = await context.newPage();
+    deps.out("Sign in to Substack in the opened browser, including any CAPTCHA. Waiting up to five minutes.");
     await page.goto("https://substack.com/sign-in");
-
-    const token = await waitForSessionCookie(context);
-    if (!token) {
-      // Throw (don't exit here) so the finally below closes the browser first.
-      throw new Error("Timed out waiting for sign-in. Nothing was saved.");
+    const deadline = Date.now() + 5 * 60 * 1000;
+    while (!(await readSessionCookie(context, "https://substack.com"))) {
+      if (Date.now() >= deadline) throw new Error("Login timed out.");
+      await new Promise(resolve => setTimeout(resolve, 1500));
     }
-
-    console.log("Signed in. Resolving your user id from the publication...");
     await page.goto(publicationUrl, { waitUntil: "domcontentloaded" });
-    const userId: string = await page.evaluate(async () => {
-      try {
-        const res = await fetch("/api/v1/archive?sort=new&limit=1", {
-          credentials: "include",
-        });
-        const data = await res.json();
-        return String(data?.[0]?.publishedBylines?.[0]?.id ?? "");
-      } catch {
-        return "";
-      }
-    });
-
-    // Prefer the cookie as seen in the publication's own context (custom
-    // domains use connect.sid); fall back to the substack.com one.
-    const publicationToken = (await readSessionCookie(context)) || token;
-
-    if (!userId) {
-      // Throw (don't exit here) so the finally below closes the browser first.
-      throw new Error(
-        "Signed in, but could not auto-resolve your user id from " +
-          `${publicationUrl}. Find it via DevTools (see the README) and set ` +
-          "SUBSTACK_USER_ID manually, or re-run with the correct publication URL.",
-      );
-    }
-
-    const file = saveSession({
-      publicationUrl,
-      sessionToken: publicationToken,
-      userId,
-    });
-
-    console.log(
-      `\nSaved. Credentials stored (encrypted, machine-bound) at:\n  ${file}\n`,
-    );
-    console.log(
-      "substack-mcp will now use these automatically when SUBSTACK_* env vars are unset.",
-    );
+    const sessionToken = await readSessionCookie(context, `${publicationUrl}/api/v1/post_management/drafts`);
+    validateCredentials(publicationUrl, sessionToken, userId);
+    const credentials = { publicationUrl, sessionToken, userId };
+    const check = await doctor(true, () => [{ ...credentials, key: options.profile ?? "default", label: "login", source: "stored", missing: [] }]);
+    if (!check.ok) throw new Error("Authenticated read did not succeed.");
+    if (options.profile) saveProfile(options.profile, credentials, options.force);
+    else saveSession(credentials);
+    deps.out(JSON.stringify({ format_version: 1, ok: true, command: "login", profile: options.profile ?? null, authentication: "authenticated_read_succeeded", user_identity: "not_verified", storage: "machine_bound_file" }));
+    deps.out(options.profile ? `Select this profile with SUBSTACK_PROFILES=${options.profile}. Remove publication credential env vars first.` : "Stored legacy session is used when publication credential env vars are unset.");
+    return 0;
+  } catch {
+    deps.error("Login or local saving failed. Check sign-in, publication access, your configured user ID and profile overwrite choice. Inspect local status before retrying; user identity is not independently verified."); return 1;
   } finally {
-    await browser.close();
+    try { await browser?.close(); }
+    catch { deps.error("Browser cleanup failed. Close the login window manually; inspect local status to confirm whether saving completed."); }
   }
 }
-
-main().catch((err) => {
-  console.error("Login failed:", err instanceof Error ? err.message : err);
-  process.exit(1);
-});
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  runLogin(process.argv.slice(2)).then(code => { process.exitCode = code; }).catch(() => { console.error("Login failed."); process.exitCode = 1; });
+}

--- a/src/profiles-cli.ts
+++ b/src/profiles-cli.ts
@@ -1,0 +1,22 @@
+import { listProfiles, migrateProfile, profileKey } from "./auth/profiles.js";
+
+const usage = "Usage: substack-mcp profiles list\n       substack-mcp profiles migrate --name key [--force]\nCopies the legacy stored session into a named profile without modifying session.json. Existing profiles require --force. To use profiles set SUBSTACK_PROFILES=key or a comma-separated list, removing publication credential env vars. Unset SUBSTACK_PROFILES to return to legacy configuration. Storage is encrypted and machine-bound, not an OS keychain or secret vault.";
+
+export async function runProfiles(args: string[], io = { out: (text: string) => console.log(text), error: (text: string) => console.error(text) }): Promise<number> {
+  if (args.length === 1 && ["--help", "-h"].includes(args[0])) { io.out(usage); return 0; }
+  const list = args.length === 1 && args[0] === "list";
+  const migrate = args[0] === "migrate" && args[1] === "--name" && (args.length === 3 || (args.length === 4 && args[3] === "--force"));
+  if (!list && !migrate) { io.error(JSON.stringify({ format_version: 1, ok: false, code: "invalid_arguments", message: usage })); return 2; }
+  if (migrate) {
+    try { profileKey(args[2]); } catch { io.error(JSON.stringify({ format_version: 1, ok: false, code: "invalid_profile_key", message: "Use a lowercase letter followed by letters, digits or hyphens; at most 64 characters." })); return 2; }
+  }
+  try {
+    if (list) io.out(JSON.stringify({ format_version: 1, ok: true, command: "profiles list", profiles: listProfiles() }));
+    else { migrateProfile(args[2], args.includes("--force")); io.out(JSON.stringify({ format_version: 1, ok: true, command: "profiles migrate", profile: args[2], legacy_session_retained: true })); }
+    return 0;
+  } catch (error) {
+    const exists = (error as NodeJS.ErrnoException).code === "EEXIST";
+    io.error(JSON.stringify({ format_version: 1, ok: false, code: exists ? "profile_exists" : "profile_operation_failed", message: exists ? "Profile already exists. Choose another name or explicitly use --force." : "Profile operation failed. Check local storage and legacy credentials; inspect saved profiles before retrying. The legacy session was not modified." }));
+    return 1;
+  }
+}


### PR DESCRIPTION
Named sessions now require explicit selection, so a missing or invalid profile cannot silently route a request to another account. Adds profile login/list/migration, exclusive creation with explicit replacement, and rollback to the untouched legacy session. The existing login binary remains an alias; login uses publication-scoped cookies and an authenticated read before saving, and requires the configured account ID instead of inferring it from a post byline.

Part of #53 and #62. Machine-bound file storage remains explicitly documented as distinct from an OS keychain. Browser interaction has fixture coverage; a live browser login is not claimed.

Validation: lint; 760 tests passed, one Windows-specific skip; installed tarball smoke (74 files, both binaries, all 24 tools); sample workflow; authentication-bypass and overwrite mutation controls. Exact-commit external reviews in progress.
