### PR TITLE
Verify and publish versioned container releases

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,7 @@
+**
+!Dockerfile
+!package.json
+!package-lock.json
+!tsconfig.json
+!src/
+!src/**

--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -1,0 +1,28 @@
+name: Container
+
+on:
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  container:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: 22
+          cache: npm
+      - run: npm ci --ignore-scripts
+      - name: Build versioned image
+        run: |
+          VERSION=$(node -p "require('./package.json').version")
+          REVISION=$(git rev-parse HEAD)
+          docker build --build-arg VERSION="$VERSION" --build-arg REVISION="$REVISION" -t substack-mcp:check .
+      - name: Verify image ownership and both transports
+        run: node scripts/test-container.mjs substack-mcp:check "$(git rev-parse HEAD)"

--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -26,3 +26,9 @@ jobs:
           docker build --build-arg VERSION="$VERSION" --build-arg REVISION="$REVISION" -t substack-mcp:check .
       - name: Verify image ownership and both transports
         run: node scripts/test-container.mjs substack-mcp:check "$(git rev-parse HEAD)"
+      - name: Reject an image with the wrong source identity
+        run: |
+          if node scripts/test-container.mjs substack-mcp:check 0000000000000000000000000000000000000000; then
+            echo "Identity control incorrectly accepted a mismatched source revision"
+            exit 1
+          fi

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -120,7 +120,7 @@ jobs:
         env:
           RELEASE_TARGET: ${{ steps.registry.outputs.target }}
         run: |
-          if git cat-file -e "$RELEASE_TARGET:scripts/test-container.mjs"; then
+          if git cat-file -e "$RELEASE_TARGET:scripts/test-container.mjs" && git cat-file -e "$RELEASE_TARGET:scripts/publish-container.mjs" && git cat-file -e "$RELEASE_TARGET:Dockerfile"; then
             echo "enabled=true" >> "$GITHUB_OUTPUT"
           else
             echo "enabled=false" >> "$GITHUB_OUTPUT"
@@ -160,8 +160,6 @@ jobs:
           REGISTRY_ACTOR: ${{ github.actor }}
         run: printf '%s' "$REGISTRY_TOKEN" | docker login ghcr.io -u "$REGISTRY_ACTOR" --password-stdin
       - name: Publish and verify versioned image
-        env:
-          GH_TOKEN: ${{ github.token }}
         run: node scripts/publish-container.mjs
       - name: Remove runner registry authentication
         if: always()

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -29,6 +29,10 @@ jobs:
     runs-on: ubuntu-latest
     if: github.ref == 'refs/heads/main' && github.repository == 'conorbronsdon/substack-mcp'
     timeout-minutes: 20
+    outputs:
+      version: ${{ steps.registry.outputs.version }}
+      target: ${{ steps.registry.outputs.target }}
+      container: ${{ steps.container.outputs.enabled }}
     env:
       GH_TOKEN: ${{ github.token }}
       RECONCILED_RELEASE_COMMIT: ${{ inputs.reconciled_commit }}
@@ -110,3 +114,55 @@ jobs:
         env:
           RELEASE_TARGET: ${{ steps.plan.outputs.target }}
         run: node scripts/release-state.mjs verify
+
+      - name: Determine original release container support
+        id: container
+        env:
+          RELEASE_TARGET: ${{ steps.registry.outputs.target }}
+        run: |
+          if git cat-file -e "$RELEASE_TARGET:scripts/test-container.mjs"; then
+            echo "enabled=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "enabled=false" >> "$GITHUB_OUTPUT"
+          fi
+
+  container:
+    needs: publish
+    if: needs.publish.outputs.container == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    permissions:
+      contents: read
+      packages: write
+    env:
+      VERSION: ${{ needs.publish.outputs.version }}
+      RELEASE_TARGET: ${{ needs.publish.outputs.target }}
+      IMAGE: ghcr.io/conorbronsdon/substack-mcp
+      DOCKER_CONFIG: ${{ runner.temp }}/release-docker-config
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ needs.publish.outputs.target }}
+          persist-credentials: false
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: 22
+      - name: Verify original source and build
+        run: |
+          test "$(git rev-parse HEAD)" = "$RELEASE_TARGET"
+          test "$(node -p "require('./package.json').version")" = "$VERSION"
+          npm ci --ignore-scripts
+          docker build --build-arg VERSION="$VERSION" --build-arg REVISION="$RELEASE_TARGET" -t "$IMAGE:build" .
+          node scripts/test-container.mjs "$IMAGE:build" "$RELEASE_TARGET"
+      - name: Authenticate only after image verification
+        env:
+          REGISTRY_TOKEN: ${{ github.token }}
+          REGISTRY_ACTOR: ${{ github.actor }}
+        run: printf '%s' "$REGISTRY_TOKEN" | docker login ghcr.io -u "$REGISTRY_ACTOR" --password-stdin
+      - name: Publish and verify versioned image
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: node scripts/publish-container.mjs
+      - name: Remove runner registry authentication
+        if: always()
+        run: docker logout ghcr.io

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and the git tag history (`v0.1.0`–`v0.5.0`).
 ## [Unreleased]
 
 ### Added
+- Versioned container release verification for Linux amd64, with source/version ownership labels, a minimal build context, stdio and authenticated HTTP checks, preserved matching release images on recovery, and explicit anonymous GHCR access verification.
 - Claude Code plugin and repository marketplace, sharing the creator workflow skill and exact-version npm launcher with the existing Codex plugin. Manifest versions are synchronized and tested with release metadata. Local plugin support is distinct from hosted ChatGPT or curated-directory admission.
 - Opt-in read-only live contract probes with clean source revision, client/transport and credential-safe coverage reports. Doctor includes installed version and runtime; startup authentication reports read access without inferring an account ID from a post byline.
 - Typed object results with matching text JSON across all object-returning MCP tools; legacy array outputs remain unchanged. Shared response validation and size limits, schema snapshots, and a documented 1.x compatibility policy. Numeric read IDs and pagination now reject unsafe or invalid values before API requests.

--- a/Dockerfile
+++ b/Dockerfile
@@ -38,13 +38,16 @@ COPY --from=builder /app/dist ./dist
 #   SUBSTACK_SESSION_TOKEN   — the `connect.sid` cookie value (`substack.sid`
 #                              on a *.substack.com domain)
 #   SUBSTACK_USER_ID         — numeric Substack user id
-# All three are optional at startup. The server starts without them and answers
-# introspection (initialize, tools/list); each tool call then returns
-# isError: true until the credentials are set. The message points at the failing
-# request path rather than naming the missing variable, which is worth tightening
-# in the server itself. The browser-login flow that writes
-# ~/.substack-mcp/session.json binds its key to the OS account and hostname, so
-# a stored session is not portable into a container — use the env vars here.
+# All three credentials are required and validated before transport startup.
+# Machine-bound stored sessions are not portable into a container; use env vars.
+
+ARG VERSION=development
+ARG REVISION=unknown
+LABEL org.opencontainers.image.source="https://github.com/conorbronsdon/substack-mcp" \
+      org.opencontainers.image.title="Substack MCP" \
+      org.opencontainers.image.licenses="MIT" \
+      org.opencontainers.image.version=$VERSION \
+      org.opencontainers.image.revision=$REVISION
 
 USER node
 EXPOSE 8080

--- a/README.md
+++ b/README.md
@@ -587,3 +587,5 @@ the same fields and returned receipt. Published or known stale drafts are
 rejected. The read/write race remains; check readback outcomes and review in
 Substack. The CLI shares this flow through `drafts plan` and `drafts apply`.
 See [draft changes and migration](docs/draft-changes.md) for examples and limits.
+
+Versioned GHCR images and transport verification: [container distribution](docs/containers.md).

--- a/docs/containers.md
+++ b/docs/containers.md
@@ -1,0 +1,64 @@
+# Container distribution
+
+Starting with 1.0, GHCR releases use `ghcr.io/conorbronsdon/substack-mcp:<version>`
+and a `sha-<full-source-commit>` alias. `latest` follows the verified current
+release. The initial published image supports Linux amd64; the pinned base image
+being multi-platform does not establish support for other server architectures.
+Inspect the GHCR package and release job before assuming a version is available.
+Docker Hub is a separate distribution follow-up; no Docker Hub image is advertised.
+
+The image runs as the non-root `node` user. Source, version, revision and license
+are recorded in OCI labels. Release CI builds the original verified npm release
+commit, checks those labels and exercises stdio and authenticated HTTP using
+synthetic configuration. These checks do not validate a user's Substack session.
+Version recovery preserves an existing image only when its source/version match
+and its transport checks pass. Unknown registry lookup failures stop publication.
+For immutable deployment selection, use the registry's image manifest digest.
+
+## Run
+
+Provide `SUBSTACK_PUBLICATION_URL`, `SUBSTACK_SESSION_TOKEN` and
+`SUBSTACK_USER_ID` in a private environment file outside the repository. Use
+restrictive file permissions and never commit the file. Named environment
+publications are supported too. All credentials must be well-formed before the
+server starts. Machine-bound sessions from a different host are not portable;
+the image does not bundle Playwright or a browser login flow.
+
+```sh
+docker run -i --rm --env-file ./substack.env ghcr.io/conorbronsdon/substack-mcp:1.0.0
+```
+
+The existing image command remains `node dist/index.js`. For an offline status
+check, explicitly select the Node entrypoint:
+
+```sh
+docker run --rm --env-file ./substack.env --entrypoint node ghcr.io/conorbronsdon/substack-mcp:1.0.0 dist/index.js status --json
+```
+
+For persistent HTTP, also configure a strong `MCP_HTTP_TOKEN` in the environment
+file, bind the host port to loopback, and allow the exact host/port clients use:
+
+```sh
+docker run --rm --env-file ./substack.env -p 127.0.0.1:8080:8080 -e MCP_TRANSPORT=http -e MCP_HTTP_ALLOWED_HOSTS=127.0.0.1:8080,localhost:8080 ghcr.io/conorbronsdon/substack-mcp:1.0.0
+```
+
+Clients send `Authorization: Bearer <your MCP_HTTP_TOKEN>` to
+`http://127.0.0.1:8080/mcp`. This token protects access to your Substack session;
+it is separate from the Substack cookie. See the README for Origin policy and
+remote deployment requirements. Local HTTP is not a hosted ChatGPT connector.
+
+## Release verification and recovery
+
+The Publish workflow verifies npm, MCP Registry and GitHub identities first,
+then builds and tests the container from that original release commit. Older
+releases without container verification scripts are skipped. A failed container
+stage can be retried through Publish without republishing an existing npm release.
+Per-run build tags may remain for diagnostics; they are not supported release tags.
+
+GHCR package visibility is separate from repository visibility. The first publish
+can create a private package. Set the project's GHCR package to public, then rerun
+Publish; the final check uses an empty Docker configuration to verify anonymous
+manifest access. A successful authenticated push alone is not a public release.
+The workflow uses only its scoped GitHub token and removes its Docker login on exit.
+
+Reference: https://docs.github.com/en/packages/learn-github-packages/configuring-a-packages-access-control-and-visibility

--- a/docs/containers.md
+++ b/docs/containers.md
@@ -53,12 +53,13 @@ The Publish workflow verifies npm, MCP Registry and GitHub identities first,
 then builds and tests the container from that original release commit. Older
 releases without container verification scripts are skipped. A failed container
 stage can be retried through Publish without republishing an existing npm release.
-Per-run build tags may remain for diagnostics; they are not supported release tags.
+OCI signing/SBOM attestations and build-tag retention are follow-ups; labels are
+identity metadata, not cryptographic attestations. Per-run build tags remain for diagnostics; they are not supported release tags.
 
 GHCR package visibility is separate from repository visibility. The first publish
 can create a private package. Set the project's GHCR package to public, then rerun
-Publish; the final check uses an empty Docker configuration to verify anonymous
-manifest access. A successful authenticated push alone is not a public release.
+Publish. The candidate is checked through an empty Docker configuration before
+release aliases are promoted, and the selected version is checked again. A successful authenticated push alone is not a public release.
 The workflow uses only its scoped GitHub token and removes its Docker login on exit.
 
 Reference: https://docs.github.com/en/packages/learn-github-packages/configuring-a-packages-access-control-and-visibility

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "lint": "tsc --noEmit -p tsconfig.lint.json",
     "test": "vitest run src/__tests__",
     "probe:contract": "node scripts/probe-contract.mjs --read-only",
-    "test:release": "node --test scripts/check-release-order.controls.mjs scripts/check-release-metadata.controls.mjs scripts/release-state.controls.mjs scripts/probe-contract.controls.mjs",
+    "test:release": "node --test scripts/check-release-order.controls.mjs scripts/check-release-metadata.controls.mjs scripts/release-state.controls.mjs scripts/probe-contract.controls.mjs scripts/publish-container.controls.mjs",
     "start": "node dist/index.js",
     "dev": "tsx src/index.ts",
     "prepublishOnly": "npm run check:release && npm run lint && npm test && npm run test:package",
@@ -77,6 +77,7 @@
     "docs/draft-changes.md",
     "docs/workflow.md",
     "docs/tool-contract.md",
-    "docs/plugins.md"
+    "docs/plugins.md",
+    "docs/containers.md"
   ]
 }

--- a/scripts/publish-container.controls.mjs
+++ b/scripts/publish-container.controls.mjs
@@ -5,7 +5,7 @@ import pkg from '../package.json' with { type: 'json' };
 const input = { version: pkg.version, revision: 'a'.repeat(40), run: '1', attempt: '1', temp: '/temporary' };
 const image = 'ghcr.io/conorbronsdon/substack-mcp';
 function fixture(mode) {
-  const calls = []; let verified = 0;
+  const calls = []; let verified = 0, versionLookups = 0;
   const manifest = { config: { digest: 'sha256:' + 'b'.repeat(64) } };
   const docker = (...args) => {
     calls.push(args);
@@ -13,9 +13,9 @@ function fixture(mode) {
       if (mode === 'private') throw new Error('unauthorized');
       return JSON.stringify(manifest);
     }
-    if (args[0] === 'image') return JSON.stringify([{ Config: { Labels: { 'org.opencontainers.image.version': pkg.version, 'org.opencontainers.image.revision': mode === 'mismatch' ? 'c'.repeat(40) : input.revision } } }]);
+    if (args[0] === 'image') return JSON.stringify([{ Id: mode === 'race' && args[2] === `${image}:${pkg.version}` ? 'sha256:' + 'd'.repeat(64) : manifest.config.digest, Config: { Labels: { 'org.opencontainers.image.version': pkg.version, 'org.opencontainers.image.revision': mode === 'mismatch' ? 'c'.repeat(40) : input.revision } } }]);
     if (args[0] === 'manifest') {
-      if (calls.filter(call => call[0] === 'manifest').length === 1 && ['absent', 'unknown'].includes(mode)) throw Object.assign(new Error('lookup failed'), { stderr: mode === 'absent' ? 'manifest unknown' : 'unauthorized' });
+      if (args[2] === `${image}:${pkg.version}` && ++versionLookups === 1 && ['absent', 'unknown'].includes(mode)) throw Object.assign(new Error('lookup failed'), { stderr: mode === 'absent' ? 'manifest unknown' : 'unauthorized' });
       return JSON.stringify(manifest);
     }
     return '';
@@ -30,10 +30,11 @@ test('existing matching version is tested and preserved on recovery', () => {
   const f = fixture('existing'); assert.equal(f.run().public, true); assert.equal(f.verified(), 1);
   assert.ok(!f.calls.some(args => args[0] === 'push' && args[1] === `${image}:${pkg.version}`));
 });
-for (const mode of ['unknown', 'mismatch']) test(`${mode} identity never moves release aliases`, () => {
+for (const mode of ['unknown', 'mismatch', 'race']) test(`${mode} identity never moves release aliases`, () => {
   const f = fixture(mode); assert.throws(f.run);
   assert.ok(!f.calls.some(args => args[0] === 'tag' && /:(latest|sha-|[0-9]+\.)/.test(args[2])));
 });
 test('private package cannot report a successful public release', () => {
   const f = fixture('private'); assert.throws(f.run, /anonymous access failed/);
+  assert.ok(!f.calls.some(args => args[0] === 'tag' && /:(latest|sha-|[0-9]+\.)/.test(args[2])));
 });

--- a/scripts/publish-container.controls.mjs
+++ b/scripts/publish-container.controls.mjs
@@ -1,0 +1,39 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { publishContainer } from './publish-container.mjs';
+import pkg from '../package.json' with { type: 'json' };
+const input = { version: pkg.version, revision: 'a'.repeat(40), run: '1', attempt: '1', temp: '/temporary' };
+const image = 'ghcr.io/conorbronsdon/substack-mcp';
+function fixture(mode) {
+  const calls = []; let verified = 0;
+  const manifest = { config: { digest: 'sha256:' + 'b'.repeat(64) } };
+  const docker = (...args) => {
+    calls.push(args);
+    if (args[0] === '--config') {
+      if (mode === 'private') throw new Error('unauthorized');
+      return JSON.stringify(manifest);
+    }
+    if (args[0] === 'image') return JSON.stringify([{ Config: { Labels: { 'org.opencontainers.image.version': pkg.version, 'org.opencontainers.image.revision': mode === 'mismatch' ? 'c'.repeat(40) : input.revision } } }]);
+    if (args[0] === 'manifest') {
+      if (calls.filter(call => call[0] === 'manifest').length === 1 && ['absent', 'unknown'].includes(mode)) throw Object.assign(new Error('lookup failed'), { stderr: mode === 'absent' ? 'manifest unknown' : 'unauthorized' });
+      return JSON.stringify(manifest);
+    }
+    return '';
+  };
+  return { calls, run: () => publishContainer(input, { docker, verifyImage: () => { verified++; }, makeDirectory: () => {} }), verified: () => verified };
+}
+test('new version publishes after an explicit missing-manifest response', () => {
+  const f = fixture('absent'); assert.equal(f.run().public, true);
+  assert.ok(f.calls.some(args => args[0] === 'push' && args[1] === `${image}:${pkg.version}`));
+});
+test('existing matching version is tested and preserved on recovery', () => {
+  const f = fixture('existing'); assert.equal(f.run().public, true); assert.equal(f.verified(), 1);
+  assert.ok(!f.calls.some(args => args[0] === 'push' && args[1] === `${image}:${pkg.version}`));
+});
+for (const mode of ['unknown', 'mismatch']) test(`${mode} identity never moves release aliases`, () => {
+  const f = fixture(mode); assert.throws(f.run);
+  assert.ok(!f.calls.some(args => args[0] === 'tag' && /:(latest|sha-|[0-9]+\.)/.test(args[2])));
+});
+test('private package cannot report a successful public release', () => {
+  const f = fixture('private'); assert.throws(f.run, /anonymous access failed/);
+});

--- a/scripts/publish-container.controls.mjs
+++ b/scripts/publish-container.controls.mjs
@@ -13,7 +13,7 @@ function fixture(mode) {
       if (mode === 'private') throw new Error('unauthorized');
       return JSON.stringify(manifest);
     }
-    if (args[0] === 'image') return JSON.stringify([{ Id: mode === 'race' && args[2] === `${image}:${pkg.version}` ? 'sha256:' + 'd'.repeat(64) : manifest.config.digest, Config: { Labels: { 'org.opencontainers.image.version': pkg.version, 'org.opencontainers.image.revision': mode === 'mismatch' ? 'c'.repeat(40) : input.revision } } }]);
+    if (args[0] === 'image') return JSON.stringify([{ Id: (mode === 'race' && args[2] === `${image}:${pkg.version}`) || (mode === 'candidate_race' && args[2].includes(':build-')) ? 'sha256:' + 'd'.repeat(64) : manifest.config.digest, Config: { Labels: { 'org.opencontainers.image.version': pkg.version, 'org.opencontainers.image.revision': mode === 'mismatch' ? 'c'.repeat(40) : input.revision } } }]);
     if (args[0] === 'manifest') {
       if (args[2] === `${image}:${pkg.version}` && ++versionLookups === 1 && ['absent', 'unknown'].includes(mode)) throw Object.assign(new Error('lookup failed'), { stderr: mode === 'absent' ? 'manifest unknown' : 'unauthorized' });
       return JSON.stringify(manifest);
@@ -30,11 +30,11 @@ test('existing matching version is tested and preserved on recovery', () => {
   const f = fixture('existing'); assert.equal(f.run().public, true); assert.equal(f.verified(), 1);
   assert.ok(!f.calls.some(args => args[0] === 'push' && args[1] === `${image}:${pkg.version}`));
 });
-for (const mode of ['unknown', 'mismatch', 'race']) test(`${mode} identity never moves release aliases`, () => {
+for (const mode of ['unknown', 'mismatch', 'race', 'candidate_race']) test(`${mode} identity never moves release aliases`, () => {
   const f = fixture(mode); assert.throws(f.run);
   assert.ok(!f.calls.some(args => args[0] === 'tag' && /:(latest|sha-|[0-9]+\.)/.test(args[2])));
 });
 test('private package cannot report a successful public release', () => {
-  const f = fixture('private'); assert.throws(f.run, /anonymous access failed/);
+  const f = fixture('private'); assert.throws(f.run, /Anonymous access failed/);
   assert.ok(!f.calls.some(args => args[0] === 'tag' && /:(latest|sha-|[0-9]+\.)/.test(args[2])));
 });

--- a/scripts/publish-container.mjs
+++ b/scripts/publish-container.mjs
@@ -13,31 +13,40 @@ const candidate = `${image}:build-${run}-${attempt}`;
 const versioned = `${image}:${version}`;
 // A fresh candidate establishes package ownership before missing-manifest checks.
 docker('tag', `${image}:build`, candidate); docker('push', candidate);
-let exists = true;
-try { docker('manifest', 'inspect', versioned); }
+// Verify public candidate access before creating or moving any release alias.
+const anonymous = join(temp, `docker-anonymous-${run}-${attempt}`); makeDirectory(anonymous);
+const inspect = ref => JSON.parse(docker('manifest', 'inspect', ref));
+const verifyPublic = (ref, expected) => {
+  let observed;
+  try { observed = JSON.parse(docker('--config', anonymous, 'manifest', 'inspect', ref)); }
+  catch { throw new Error('Candidate published but anonymous access failed. Verify the GHCR package is public, then rerun Publish; publication stopped; inspect existing tags before retrying.'); }
+  assert.deepEqual(observed, expected);
+};
+const candidateManifest = inspect(candidate);
+assert.ok(candidateManifest.config?.digest, 'Expected a single-platform image manifest');
+assert.equal(JSON.parse(docker('image', 'inspect', candidate))[0].Id, candidateManifest.config.digest);
+verifyPublic(candidate, candidateManifest);
+let existing;
+try { existing = inspect(versioned); }
 catch (error) {
   if (!/manifest unknown|no such manifest/i.test(String(error.stderr))) throw new Error('Cannot determine existing container release; stop without moving version tags.');
-  exists = false;
 }
-if (exists) {
+if (existing) {
   docker('pull', versioned);
   const info = JSON.parse(docker('image', 'inspect', versioned))[0];
+  assert.equal(info.Id, existing.config?.digest, 'Pulled image differs from the inspected release manifest');
   assert.equal(info.Config.Labels['org.opencontainers.image.version'], version);
   assert.equal(info.Config.Labels['org.opencontainers.image.revision'], revision);
   verifyImage(versioned, revision);
+  verifyPublic(versioned, existing);
 } else {
   docker('tag', candidate, versioned); docker('push', versioned);
 }
-const manifest = JSON.parse(docker('manifest', 'inspect', versioned));
-assert.ok(manifest.config?.digest, 'Expected a single-platform image manifest');
-// Full-SHA and latest aliases point to the same already-verified version image.
+const manifest = inspect(versioned);
+assert.deepEqual(manifest, existing ?? candidateManifest);
+verifyPublic(versioned, manifest);
+// Full-SHA and latest aliases point to the same already-verified public version.
 for (const tag of [`sha-${revision}`, 'latest']) { docker('tag', versioned, `${image}:${tag}`); docker('push', `${image}:${tag}`); }
-// Public discovery is a release gate. This isolated config has no auth helpers.
-const anonymous = join(temp, `docker-anonymous-${run}-${attempt}`); makeDirectory(anonymous);
-let publicManifest;
-try { publicManifest = JSON.parse(docker('--config', anonymous, 'manifest', 'inspect', versioned)); }
-catch { throw new Error('Image published but anonymous access failed. Verify the GHCR package is public, then rerun Publish; existing version images are preserved.'); }
-assert.deepEqual(publicManifest, manifest);
 return { image: versioned, revision, architecture: 'linux/amd64', public: true, config_digest: manifest.config.digest };
 }
 if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {

--- a/scripts/publish-container.mjs
+++ b/scripts/publish-container.mjs
@@ -1,0 +1,52 @@
+// Runs only in the verified release job. Never prints credentials or registry bodies.
+import assert from 'node:assert/strict';
+import { execFileSync } from 'node:child_process';
+import { mkdirSync } from 'node:fs';
+import { join } from 'node:path';
+import pkg from '../package.json' with { type: 'json' };
+import { pathToFileURL } from 'node:url';
+export function publishContainer({ version, revision, run, attempt, temp }, { docker, verifyImage, makeDirectory }) {
+const image = 'ghcr.io/conorbronsdon/substack-mcp';
+assert.equal(version, pkg.version); assert.match(version, /^\d+\.\d+\.\d+$/);
+assert.match(revision ?? '', /^[a-f0-9]{40}$/); assert.match(run ?? '', /^\d+$/); assert.match(attempt ?? '', /^\d+$/); assert.ok(temp);
+const candidate = `${image}:build-${run}-${attempt}`;
+const versioned = `${image}:${version}`;
+// A fresh candidate establishes package ownership before missing-manifest checks.
+docker('tag', `${image}:build`, candidate); docker('push', candidate);
+let exists = true;
+try { docker('manifest', 'inspect', versioned); }
+catch (error) {
+  if (!/manifest unknown|no such manifest/i.test(String(error.stderr))) throw new Error('Cannot determine existing container release; stop without moving version tags.');
+  exists = false;
+}
+if (exists) {
+  docker('pull', versioned);
+  const info = JSON.parse(docker('image', 'inspect', versioned))[0];
+  assert.equal(info.Config.Labels['org.opencontainers.image.version'], version);
+  assert.equal(info.Config.Labels['org.opencontainers.image.revision'], revision);
+  verifyImage(versioned, revision);
+} else {
+  docker('tag', candidate, versioned); docker('push', versioned);
+}
+const manifest = JSON.parse(docker('manifest', 'inspect', versioned));
+assert.ok(manifest.config?.digest, 'Expected a single-platform image manifest');
+// Full-SHA and latest aliases point to the same already-verified version image.
+for (const tag of [`sha-${revision}`, 'latest']) { docker('tag', versioned, `${image}:${tag}`); docker('push', `${image}:${tag}`); }
+// Public discovery is a release gate. This isolated config has no auth helpers.
+const anonymous = join(temp, `docker-anonymous-${run}-${attempt}`); makeDirectory(anonymous);
+let publicManifest;
+try { publicManifest = JSON.parse(docker('--config', anonymous, 'manifest', 'inspect', versioned)); }
+catch { throw new Error('Image published but anonymous access failed. Verify the GHCR package is public, then rerun Publish; existing version images are preserved.'); }
+assert.deepEqual(publicManifest, manifest);
+return { image: versioned, revision, architecture: 'linux/amd64', public: true, config_digest: manifest.config.digest };
+}
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  const { VERSION: version, RELEASE_TARGET: revision, GITHUB_RUN_ID: run, GITHUB_RUN_ATTEMPT: attempt, RUNNER_TEMP: temp } = process.env;
+  const docker = (...args) => execFileSync('docker', args, { encoding: 'utf8', timeout: 180000, maxBuffer: 1024 * 1024, stdio: ['ignore', 'pipe', 'pipe'] });
+  try {
+    console.log(JSON.stringify(publishContainer({ version, revision, run, attempt, temp }, {
+      docker, makeDirectory: path => mkdirSync(path, { recursive: true }),
+      verifyImage: (image, sha) => execFileSync(process.execPath, ['scripts/test-container.mjs', image, sha], { stdio: 'inherit', timeout: 120000 }),
+    })));
+  } catch (error) { console.error(error instanceof assert.AssertionError ? 'Container identity mismatch; publication stopped.' : error.message.startsWith('Command failed') ? 'Container command failed; inspect the release stage and reconcile before retrying.' : error.message); process.exitCode = 1; }
+}

--- a/scripts/publish-container.mjs
+++ b/scripts/publish-container.mjs
@@ -19,7 +19,7 @@ const inspect = ref => JSON.parse(docker('manifest', 'inspect', ref));
 const verifyPublic = (ref, expected) => {
   let observed;
   try { observed = JSON.parse(docker('--config', anonymous, 'manifest', 'inspect', ref)); }
-  catch { throw new Error('Candidate published but anonymous access failed. Verify the GHCR package is public, then rerun Publish; publication stopped; inspect existing tags before retrying.'); }
+  catch { throw new Error(`Anonymous access failed for ${ref}. Verify the GHCR package is public, then rerun Publish; inspect existing tags before retrying.`); }
   assert.deepEqual(observed, expected);
 };
 const candidateManifest = inspect(candidate);

--- a/scripts/test-container.mjs
+++ b/scripts/test-container.mjs
@@ -1,0 +1,63 @@
+// Synthetic transport checks. No live publication or credentials are used.
+import assert from 'node:assert/strict';
+import { execFileSync } from 'node:child_process';
+import { randomUUID } from 'node:crypto';
+import { setTimeout as delay } from 'node:timers/promises';
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { StdioClientTransport } from '@modelcontextprotocol/sdk/client/stdio.js';
+import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/streamableHttp.js';
+import pkg from '../package.json' with { type: 'json' };
+
+const [image, revision] = process.argv.slice(2);
+assert.ok(image && !image.startsWith('-'), 'Provide a Docker image reference');
+assert.match(revision ?? '', /^[a-f0-9]{40}$/, 'Provide the source commit SHA');
+const docker = (...args) => execFileSync('docker', args, { encoding: 'utf8', timeout: 60000, maxBuffer: 1024 * 1024 });
+const info = JSON.parse(docker('image', 'inspect', image))[0];
+assert.equal(info.Config.User, 'node');
+for (const [key, value] of Object.entries({ version: pkg.version, revision, source: 'https://github.com/conorbronsdon/substack-mcp', licenses: 'MIT' })) {
+  assert.equal(info.Config.Labels[`org.opencontainers.image.${key}`], value);
+}
+const env = ['-e', 'SUBSTACK_PUBLICATION_URL=https://example.invalid', '-e', 'SUBSTACK_SESSION_TOKEN=example-container-token', '-e', 'SUBSTACK_USER_ID=1', '-e', 'SUBSTACK_REQUEST_TIMEOUT_MS=1000'];
+const status = JSON.parse(docker('run', '--rm', '--network', 'none', ...env, '--entrypoint', 'node', image, 'dist/index.js', 'status', '--json'));
+assert.equal(status.version, pkg.version);
+const catalog = async client => {
+  assert.equal(client.getServerVersion().version, pkg.version);
+  const { tools } = await client.listTools();
+  assert.equal(tools.length, 24);
+  for (const name of ['get_publication', 'list_drafts', 'plan_draft_update', 'update_draft']) assert.ok(tools.some(tool => tool.name === name));
+  for (const name of ['publish_post', 'delete_post', 'schedule_post']) assert.ok(!tools.some(tool => tool.name === name));
+};
+const prefix = `substack-smoke-${randomUUID()}`;
+let stdio, http;
+try {
+  stdio = new Client({ name: 'container-stdio-check', version: '1' });
+  await stdio.connect(new StdioClientTransport({ command: 'docker', args: ['run', '--name', `${prefix}-stdio`, '-i', '--rm', '--network', 'none', ...env, image], stderr: 'pipe' }));
+  await catalog(stdio);
+  await stdio.close(); stdio = undefined;
+  docker('run', '-d', '--name', `${prefix}-http`, '--rm', '-p', '127.0.0.1::8080', ...env,
+    '-e', 'MCP_TRANSPORT=http', '-e', 'MCP_HTTP_HOST=0.0.0.0', '-e', 'MCP_HTTP_TOKEN=example-http-token',
+    '-e', 'MCP_HTTP_ALLOWED_HOSTS=127.0.0.1', image);
+  const inspection = JSON.parse(docker('inspect', `${prefix}-http`))[0];
+  const port = inspection.NetworkSettings.Ports['8080/tcp'][0].HostPort;
+  const url = new URL(`http://127.0.0.1:${port}/mcp`);
+  // Explicit Host keeps the server allowlist exact despite an ephemeral host port.
+  const headers = { Host: '127.0.0.1', Authorization: 'Bearer example-http-token' };
+  let ready = false;
+  for (let i = 0; i < 40; i++) {
+    try { const response = await fetch(new URL('/health', url), { headers, signal: AbortSignal.timeout(1000) }); ready = response.status === 200; await response.arrayBuffer(); if (ready) break; }
+    catch { /* bounded startup polling */ }
+    await delay(250);
+  }
+  assert.ok(ready, 'HTTP container did not become ready');
+  for (const authorization of [undefined, 'Bearer example-wrong-token']) {
+    const response = await fetch(url, { method: 'POST', headers: { Host: '127.0.0.1', ...(authorization ? { Authorization: authorization } : {}) }, signal: AbortSignal.timeout(3000) });
+    assert.equal(response.status, 401); await response.arrayBuffer();
+  }
+  http = new Client({ name: 'container-http-check', version: '1' });
+  await http.connect(new StreamableHTTPClientTransport(url, { requestInit: { headers } }));
+  await catalog(http);
+  console.log(JSON.stringify({ version: pkg.version, revision, user: 'node', stdio: true, authenticated_http: true, rejects_missing_and_wrong_bearer: true, live_api: false }));
+} finally {
+  await http?.close().catch(() => {}); await stdio?.close().catch(() => {});
+  for (const suffix of ['stdio', 'http']) { try { docker('rm', '-f', `${prefix}-${suffix}`); } catch { /* already removed */ } }
+}

