### PR TITLE
ci: add HOL plugin security scan

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -7,9 +7,9 @@
     {
       "name": "substack-mcp",
       "source": "./",
-      "description": "Read Substack content and manage long-form drafts; Notes publish immediately.",
+      "description": "Safe creator operations for Substack: rich drafts, Notes, analytics, and consented subscribers. Long-form posts stay draft-only; Notes publish immediately.",
       "version": "1.0.0"
     }
   ],
-  "description": "Substack creator tools and a shared draft-review workflow, maintained with the server."
+  "description": "Safe Substack creator tools for drafts, Notes, analytics, and consented subscribers, maintained with the server."
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "substack-mcp",
   "version": "1.0.0",
-  "description": "Read Substack content and manage long-form drafts; Notes publish immediately.",
+  "description": "Safe creator operations for Substack: rich drafts, Notes, analytics, and consented subscribers. Long-form posts stay draft-only; Notes publish immediately.",
   "author": {
     "name": "Conor Bronsdon",
     "url": "https://github.com/conorbronsdon"

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,7 +1,14 @@
 {
   "name": "substack-mcp",
   "version": "1.0.0",
-  "description": "Read Substack content and manage long-form drafts; Notes publish immediately.",
+  "description": "Safe creator operations for Substack: rich drafts, Notes, analytics, and consented subscribers. Long-form posts stay draft-only; Notes publish immediately.",
+  "keywords": [
+    "mcp",
+    "substack",
+    "newsletter",
+    "ai",
+    "claude"
+  ],
   "author": {
     "name": "Conor Bronsdon",
     "url": "https://github.com/conorbronsdon"
@@ -12,8 +19,8 @@
   "mcpServers": "./.mcp.json",
   "interface": {
     "displayName": "Substack MCP",
-    "shortDescription": "Read Substack content and manage long-form drafts; Notes publish immediately.",
-    "longDescription": "Runs the published Substack MCP server over stdio. Long-form posts have no publish, delete, or schedule tools. Notes publish immediately. Configure your own credentials outside the plugin.",
+    "shortDescription": "Substack drafts, analytics, consented subscribers; Notes publish immediately.",
+    "longDescription": "Runs the published Substack MCP server over stdio for safe creator operations across publications: rich drafts, Notes, analytics, and consented subscribers. Long-form posts have no publish, delete, or schedule tools. Notes publish immediately. Configure your own credentials outside the plugin.",
     "developerName": "Conor Bronsdon",
     "category": "Productivity",
     "capabilities": [

--- a/.github/workflows/hol-plugin-scanner.yml
+++ b/.github/workflows/hol-plugin-scanner.yml
@@ -1,0 +1,34 @@
+name: HOL Plugin Security Scan
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: hol-plugin-scan-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  scan:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      # This action revision installs the attested plugin-scanner 3.0.123 wheel.
+      - uses: hashgraph-online/ai-plugin-scanner-action@caba2e96aa8ad2feb6cf6fca52442b52e22e779f # v1.2.635
+        with:
+          # Verify deliberately safety-skips command-based MCP servers; test:package covers runtime execution.
+          mode: scan
+          plugin_dir: "."
+          min_score: 80
+          fail_on_severity: high
+          online: "false"
+          pr_comment: "off"
+          upload_sarif: "false"

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ Safe creator operations for Substack, via MCP. Prepare rich drafts, publish Note
 [![Language: TypeScript](https://img.shields.io/badge/TypeScript-3178c6?style=flat-square&logo=typescript&logoColor=white)](https://www.typescriptlang.org/)
 [![npm version](https://img.shields.io/npm/v/@conorbronsdon/substack-mcp?style=flat-square)](https://www.npmjs.com/package/@conorbronsdon/substack-mcp)
 [![MCP](https://img.shields.io/badge/MCP-Model_Context_Protocol-1f6feb?style=flat-square)](https://modelcontextprotocol.io/)
+[![HOL Plugin Security Scan](https://github.com/conorbronsdon/substack-mcp/actions/workflows/hol-plugin-scanner.yml/badge.svg)](https://github.com/conorbronsdon/substack-mcp/actions/workflows/hol-plugin-scanner.yml)
 [![Podcast](https://img.shields.io/badge/Podcast-Chain_of_Thought-purple?style=flat-square)](https://chainofthought.show/?utm_source=github&utm_medium=referral&utm_campaign=repo-readme&utm_content=substack-mcp)
 [![X](https://img.shields.io/badge/X-@ConorBronsdon-black?style=flat-square&logo=x)](https://x.com/ConorBronsdon)
 

--- a/src/__tests__/plugin-package.test.ts
+++ b/src/__tests__/plugin-package.test.ts
@@ -23,7 +23,20 @@ describe("Codex plugin package", () => {
   it("discloses the immediate Notes publishing boundary", () => {
     const manifest = readJson(".codex-plugin/plugin.json");
     expect(manifest.description).toContain("Notes publish immediately");
+    expect(manifest.interface.shortDescription).toContain("Notes publish immediately");
     expect(manifest.interface.longDescription).toContain("no publish, delete, or schedule tools");
     expect(manifest.interface.longDescription).toContain("Notes publish immediately");
+  });
+
+  it("keeps discovery metadata aligned across package formats", () => {
+    const pkg = readJson("package.json");
+    const codex = readJson(".codex-plugin/plugin.json");
+    const claude = readJson(".claude-plugin/plugin.json");
+    const marketplace = readJson(".claude-plugin/marketplace.json");
+
+    expect(codex.description).toBe(pkg.description);
+    expect(claude.description).toBe(pkg.description);
+    expect(marketplace.plugins[0].description).toBe(pkg.description);
+    expect(codex.keywords).toEqual(pkg.keywords);
   });
 });


### PR DESCRIPTION
## Summary

- add a pinned, read-only HOL plugin scanner workflow for pull requests and `main`
- gate on score 80 and high-or-greater findings using scanner 3.0.123
- show the live workflow badge in the README
- align Codex and Claude discovery metadata with the package description
- protect the Notes publishing warning and cross-manifest metadata agreement with tests

`scan` is intentional: HOL `verify` safety-skips all command-based MCP servers. The existing `test:package` smoke test launches the packaged stdio server and verifies its tool surface.

## Local verification

- HOL plugin scanner 3.0.123: **98/A**, policy passed, 0 critical/high/medium/low findings
- `npm run check:release`
- `npm run test:release` (33 passed)
- `npm run lint`
- `npm run test:package` (both bins load; all 24 tools present)
- `npm test` (779 passed)
- Astra independent review: no blocking findings
