### PR TITLE
fix: unblock 1.0 publication and validate workflow contexts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,15 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  workflows:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - name: Validate all workflow syntax and expression contexts
+        run: |
+          go install github.com/rhysd/actionlint/cmd/actionlint@v1.7.12
+          "$(go env GOPATH)/bin/actionlint" -shellcheck= -pyflakes=
   test:
     runs-on: ${{ matrix.os }}
     timeout-minutes: 15

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -138,12 +138,13 @@ jobs:
       VERSION: ${{ needs.publish.outputs.version }}
       RELEASE_TARGET: ${{ needs.publish.outputs.target }}
       IMAGE: ghcr.io/conorbronsdon/substack-mcp
-      DOCKER_CONFIG: ${{ runner.temp }}/release-docker-config
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ needs.publish.outputs.target }}
           persist-credentials: false
+      - name: Isolate registry authentication in the runner temporary directory
+        run: printf 'DOCKER_CONFIG=%s/release-docker-config\n' "$RUNNER_TEMP" >> "$GITHUB_ENV"
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 22


### PR DESCRIPTION
The 1.0 Publish workflow was rejected before any jobs ran because `runner.temp` is unavailable in job-level `env`. Initialize the isolated Docker authentication directory from `RUNNER_TEMP` inside an executed step, before build/login/publication, so GitHub can validate and run the workflow.

CI now validates all workflows with pinned actionlint v1.7.12. The original workflow fails that linter with the same invalid-context error; the repaired workflows pass. Package and production source are unchanged. Independent review and CI receipts follow before merge; after merge, dispatch Publish to resume the authorized 1.0 release.

Refs #62, #65. Failed run: https://github.com/conorbronsdon/substack-mcp/actions/runs/34196649871