--- a/scripts/test-container.mjs
+++ b/scripts/test-container.mjs
@@ -1,6 +1,7 @@
 // Synthetic transport checks. No live publication or credentials are used.
 import assert from 'node:assert/strict';
 import { execFileSync } from 'node:child_process';
+import net from 'node:net';
 import { randomUUID } from 'node:crypto';
 import { setTimeout as delay } from 'node:timers/promises';
 import { Client } from '@modelcontextprotocol/sdk/client/index.js';
@@ -11,7 +12,7 @@ import pkg from '../package.json' with { type: 'json' };
 const [image, revision] = process.argv.slice(2);
 assert.ok(image && !image.startsWith('-'), 'Provide a Docker image reference');
 assert.match(revision ?? '', /^[a-f0-9]{40}$/, 'Provide the source commit SHA');
-const docker = (...args) => execFileSync('docker', args, { encoding: 'utf8', timeout: 60000, maxBuffer: 1024 * 1024 });
+const docker = (...args) => execFileSync('docker', args, { encoding: 'utf8', timeout: 60000, maxBuffer: 1024 * 1024, stdio: ['ignore', 'pipe', 'pipe'] });
 const info = JSON.parse(docker('image', 'inspect', image))[0];
 assert.equal(info.Config.User, 'node');
 for (const [key, value] of Object.entries({ version: pkg.version, revision, source: 'https://github.com/conorbronsdon/substack-mcp', licenses: 'MIT' })) {
@@ -34,14 +35,16 @@ try {
   await stdio.connect(new StdioClientTransport({ command: 'docker', args: ['run', '--name', `${prefix}-stdio`, '-i', '--rm', '--network', 'none', ...env, image], stderr: 'pipe' }));
   await catalog(stdio);
   await stdio.close(); stdio = undefined;
-  docker('run', '-d', '--name', `${prefix}-http`, '--rm', '-p', '127.0.0.1::8080', ...env,
+  const reservation = net.createServer();
+  await new Promise(resolve => reservation.listen(0, '127.0.0.1', resolve));
+  const port = reservation.address().port;
+  await new Promise((resolve, reject) => reservation.close(error => error ? reject(error) : resolve()));
+  // If another process takes the port, Docker fails; no alternate interface is used.
+  docker('run', '-d', '--name', `${prefix}-http`, '--rm', '-p', `127.0.0.1:${port}:8080`, ...env,
     '-e', 'MCP_TRANSPORT=http', '-e', 'MCP_HTTP_HOST=0.0.0.0', '-e', 'MCP_HTTP_TOKEN=example-http-token',
-    '-e', 'MCP_HTTP_ALLOWED_HOSTS=127.0.0.1', image);
-  const inspection = JSON.parse(docker('inspect', `${prefix}-http`))[0];
-  const port = inspection.NetworkSettings.Ports['8080/tcp'][0].HostPort;
+    '-e', `MCP_HTTP_ALLOWED_HOSTS=127.0.0.1:${port}`, image);
   const url = new URL(`http://127.0.0.1:${port}/mcp`);
-  // Explicit Host keeps the server allowlist exact despite an ephemeral host port.
-  const headers = { Host: '127.0.0.1', Authorization: 'Bearer example-http-token' };
+  const headers = { Authorization: 'Bearer example-http-token' };
   let ready = false;
   for (let i = 0; i < 40; i++) {
     try { const response = await fetch(new URL('/health', url), { headers, signal: AbortSignal.timeout(1000) }); ready = response.status === 200; await response.arrayBuffer(); if (ready) break; }
@@ -50,7 +53,7 @@ try {
   }
   assert.ok(ready, 'HTTP container did not become ready');
   for (const authorization of [undefined, 'Bearer example-wrong-token']) {
-    const response = await fetch(url, { method: 'POST', headers: { Host: '127.0.0.1', ...(authorization ? { Authorization: authorization } : {}) }, signal: AbortSignal.timeout(3000) });
+    const response = await fetch(url, { method: 'POST', headers: authorization ? { Authorization: authorization } : {}, signal: AbortSignal.timeout(3000) });
     assert.equal(response.status, 401); await response.arrayBuffer();
   }
   http = new Client({ name: 'container-http-check', version: '1' });

--- a/scripts/test-package.mjs
+++ b/scripts/test-package.mjs
@@ -30,7 +30,7 @@ const expectedTools = [
 
 const requiredFiles = ['package.json', 'server.json', 'README.md', 'LICENSE', 'CHANGELOG.md',
   'docs/calendar-sync.md', 'docs/cloud-calendar-sync.md', 'docs/subscribers.md', 'docs/authoring.md', 'docs/export.md', 'docs/draft-changes.md',
-  'docs/workflow.md', 'docs/tool-contract.md', 'docs/plugins.md', 'dist/index.js', 'dist/login.js'];
+  'docs/workflow.md', 'docs/tool-contract.md', 'docs/plugins.md', 'docs/containers.md', 'dist/index.js', 'dist/login.js'];
 let transport;
 try {
   const [packed] = JSON.parse(npm(['pack', '--json', '--ignore-scripts', '--pack-destination', scratch], process.cwd()));


### PR DESCRIPTION
Build versioned GHCR images from the original verified npm release commit and test them before registry authentication. The image carries source/version/revision/license metadata, runs as `node`, and uses a minimal build context. CI exercises stdio, authenticated HTTP, missing/wrong bearer rejection and a wrong-source rejection control with synthetic credentials.

Publication verifies anonymous access to a per-run candidate before promoting release aliases. Existing matching version images are pulled, bound to the inspected manifest config digest and tested again, then preserved. Unknown lookups, mismatched source/image identity and private packages stop promotion. Publish can recover the container stage after verified npm/Registry/GitHub artifacts; original releases without container support are skipped. Initial architecture is Linux amd64. OCI attestations and safe candidate retention remain in #91; labels are not attestations.

Validation: all four Node 22/24 Windows/Linux CI jobs passed at `1103408869d282ffcaed4ed9f172df9eaa1dc727` (34193485124), plus actual Docker build/stdio/HTTP and wrong-revision control (34193485117). Local checks: 777 tests passed with one Windows skip, lint, 79-file installed package/both binaries/24 tools, seven fixture workflow steps; final 33 release controls passed. Mutating unknown lookup classification and removing candidate identity binding each made the corresponding control fail. No live Substack writes or real credentials were used.

Exact-commit external review: authenticated `claude-opus-5`, `opencode/muse-spark-1.3-contributor-free` and `opencode/mimo-v2.5-free` reviewed initial `14ee4b3006e5a1feb3db7e1e2fe028cadae57dca`, first repair `9acf888d8ae288e74eb5d3c390f95d4d27fb0d78`, and final affected scope `1103408869d282ffcaed4ed9f172df9eaa1dc727`. Two repair cycles used; no unresolved verified blocker. Repairs move the anonymous gate before alias creation, bind pulled and candidate image IDs, check all original-release support files, identify the actual failing ref, and cover candidate mismatch.

Conditional findings were checked against actual source: workflow-level concurrency covers both jobs; `assert.AssertionError` exists; metadata checking imports only Node built-ins; `verifyStage` binds every target; `releaseManifest` checks original commit availability and package identity; `decideRelease` rejects older-than-latest releases and requires exact npm/latest version agreement. The explicit `test:release` list includes publication controls. The existing 0.9 npm artifact is not republished by this preparation branch and has no container support script.

This PR verifies container behavior in CI and registry decisions through controls. Actual GHCR publication/anonymous availability is a release-stage check, not claimed by these test results. First package visibility may require the maintainer to set GHCR public before promotion can complete.
