### PR TITLE
ci: attest OCI releases by immutable digest

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -33,6 +33,8 @@ jobs:
       version: ${{ steps.registry.outputs.version }}
       target: ${{ steps.registry.outputs.target }}
       container: ${{ steps.container.outputs.enabled }}
+      attestations: ${{ steps.container.outputs.attestations }}
+      generate_attestations: ${{ steps.container.outputs.generate_attestations }}
     env:
       GH_TOKEN: ${{ github.token }}
       RECONCILED_RELEASE_COMMIT: ${{ inputs.reconciled_commit }}
@@ -120,17 +122,34 @@ jobs:
         env:
           RELEASE_TARGET: ${{ steps.registry.outputs.target }}
         run: |
+          enabled=false
+          attestations=false
+          generate_attestations=false
           if git cat-file -e "$RELEASE_TARGET:scripts/test-container.mjs" && git cat-file -e "$RELEASE_TARGET:scripts/publish-container.mjs" && git cat-file -e "$RELEASE_TARGET:Dockerfile"; then
-            echo "enabled=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "enabled=false" >> "$GITHUB_OUTPUT"
+            enabled=true
+            if git cat-file -e "$RELEASE_TARGET:scripts/container-attestation.mjs"; then
+              attestations=true
+              if [ "$RELEASE_TARGET" = "$GITHUB_SHA" ]; then
+                generate_attestations=true
+              fi
+            fi
           fi
+          {
+            echo "enabled=$enabled"
+            echo "attestations=$attestations"
+            echo "generate_attestations=$generate_attestations"
+          } >> "$GITHUB_OUTPUT"
 
   container:
     needs: publish
     if: needs.publish.outputs.container == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 20
+    outputs:
+      image: ${{ steps.publish.outputs.image }}
+      manifest_digest: ${{ steps.publish.outputs.manifest-digest }}
+      candidate_digest: ${{ steps.publish.outputs.candidate-digest }}
+      provenance_eligible: ${{ steps.publish.outputs.provenance-eligible }}
     permissions:
       contents: read
       packages: write
@@ -161,7 +180,104 @@ jobs:
           REGISTRY_ACTOR: ${{ github.actor }}
         run: printf '%s' "$REGISTRY_TOKEN" | docker login ghcr.io -u "$REGISTRY_ACTOR" --password-stdin
       - name: Publish and verify versioned image
+        id: publish
         run: node scripts/publish-container.mjs
+      - name: Remove runner registry authentication
+        if: always()
+        run: docker logout ghcr.io
+
+  attest:
+    needs: [publish, container]
+    if: needs.publish.outputs.attestations == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
+      attestations: write
+      artifact-metadata: write
+    env:
+      VERSION: ${{ needs.publish.outputs.version }}
+      RELEASE_TARGET: ${{ needs.publish.outputs.target }}
+      IMAGE: ghcr.io/conorbronsdon/substack-mcp
+      MANIFEST_DIGEST: ${{ needs.container.outputs.manifest_digest }}
+      GENERATE_ATTESTATIONS: ${{ needs.publish.outputs.generate_attestations == 'true' && needs.container.outputs.provenance_eligible == 'true' }}
+      GH_TOKEN: ${{ github.token }}
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ needs.publish.outputs.target }}
+          persist-credentials: false
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: 22
+      - name: Bind attestation subject to the verified release source
+        id: subject
+        run: node scripts/container-attestation.mjs
+      - name: Isolate registry authentication in the runner temporary directory
+        run: printf 'DOCKER_CONFIG=%s/attestation-docker-config\n' "$RUNNER_TEMP" >> "$GITHUB_ENV"
+      - name: Authenticate for OCI attestation publication and verification
+        env:
+          REGISTRY_TOKEN: ${{ github.token }}
+          REGISTRY_ACTOR: ${{ github.actor }}
+        run: printf '%s' "$REGISTRY_TOKEN" | docker login ghcr.io -u "$REGISTRY_ACTOR" --password-stdin
+      - name: Generate SPDX SBOM from the immutable image
+        if: steps.subject.outputs.generate == 'true'
+        uses: anchore/sbom-action@3ad7283483fc7af8ff2b4ea19663c2d5ca935e26 # v0.24.2
+        with:
+          image: ${{ steps.subject.outputs.image-ref }}
+          format: spdx-json
+          output-file: ${{ runner.temp }}/substack-mcp.spdx.json
+          upload-artifact: false
+          upload-release-assets: false
+      - name: Attest image build provenance
+        if: steps.subject.outputs.generate == 'true'
+        uses: actions/attest@1e69f48acb82d1966a394da916b4c1698aa569d6 # v4.2.2
+        with:
+          subject-name: ${{ steps.subject.outputs.subject-name }}
+          subject-digest: ${{ steps.subject.outputs.manifest-digest }}
+          subject-version: ${{ needs.publish.outputs.version }}
+          push-to-registry: true
+      - name: Attest image SBOM
+        if: steps.subject.outputs.generate == 'true'
+        uses: actions/attest@1e69f48acb82d1966a394da916b4c1698aa569d6 # v4.2.2
+        with:
+          subject-name: ${{ steps.subject.outputs.subject-name }}
+          subject-digest: ${{ steps.subject.outputs.manifest-digest }}
+          subject-version: ${{ needs.publish.outputs.version }}
+          sbom-path: ${{ runner.temp }}/substack-mcp.spdx.json
+          push-to-registry: true
+      - name: Verify provenance, SBOM and rejection controls
+        env:
+          SUBJECT_REF: ${{ steps.subject.outputs.subject-ref }}
+          SOURCE_DIGEST: ${{ steps.subject.outputs.source-digest }}
+          WRONG_SOURCE_DIGEST: ${{ steps.subject.outputs.wrong-source-digest }}
+          SIGNER_WORKFLOW: ${{ steps.subject.outputs.signer-workflow }}
+          WRONG_SIGNER_WORKFLOW: ${{ steps.subject.outputs.wrong-signer-workflow }}
+          SPDX_PREDICATE_TYPE: ${{ steps.subject.outputs.spdx-predicate-type }}
+        run: |
+          gh attestation verify "$SUBJECT_REF" --bundle-from-oci --repo "$GITHUB_REPOSITORY" --source-digest "$SOURCE_DIGEST" --signer-workflow "$SIGNER_WORKFLOW"
+          gh attestation verify "$SUBJECT_REF" --bundle-from-oci --repo "$GITHUB_REPOSITORY" --source-digest "$SOURCE_DIGEST" --signer-workflow "$SIGNER_WORKFLOW" --predicate-type "$SPDX_PREDICATE_TYPE"
+
+          cd "$RUNNER_TEMP"
+          gh attestation download "$SUBJECT_REF" --repo "$GITHUB_REPOSITORY" --predicate-type https://slsa.dev/provenance/v1
+          provenance_bundle="$RUNNER_TEMP/${MANIFEST_DIGEST}.jsonl"
+          tampered_bundle="$RUNNER_TEMP/tampered-provenance.jsonl"
+          gh attestation verify "$SUBJECT_REF" --bundle "$provenance_bundle" --repo "$GITHUB_REPOSITORY" --source-digest "$SOURCE_DIGEST" --signer-workflow "$SIGNER_WORKFLOW"
+          node "$GITHUB_WORKSPACE/scripts/container-attestation.mjs" tamper-bundle "$provenance_bundle" "$tampered_bundle"
+          if gh attestation verify "$SUBJECT_REF" --bundle "$tampered_bundle" --repo "$GITHUB_REPOSITORY" --source-digest "$SOURCE_DIGEST" --signer-workflow "$SIGNER_WORKFLOW" >/dev/null 2>&1; then
+            echo "A signature-preserving payload modification unexpectedly passed verification." >&2
+            exit 1
+          fi
+          if gh attestation verify "$SUBJECT_REF" --bundle-from-oci --repo "$GITHUB_REPOSITORY" --source-digest "$WRONG_SOURCE_DIGEST" --signer-workflow "$SIGNER_WORKFLOW" >/dev/null 2>&1; then
+            echo "Wrong source commit unexpectedly passed attestation verification." >&2
+            exit 1
+          fi
+          if gh attestation verify "$SUBJECT_REF" --bundle-from-oci --repo "$GITHUB_REPOSITORY" --source-digest "$SOURCE_DIGEST" --signer-workflow "$WRONG_SIGNER_WORKFLOW" >/dev/null 2>&1; then
+            echo "Wrong signer workflow unexpectedly passed attestation verification." >&2
+            exit 1
+          fi
       - name: Remove runner registry authentication
         if: always()
         run: docker logout ghcr.io

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -249,6 +249,7 @@ jobs:
           sbom-path: ${{ runner.temp }}/substack-mcp.spdx.json
           push-to-registry: true
       - name: Verify provenance, SBOM and rejection controls
+        if: steps.subject.outputs.generate == 'true'
         env:
           SUBJECT_REF: ${{ steps.subject.outputs.subject-ref }}
           SOURCE_DIGEST: ${{ steps.subject.outputs.source-digest }}
@@ -262,6 +263,8 @@ jobs:
 
           cd "$RUNNER_TEMP"
           gh attestation download "$SUBJECT_REF" --repo "$GITHUB_REPOSITORY" --predicate-type https://slsa.dev/provenance/v1
+          # gh names the bundle after the digest and only replaces the colon
+          # with a dash on Windows, so this holds while the job runs on Linux.
           provenance_bundle="$RUNNER_TEMP/${MANIFEST_DIGEST}.jsonl"
           tampered_bundle="$RUNNER_TEMP/tampered-provenance.jsonl"
           gh attestation verify "$SUBJECT_REF" --bundle "$provenance_bundle" --repo "$GITHUB_REPOSITORY" --source-digest "$SOURCE_DIGEST" --signer-workflow "$SIGNER_WORKFLOW"
@@ -270,14 +273,44 @@ jobs:
             echo "A signature-preserving payload modification unexpectedly passed verification." >&2
             exit 1
           fi
-          if gh attestation verify "$SUBJECT_REF" --bundle-from-oci --repo "$GITHUB_REPOSITORY" --source-digest "$WRONG_SOURCE_DIGEST" --signer-workflow "$SIGNER_WORKFLOW" >/dev/null 2>&1; then
+          if gh attestation verify "$SUBJECT_REF" --bundle "$provenance_bundle" --repo "$GITHUB_REPOSITORY" --source-digest "$WRONG_SOURCE_DIGEST" --signer-workflow "$SIGNER_WORKFLOW" >/dev/null 2>&1; then
             echo "Wrong source commit unexpectedly passed attestation verification." >&2
             exit 1
           fi
-          if gh attestation verify "$SUBJECT_REF" --bundle-from-oci --repo "$GITHUB_REPOSITORY" --source-digest "$SOURCE_DIGEST" --signer-workflow "$WRONG_SIGNER_WORKFLOW" >/dev/null 2>&1; then
+          if gh attestation verify "$SUBJECT_REF" --bundle "$provenance_bundle" --repo "$GITHUB_REPOSITORY" --source-digest "$SOURCE_DIGEST" --signer-workflow "$WRONG_SIGNER_WORKFLOW" >/dev/null 2>&1; then
             echo "Wrong signer workflow unexpectedly passed attestation verification." >&2
             exit 1
           fi
+      # A recovery run may rebuild a different image, so it cannot mint
+      # provenance for the preserved digest. Absent attestations must not block
+      # recovery of the npm, registry and GitHub release identities, so they are
+      # reported. Whatever does verify still has to reject wrong identities.
+      - name: Verify preserved attestations without minting provenance
+        if: steps.subject.outputs.generate != 'true'
+        env:
+          SUBJECT_REF: ${{ steps.subject.outputs.subject-ref }}
+          SOURCE_DIGEST: ${{ steps.subject.outputs.source-digest }}
+          WRONG_SOURCE_DIGEST: ${{ steps.subject.outputs.wrong-source-digest }}
+          SIGNER_WORKFLOW: ${{ steps.subject.outputs.signer-workflow }}
+          WRONG_SIGNER_WORKFLOW: ${{ steps.subject.outputs.wrong-signer-workflow }}
+          SPDX_PREDICATE_TYPE: ${{ steps.subject.outputs.spdx-predicate-type }}
+        run: |
+          for predicate in https://slsa.dev/provenance/v1 "$SPDX_PREDICATE_TYPE"; do
+            if ! gh attestation verify "$SUBJECT_REF" --bundle-from-oci --repo "$GITHUB_REPOSITORY" --source-digest "$SOURCE_DIGEST" --signer-workflow "$SIGNER_WORKFLOW" --predicate-type "$predicate"; then
+              echo "::warning::No verifiable $predicate attestation for $SUBJECT_REF. Inspect the verification error; absence, invalid evidence and service failures are not distinguished here."
+              printf 'Attestation UNVERIFIED: %s for %s. Recover a failed attest job with Re-run failed jobs on the original Publish run.\n' "$predicate" "$SUBJECT_REF" >> "$GITHUB_STEP_SUMMARY"
+              continue
+            fi
+            # These registry controls test policy plumbing, not a competing signer.
+            if gh attestation verify "$SUBJECT_REF" --bundle-from-oci --repo "$GITHUB_REPOSITORY" --source-digest "$WRONG_SOURCE_DIGEST" --signer-workflow "$SIGNER_WORKFLOW" --predicate-type "$predicate" >/dev/null 2>&1; then
+              echo "Wrong source commit unexpectedly passed attestation verification." >&2
+              exit 1
+            fi
+            if gh attestation verify "$SUBJECT_REF" --bundle-from-oci --repo "$GITHUB_REPOSITORY" --source-digest "$SOURCE_DIGEST" --signer-workflow "$WRONG_SIGNER_WORKFLOW" --predicate-type "$predicate" >/dev/null 2>&1; then
+              echo "Wrong signer workflow unexpectedly passed attestation verification." >&2
+              exit 1
+            fi
+          done
       - name: Remove runner registry authentication
         if: always()
         run: docker logout ghcr.io

--- a/docs/containers.md
+++ b/docs/containers.md
@@ -59,6 +59,15 @@ The provenance generation step runs only when the workflow commit is the verifie
 release source commit and the published digest equals the candidate built in that
 run. Historical recovery may verify an existing attestation, but it cannot mint
 new provenance from a different workflow commit or a different preserved image.
+Rebuilds are not guaranteed to be byte-identical, so a later Publish run cannot
+reliably attest a digest an earlier run left unattested. Recover a failed attest job with "Re-run
+failed jobs" on that original Publish run, which reuses the already verified
+candidate digest. A recovery run checks provenance and SBOM independently and reports unverifiable
+attestations as warnings and UNVERIFIED entries in the job summary instead of
+blocking release recovery. This includes missing or invalid evidence and service
+errors; a green recovery run does not certify that the image has valid
+attestations. Inspect the verification errors and require both consumer checks
+below to pass before treating the image as attested.
 Images built before this support may not have attestations. npm provenance is a
 separate attestation for the npm package and does not verify the container.
 
@@ -102,7 +111,10 @@ and identity. To inspect the provenance statement as additional evidence, add
 `verificationResult.statement.predicate.buildDefinition.resolvedDependencies`.
 Publish also downloads a real signed provenance bundle, alters its DSSE payload
 without changing its signature and requires verification to fail. Wrong source
-commit and wrong signer-workflow controls must fail against the real OCI bundles.
+commit and wrong signer-workflow controls must fail against that same positively
+verified downloaded bundle. These test identity constraints on a known bundle,
+not rejection of a separate artifact signed by a competing workflow. Recovery
+uses registry-based negative controls for each predicate that verifies.
 
 Reference: https://docs.github.com/en/actions/how-tos/secure-your-work/use-artifact-attestations/use-artifact-attestations
 

--- a/docs/containers.md
+++ b/docs/containers.md
@@ -53,13 +53,79 @@ The Publish workflow verifies npm, MCP Registry and GitHub identities first,
 then builds and tests the container from that original release commit. Older
 releases without container verification scripts are skipped. A failed container
 stage can be retried through Publish without republishing an existing npm release.
-OCI signing/SBOM attestations and build-tag retention are follow-ups; labels are
-identity metadata, not cryptographic attestations. Per-run build tags remain for diagnostics; they are not supported release tags.
+Releases whose source contains attestation support also publish signed GitHub
+build provenance and an SPDX 2.3 SBOM for the immutable image manifest digest.
+The provenance generation step runs only when the workflow commit is the verified
+release source commit and the published digest equals the candidate built in that
+run. Historical recovery may verify an existing attestation, but it cannot mint
+new provenance from a different workflow commit or a different preserved image.
+Images built before this support may not have attestations. npm provenance is a
+separate attestation for the npm package and does not verify the container.
 
 GHCR package visibility is separate from repository visibility. The first publish
 can create a private package. Set the project's GHCR package to public, then rerun
 Publish. The candidate is checked through an empty Docker configuration before
 release aliases are promoted, and the selected version is checked again. A successful authenticated push alone is not a public release.
 The workflow uses only its scoped GitHub token and removes its Docker login on exit.
+
+## Verify container attestations
+
+Use the digest recorded by the release workflow, not a mutable tag, and require
+this repository as the signer identity. GitHub CLI verification for GHCR uses the
+Docker credential store, so authenticate to `ghcr.io` first if needed.
+
+```sh
+IMAGE=ghcr.io/conorbronsdon/substack-mcp
+DIGEST=sha256:<64-hex-character-manifest-digest>
+SOURCE_COMMIT=<40-hex-character-release-commit>
+SIGNER_WORKFLOW=conorbronsdon/substack-mcp/.github/workflows/publish.yml
+
+docker login ghcr.io
+gh attestation verify "oci://$IMAGE@$DIGEST" \
+  --bundle-from-oci \
+  --repo conorbronsdon/substack-mcp \
+  --source-digest "$SOURCE_COMMIT" \
+  --signer-workflow "$SIGNER_WORKFLOW"
+gh attestation verify "oci://$IMAGE@$DIGEST" \
+  --bundle-from-oci \
+  --repo conorbronsdon/substack-mcp \
+  --source-digest "$SOURCE_COMMIT" \
+  --signer-workflow "$SIGNER_WORKFLOW" \
+  --predicate-type https://spdx.dev/Document/v2.3
+```
+
+The first command verifies registry-resident SLSA build provenance and constrains
+the signing certificate to the exact source commit and Publish workflow. The
+second verifies the signed SPDX SBOM predicate for the same image manifest digest
+and identity. To inspect the provenance statement as additional evidence, add
+`--format json` and review
+`verificationResult.statement.predicate.buildDefinition.resolvedDependencies`.
+Publish also downloads a real signed provenance bundle, alters its DSSE payload
+without changing its signature and requires verification to fail. Wrong source
+commit and wrong signer-workflow controls must fail against the real OCI bundles.
+
+Reference: https://docs.github.com/en/actions/how-tos/secure-your-work/use-artifact-attestations/use-artifact-attestations
+
+## Build-tag retention
+
+Supported release identities are the semantic version tag, every supported
+release's `sha-<full-source-commit>` alias and its immutable manifest digest.
+`latest` is a convenience alias and is never the identity used for retention or
+attestation verification. These identities and their attestations must not be
+removed by candidate cleanup.
+
+Per-run `build-<run-id>-<attempt>` tags are publication receipts. An unpromoted
+candidate may become cleanup-eligible after 30 days. A promoted candidate points
+at the same manifest as release tags, so it is retained for as long as any
+supported release alias references that manifest. GHCR's package-version delete
+operation can remove a shared manifest and all of its tags; deleting such a
+version merely to hide one build tag is prohibited.
+
+Automated deletion remains disabled until a staging package proves tag/version
+semantics end to end. Any future cleanup must run in a dedicated least-privilege
+job, inventory digest-to-tag relationships immediately before deletion, limit
+itself to unpromoted build-only versions older than 30 days, re-read the candidate
+before deleting it and stop on unknown API responses. It must have regression
+controls showing version, source and attestation-bearing digests are preserved.
 
 Reference: https://docs.github.com/en/packages/learn-github-packages/configuring-a-packages-access-control-and-visibility

--- a/scripts/container-attestation.mjs
+++ b/scripts/container-attestation.mjs
@@ -1,0 +1,103 @@
+// Builds only validated attestation references. It does not contact GitHub or a registry.
+import assert from 'node:assert/strict';
+import { appendFileSync, readFileSync, writeFileSync } from 'node:fs';
+import { pathToFileURL } from 'node:url';
+
+export const SPDX_PREDICATE_TYPE = 'https://spdx.dev/Document/v2.3';
+const expectedImage = 'ghcr.io/conorbronsdon/substack-mcp';
+const expectedRepository = 'conorbronsdon/substack-mcp';
+const digestPattern = /^sha256:[a-f0-9]{64}$/;
+const revisionPattern = /^[a-f0-9]{40}$/;
+
+export function prepareContainerAttestation({ image, digest, revision, workflowRevision, repository, generate }) {
+  assert.equal(image, expectedImage, 'Refusing to attest an unexpected container image');
+  assert.equal(repository, expectedRepository, 'Refusing to attest from an unexpected source repository');
+  assert.match(digest ?? '', digestPattern, 'Expected a SHA-256 image manifest digest');
+  assert.match(revision ?? '', revisionPattern, 'Expected the verified release source commit');
+  assert.match(workflowRevision ?? '', revisionPattern, 'Expected the workflow source commit');
+  assert.ok(typeof generate === 'boolean', 'Expected an explicit attestation generation decision');
+  if (generate) assert.equal(workflowRevision, revision, 'Refusing to mint provenance from a workflow commit other than the verified release source');
+
+  const wrongSourceDigest = `${revision.slice(0, -1)}${revision.endsWith('0') ? '1' : '0'}`;
+  return {
+    subject_name: image,
+    manifest_digest: digest,
+    image_ref: `${image}@${digest}`,
+    subject_ref: `oci://${image}@${digest}`,
+    source_digest: revision,
+    wrong_source_digest: wrongSourceDigest,
+    signer_workflow: `${repository}/.github/workflows/publish.yml`,
+    wrong_signer_workflow: `${repository}/.github/workflows/container.yml`,
+    generate,
+    spdx_predicate_type: SPDX_PREDICATE_TYPE,
+  };
+}
+
+export function tamperAttestationBundle(contents) {
+  const lines = contents.split(/\r?\n/).filter(line => line.trim());
+  assert.ok(lines.length > 0, 'Expected at least one Sigstore bundle');
+  return `${lines.map(line => {
+    const bundle = JSON.parse(line);
+    assert.equal(typeof bundle.dsseEnvelope?.payload, 'string', 'Expected a DSSE payload in each Sigstore bundle');
+    const statement = JSON.parse(Buffer.from(bundle.dsseEnvelope.payload, 'base64').toString('utf8'));
+    assert.equal(typeof statement.predicate, 'object', 'Expected an in-toto predicate in each Sigstore bundle');
+    statement.predicate = { ...statement.predicate, _signature_tamper_control: true };
+    bundle.dsseEnvelope.payload = Buffer.from(JSON.stringify(statement)).toString('base64');
+    return JSON.stringify(bundle);
+  }).join('\n')}\n`;
+}
+
+export function githubOutputs(result) {
+  return [
+    `subject-name=${result.subject_name}`,
+    `manifest-digest=${result.manifest_digest}`,
+    `image-ref=${result.image_ref}`,
+    `subject-ref=${result.subject_ref}`,
+    `source-digest=${result.source_digest}`,
+    `wrong-source-digest=${result.wrong_source_digest}`,
+    `signer-workflow=${result.signer_workflow}`,
+    `wrong-signer-workflow=${result.wrong_signer_workflow}`,
+    `generate=${result.generate}`,
+    `spdx-predicate-type=${result.spdx_predicate_type}`,
+    '',
+  ].join('\n');
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  if (process.argv[2] === 'tamper-bundle') {
+    try {
+      const [, , , source, destination] = process.argv;
+      if (!source || !destination) throw new Error('Source and destination bundle paths are required');
+      writeFileSync(destination, tamperAttestationBundle(readFileSync(source, 'utf8')), { flag: 'wx' });
+    } catch {
+      console.error('Could not create the signature-tampering control bundle.');
+      process.exitCode = 1;
+    }
+  } else {
+    const {
+      IMAGE: image,
+      MANIFEST_DIGEST: digest,
+      RELEASE_TARGET: revision,
+      GITHUB_SHA: workflowRevision,
+      GITHUB_REPOSITORY: repository,
+      GENERATE_ATTESTATIONS,
+      GITHUB_OUTPUT,
+    } = process.env;
+    try {
+      const result = prepareContainerAttestation({
+        image,
+        digest,
+        revision,
+        workflowRevision,
+        repository,
+        generate: GENERATE_ATTESTATIONS === 'true',
+      });
+      if (!GITHUB_OUTPUT) throw new Error('GITHUB_OUTPUT is required in the release workflow');
+      appendFileSync(GITHUB_OUTPUT, githubOutputs(result));
+      console.log(JSON.stringify({ subject: result.subject_ref, source: revision }));
+    } catch (error) {
+      console.error(error instanceof assert.AssertionError ? error.message : 'Could not prepare container attestation inputs.');
+      process.exitCode = 1;
+    }
+  }
+}

--- a/scripts/publish-container.controls.mjs
+++ b/scripts/publish-container.controls.mjs
@@ -1,40 +1,138 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
-import { publishContainer } from './publish-container.mjs';
+import { readFileSync } from 'node:fs';
+import { githubOutputs as attestationOutputs, prepareContainerAttestation, SPDX_PREDICATE_TYPE, tamperAttestationBundle } from './container-attestation.mjs';
+import { githubOutputs, publishContainer } from './publish-container.mjs';
 import pkg from '../package.json' with { type: 'json' };
 const input = { version: pkg.version, revision: 'a'.repeat(40), run: '1', attempt: '1', temp: '/temporary' };
 const image = 'ghcr.io/conorbronsdon/substack-mcp';
 function fixture(mode) {
   const calls = []; let verified = 0, versionLookups = 0;
   const manifest = { config: { digest: 'sha256:' + 'b'.repeat(64) } };
+  const differentManifest = { config: { digest: 'sha256:' + 'c'.repeat(64) } };
+  const registryDigest = 'sha256:' + 'e'.repeat(64);
+  const differentRegistryDigest = 'sha256:' + 'd'.repeat(64);
+  const usesExistingRelease = ref => mode === 'existing_different' && (ref === `${image}:${pkg.version}` || ref === `${image}:latest` || ref.startsWith(`${image}:sha-`));
   const docker = (...args) => {
     calls.push(args);
     if (args[0] === '--config') {
       if (mode === 'private') throw new Error('unauthorized');
-      return JSON.stringify(manifest);
+      return JSON.stringify(usesExistingRelease(args[4]) ? differentManifest : manifest);
     }
-    if (args[0] === 'image') return JSON.stringify([{ Id: (mode === 'race' && args[2] === `${image}:${pkg.version}`) || (mode === 'candidate_race' && args[2].includes(':build-')) ? 'sha256:' + 'd'.repeat(64) : manifest.config.digest, Config: { Labels: { 'org.opencontainers.image.version': pkg.version, 'org.opencontainers.image.revision': mode === 'mismatch' ? 'c'.repeat(40) : input.revision } } }]);
+    if (args[0] === 'image') return JSON.stringify([{
+      Id: (mode === 'race' && args[2] === `${image}:${pkg.version}`) || (mode === 'candidate_race' && args[2].includes(':build-')) ? 'sha256:' + 'd'.repeat(64) : mode === 'existing_different' && args[2] === `${image}:${pkg.version}` ? differentManifest.config.digest : manifest.config.digest,
+      Config: { Labels: { 'org.opencontainers.image.version': pkg.version, 'org.opencontainers.image.revision': mode === 'mismatch' ? 'c'.repeat(40) : input.revision } },
+    }]);
     if (args[0] === 'manifest') {
+      if (args[2] === '--verbose') {
+        const ref = args[3];
+        if (mode === 'missing_digest') return JSON.stringify({ Descriptor: {} });
+        if (mode === 'conflicting_digests') return JSON.stringify({ Descriptor: { digest: registryDigest }, Digest: 'sha256:' + 'f'.repeat(64) });
+        if (mode === 'manifest_list') return JSON.stringify([{ Descriptor: { digest: registryDigest } }]);
+        return JSON.stringify({ Descriptor: { digest: usesExistingRelease(ref) ? differentRegistryDigest : registryDigest } });
+      }
       if (args[2] === `${image}:${pkg.version}` && ++versionLookups === 1 && ['absent', 'unknown'].includes(mode)) throw Object.assign(new Error('lookup failed'), { stderr: mode === 'absent' ? 'manifest unknown' : 'unauthorized' });
-      return JSON.stringify(manifest);
+      return JSON.stringify(usesExistingRelease(args[2]) ? differentManifest : manifest);
     }
     return '';
   };
   return { calls, run: () => publishContainer(input, { docker, verifyImage: () => { verified++; }, makeDirectory: () => {} }), verified: () => verified };
 }
 test('new version publishes after an explicit missing-manifest response', () => {
-  const f = fixture('absent'); assert.equal(f.run().public, true);
+  const f = fixture('absent'); const result = f.run(); assert.equal(result.public, true);
+  assert.equal(result.manifest_digest, 'sha256:' + 'e'.repeat(64));
+  assert.equal(result.subject_name, image); assert.equal(result.provenance_eligible, true); assert.equal(f.verified(), 1);
   assert.ok(f.calls.some(args => args[0] === 'push' && args[1] === `${image}:${pkg.version}`));
 });
 test('existing matching version is tested and preserved on recovery', () => {
   const f = fixture('existing'); assert.equal(f.run().public, true); assert.equal(f.verified(), 1);
   assert.ok(!f.calls.some(args => args[0] === 'push' && args[1] === `${image}:${pkg.version}`));
 });
+test('a preserved existing image with different bytes cannot receive new provenance', () => {
+  const f = fixture('existing_different'); const result = f.run();
+  assert.equal(result.manifest_digest, 'sha256:' + 'd'.repeat(64));
+  assert.equal(result.candidate_digest, 'sha256:' + 'e'.repeat(64));
+  assert.equal(result.provenance_eligible, false);
+  assert.ok(!f.calls.some(args => args[0] === 'push' && args[1] === `${image}:${pkg.version}`));
+});
 for (const mode of ['unknown', 'mismatch', 'race', 'candidate_race']) test(`${mode} identity never moves release aliases`, () => {
   const f = fixture(mode); assert.throws(f.run);
+  assert.ok(!f.calls.some(args => args[0] === 'tag' && /:(latest|sha-|[0-9]+\.)/.test(args[2])));
+});
+for (const mode of ['missing_digest', 'conflicting_digests', 'manifest_list']) test(`${mode} stops before release aliases move`, () => {
+  const f = fixture(mode); assert.throws(f.run, /manifest descriptor digest/);
   assert.ok(!f.calls.some(args => args[0] === 'tag' && /:(latest|sha-|[0-9]+\.)/.test(args[2])));
 });
 test('private package cannot report a successful public release', () => {
   const f = fixture('private'); assert.throws(f.run, /Anonymous access failed/);
   assert.ok(!f.calls.some(args => args[0] === 'tag' && /:(latest|sha-|[0-9]+\.)/.test(args[2])));
+});
+test('workflow outputs expose immutable registry digests and provenance eligibility', () => {
+  const result = fixture('absent').run();
+  assert.equal(githubOutputs(result), `image=${image}:${pkg.version}\nsubject-name=${image}\nmanifest-digest=sha256:${'e'.repeat(64)}\ncandidate-digest=sha256:${'e'.repeat(64)}\nprovenance-eligible=true\n`);
+  assert.ok(!githubOutputs(result).includes(manifestConfigDigest()));
+});
+function manifestConfigDigest() { return 'sha256:' + 'b'.repeat(64); }
+
+test('attestation subject is the immutable manifest digest from the verified source', () => {
+  const digest = 'sha256:' + 'e'.repeat(64);
+  const result = prepareContainerAttestation({
+    image, digest, revision: input.revision, workflowRevision: input.revision,
+    repository: 'conorbronsdon/substack-mcp', generate: true,
+  });
+  assert.equal(result.subject_ref, `oci://${image}@${digest}`);
+  assert.equal(result.image_ref, `${image}@${digest}`);
+  assert.equal(result.spdx_predicate_type, SPDX_PREDICATE_TYPE);
+  assert.equal(result.source_digest, input.revision);
+  assert.notEqual(result.wrong_source_digest, result.source_digest);
+  assert.equal(result.signer_workflow, 'conorbronsdon/substack-mcp/.github/workflows/publish.yml');
+  assert.equal(result.wrong_signer_workflow, 'conorbronsdon/substack-mcp/.github/workflows/container.yml');
+  assert.match(attestationOutputs(result), new RegExp(`manifest-digest=${digest}`));
+});
+
+test('attestation generation rejects a different workflow source commit', () => {
+  assert.throws(() => prepareContainerAttestation({
+    image, digest: 'sha256:' + 'e'.repeat(64), revision: input.revision,
+    workflowRevision: 'f'.repeat(40), repository: 'conorbronsdon/substack-mcp', generate: true,
+  }), /workflow commit other than the verified release source/);
+});
+
+test('attestation preparation rejects malformed digests and unexpected identities', () => {
+  const valid = { image, digest: 'sha256:' + 'e'.repeat(64), revision: input.revision, workflowRevision: input.revision, repository: 'conorbronsdon/substack-mcp', generate: true };
+  assert.throws(() => prepareContainerAttestation({ ...valid, digest: manifestConfigDigest().slice(0, -1) }), /manifest digest/);
+  assert.throws(() => prepareContainerAttestation({ ...valid, image: 'ghcr.io/attacker/image' }), /unexpected container image/);
+  assert.throws(() => prepareContainerAttestation({ ...valid, repository: 'attacker/repository' }), /unexpected source repository/);
+});
+
+test('historical recovery may verify existing attestations but cannot mint new provenance', () => {
+  const result = prepareContainerAttestation({
+    image, digest: 'sha256:' + 'e'.repeat(64), revision: input.revision,
+    workflowRevision: 'f'.repeat(40), repository: 'conorbronsdon/substack-mcp', generate: false,
+  });
+  assert.equal(result.subject_ref, `oci://${image}@sha256:${'e'.repeat(64)}`);
+  assert.equal(result.generate, false);
+});
+
+test('signature tamper control changes signed DSSE payload but preserves its signature', () => {
+  const statement = { _type: 'https://in-toto.io/Statement/v1', predicate: { buildDefinition: {} } };
+  const bundle = { dsseEnvelope: { payload: Buffer.from(JSON.stringify(statement)).toString('base64'), payloadType: 'application/vnd.in-toto+json', signatures: [{ sig: 'signed-value' }] } };
+  const tampered = JSON.parse(tamperAttestationBundle(`${JSON.stringify(bundle)}\n`).trim());
+  const tamperedStatement = JSON.parse(Buffer.from(tampered.dsseEnvelope.payload, 'base64').toString('utf8'));
+  assert.equal(tamperedStatement.predicate._signature_tamper_control, true);
+  assert.notEqual(tampered.dsseEnvelope.payload, bundle.dsseEnvelope.payload);
+  assert.deepEqual(tampered.dsseEnvelope.signatures, bundle.dsseEnvelope.signatures);
+});
+
+test('publish workflow pins generation and verification to digest, source and signer', () => {
+  const workflow = readFileSync('.github/workflows/publish.yml', 'utf8').replaceAll('\r\n', '\n');
+  for (const required of [
+    'anchore/sbom-action@3ad7283483fc7af8ff2b4ea19663c2d5ca935e26',
+    'actions/attest@1e69f48acb82d1966a394da916b4c1698aa569d6',
+    "needs.container.outputs.provenance_eligible == 'true'",
+    '--bundle-from-oci', '--source-digest "$SOURCE_DIGEST"', '--signer-workflow "$SIGNER_WORKFLOW"',
+    'artifact-metadata: write',
+  ]) assert.ok(workflow.includes(required), `Missing release attestation control: ${required}`);
+  const downloadedBundleVerification = workflow.indexOf('gh attestation verify "$SUBJECT_REF" --bundle "$provenance_bundle"');
+  const bundleTamper = workflow.indexOf('tamper-bundle "$provenance_bundle"');
+  assert.ok(downloadedBundleVerification > 0 && bundleTamper > downloadedBundleVerification, 'The real bundle must pass before the tampered copy is rejected');
 });

--- a/scripts/publish-container.controls.mjs
+++ b/scripts/publish-container.controls.mjs
@@ -1,6 +1,9 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
-import { readFileSync } from 'node:fs';
+import { mkdtempSync, readFileSync, rmSync } from 'node:fs';
+import { spawnSync } from 'node:child_process';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 import { githubOutputs as attestationOutputs, prepareContainerAttestation, SPDX_PREDICATE_TYPE, tamperAttestationBundle } from './container-attestation.mjs';
 import { githubOutputs, publishContainer } from './publish-container.mjs';
 import pkg from '../package.json' with { type: 'json' };
@@ -135,4 +138,77 @@ test('publish workflow pins generation and verification to digest, source and si
   const downloadedBundleVerification = workflow.indexOf('gh attestation verify "$SUBJECT_REF" --bundle "$provenance_bundle"');
   const bundleTamper = workflow.indexOf('tamper-bundle "$provenance_bundle"');
   assert.ok(downloadedBundleVerification > 0 && bundleTamper > downloadedBundleVerification, 'The real bundle must pass before the tampered copy is rejected');
+  for (const identity of ['--source-digest "$WRONG_SOURCE_DIGEST"', '--signer-workflow "$WRONG_SIGNER_WORKFLOW"']) {
+    assert.ok(workflow.split('\n').some(line => line.includes('--bundle "$provenance_bundle"') && line.includes(identity)), 'Generation must test the known verified bundle against each wrong identity');
+  }
 });
+
+test('attestation verification is gated so a recovery run can never be permanently stuck', () => {
+  const workflow = readFileSync('.github/workflows/publish.yml', 'utf8').replaceAll('\r\n', '\n');
+  const steps = new Map(workflow.split('\n      - name: ').slice(1).map(block => [block.split('\n')[0], block]));
+  const minting = steps.get('Verify provenance, SBOM and rejection controls');
+  const recovery = steps.get('Verify preserved attestations without minting provenance');
+  assert.ok(minting && recovery, 'Expected separate minting and recovery verification steps');
+  // Only the run that minted attestations may require them; a recovery run
+  // rebuilds a different image and can never produce them for this digest.
+  assert.match(minting, /^\s+if: steps\.subject\.outputs\.generate == 'true'$/m);
+  assert.match(recovery, /^\s+if: steps\.subject\.outputs\.generate != 'true'$/m);
+  assert.ok(minting.includes('tamper-bundle'), 'The tamper control belongs to the minting run');
+  assert.ok(!recovery.includes('tamper-bundle'));
+  // Absent attestations are reported, but a wrong identity is never accepted.
+  assert.ok(recovery.includes('::warning::No verifiable $predicate attestation'));
+  for (const control of ['$WRONG_SOURCE_DIGEST', '$WRONG_SIGNER_WORKFLOW']) {
+    assert.ok(minting.includes(control) && recovery.includes(control), `Both runs must reject ${control}`);
+  }
+});
+
+// Execute the actual recovery shell with synthetic gh results. Production runs
+// on Ubuntu; no registry access or credentials are involved in these controls.
+for (const scenario of ['valid', 'missing-provenance', 'missing-sbom', 'unavailable', 'wrong-source', 'wrong-signer']) {
+  test(`recovery shell handles ${scenario}`, { skip: process.platform === 'win32' }, () => {
+    const workflow = readFileSync('.github/workflows/publish.yml', 'utf8').replaceAll('\r\n', '\n');
+    const block = workflow.split('      - name: Verify preserved attestations without minting provenance\n')[1].split('      - name: ')[0];
+    const shell = block.split('        run: |\n')[1].replace(/^          /gm, '');
+    const directory = mkdtempSync(join(tmpdir(), 'attestation-control-'));
+    const summary = join(directory, 'summary');
+    const calls = join(directory, 'calls');
+    try {
+      const mock = `
+        gh() {
+          printf '%s\\n' "$*" >> "$CALLS"
+          case "$SCENARIO:$*" in
+            unavailable:*) return 1 ;;
+            missing-provenance:*https://slsa.dev/provenance/v1*) return 1 ;;
+            missing-sbom:*https://spdx.dev/Document/v2.3*) return 1 ;;
+          esac
+          case "$*" in
+            *wrong-source*) [ "$SCENARIO" = wrong-source ]; return $? ;;
+            *wrong-signer*) [ "$SCENARIO" = wrong-signer ]; return $? ;;
+          esac
+          return 0
+        }
+      `;
+      const result = spawnSync('bash', ['--noprofile', '--norc', '-e', '-o', 'pipefail', '-c', mock + shell], {
+        encoding: 'utf8',
+        env: { ...process.env, SCENARIO: scenario, CALLS: calls, GITHUB_STEP_SUMMARY: summary,
+          SUBJECT_REF: 'oci://example-image@sha256:example-digest', GITHUB_REPOSITORY: 'example/repository',
+          SOURCE_DIGEST: 'example-source', WRONG_SOURCE_DIGEST: 'wrong-source',
+          SIGNER_WORKFLOW: 'example-signer', WRONG_SIGNER_WORKFLOW: 'wrong-signer',
+          SPDX_PREDICATE_TYPE: SPDX_PREDICATE_TYPE },
+      });
+      assert.ifError(result.error);
+      assert.equal(result.status, scenario.startsWith('wrong-') ? 1 : 0, result.stderr);
+      const invocations = readFileSync(calls, 'utf8').trim().split('\n');
+      if (!scenario.startsWith('wrong-')) {
+        assert.ok(invocations.some(call => call.includes(SPDX_PREDICATE_TYPE)), 'SBOM must be checked even without provenance');
+        assert.equal(invocations.length, scenario === 'valid' ? 6 : scenario === 'unavailable' ? 2 : 4);
+      }
+      if (scenario.startsWith('missing-') || scenario === 'unavailable') {
+        assert.match(result.stdout, /::warning::/);
+        assert.match(readFileSync(summary, 'utf8'), /Attestation UNVERIFIED/);
+      }
+    } finally {
+      rmSync(directory, { recursive: true, force: true });
+    }
+  });
+}

--- a/scripts/publish-container.mjs
+++ b/scripts/publish-container.mjs
@@ -1,10 +1,20 @@
 // Runs only in the verified release job. Never prints credentials or registry bodies.
 import assert from 'node:assert/strict';
 import { execFileSync } from 'node:child_process';
-import { mkdirSync } from 'node:fs';
+import { appendFileSync, mkdirSync } from 'node:fs';
 import { join } from 'node:path';
 import pkg from '../package.json' with { type: 'json' };
 import { pathToFileURL } from 'node:url';
+const digestPattern = /^sha256:[a-f0-9]{64}$/;
+function manifestDigest(inspected) {
+const matches = [...new Set([inspected.Descriptor?.digest, inspected.Digest].filter(Boolean))];
+assert.equal(matches.length, 1, 'Expected one remote manifest descriptor digest for the published image');
+assert.match(matches[0], digestPattern, 'Expected a SHA-256 registry manifest digest');
+return matches[0];
+}
+export function githubOutputs(result) {
+return `image=${result.image}\nsubject-name=${result.subject_name}\nmanifest-digest=${result.manifest_digest}\ncandidate-digest=${result.candidate_digest}\nprovenance-eligible=${result.provenance_eligible}\n`;
+}
 export function publishContainer({ version, revision, run, attempt, temp }, { docker, verifyImage, makeDirectory }) {
 const image = 'ghcr.io/conorbronsdon/substack-mcp';
 assert.equal(version, pkg.version); assert.match(version, /^\d+\.\d+\.\d+$/);
@@ -16,6 +26,7 @@ docker('tag', `${image}:build`, candidate); docker('push', candidate);
 // Verify public candidate access before creating or moving any release alias.
 const anonymous = join(temp, `docker-anonymous-${run}-${attempt}`); makeDirectory(anonymous);
 const inspect = ref => JSON.parse(docker('manifest', 'inspect', ref));
+const inspectVerbose = ref => JSON.parse(docker('manifest', 'inspect', '--verbose', ref));
 const verifyPublic = (ref, expected) => {
   let observed;
   try { observed = JSON.parse(docker('--config', anonymous, 'manifest', 'inspect', ref)); }
@@ -24,8 +35,14 @@ const verifyPublic = (ref, expected) => {
 };
 const candidateManifest = inspect(candidate);
 assert.ok(candidateManifest.config?.digest, 'Expected a single-platform image manifest');
-assert.equal(JSON.parse(docker('image', 'inspect', candidate))[0].Id, candidateManifest.config.digest);
 verifyPublic(candidate, candidateManifest);
+// The remote descriptor is scoped to this exact tag. Unlike RepoDigests on a
+// local config/image ID, it cannot become ambiguous across multiple manifests.
+const candidateDigest = manifestDigest(inspectVerbose(candidate));
+const candidateInfo = JSON.parse(docker('image', 'inspect', candidate))[0];
+assert.equal(candidateInfo.Id, candidateManifest.config.digest);
+assert.equal(candidateInfo.Config.Labels['org.opencontainers.image.version'], version);
+assert.equal(candidateInfo.Config.Labels['org.opencontainers.image.revision'], revision);
 let existing;
 try { existing = inspect(versioned); }
 catch (error) {
@@ -33,11 +50,10 @@ catch (error) {
 }
 if (existing) {
   docker('pull', versioned);
-  const info = JSON.parse(docker('image', 'inspect', versioned))[0];
-  assert.equal(info.Id, existing.config?.digest, 'Pulled image differs from the inspected release manifest');
-  assert.equal(info.Config.Labels['org.opencontainers.image.version'], version);
-  assert.equal(info.Config.Labels['org.opencontainers.image.revision'], revision);
-  verifyImage(versioned, revision);
+  const releaseInfo = JSON.parse(docker('image', 'inspect', versioned))[0];
+  assert.equal(releaseInfo.Id, existing.config?.digest, 'Pulled image differs from the inspected release manifest');
+  assert.equal(releaseInfo.Config.Labels['org.opencontainers.image.version'], version);
+  assert.equal(releaseInfo.Config.Labels['org.opencontainers.image.revision'], revision);
   verifyPublic(versioned, existing);
 } else {
   docker('tag', candidate, versioned); docker('push', versioned);
@@ -45,17 +61,32 @@ if (existing) {
 const manifest = inspect(versioned);
 assert.deepEqual(manifest, existing ?? candidateManifest);
 verifyPublic(versioned, manifest);
+verifyImage(versioned, revision);
+const releaseDigest = manifestDigest(inspectVerbose(versioned));
+if (!existing) assert.equal(releaseDigest, candidateDigest, 'Version tag differs from the verified candidate manifest');
 // Full-SHA and latest aliases point to the same already-verified public version.
-for (const tag of [`sha-${revision}`, 'latest']) { docker('tag', versioned, `${image}:${tag}`); docker('push', `${image}:${tag}`); }
-return { image: versioned, revision, architecture: 'linux/amd64', public: true, config_digest: manifest.config.digest };
+for (const tag of [`sha-${revision}`, 'latest']) {
+  const alias = `${image}:${tag}`;
+  docker('tag', versioned, alias); docker('push', alias);
+  assert.deepEqual(inspect(alias), manifest, `Published alias ${alias} differs from the version manifest`);
+  assert.equal(manifestDigest(inspectVerbose(alias)), releaseDigest, `Published alias ${alias} has a different manifest digest`);
+  verifyPublic(alias, manifest);
+}
+return {
+  image: versioned, subject_name: image, revision, architecture: 'linux/amd64', public: true,
+  manifest_digest: releaseDigest, candidate_digest: candidateDigest,
+  provenance_eligible: releaseDigest === candidateDigest, config_digest: manifest.config.digest,
+};
 }
 if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
   const { VERSION: version, RELEASE_TARGET: revision, GITHUB_RUN_ID: run, GITHUB_RUN_ATTEMPT: attempt, RUNNER_TEMP: temp } = process.env;
   const docker = (...args) => execFileSync('docker', args, { encoding: 'utf8', timeout: 180000, maxBuffer: 1024 * 1024, stdio: ['ignore', 'pipe', 'pipe'] });
   try {
-    console.log(JSON.stringify(publishContainer({ version, revision, run, attempt, temp }, {
+    const result = publishContainer({ version, revision, run, attempt, temp }, {
       docker, makeDirectory: path => mkdirSync(path, { recursive: true }),
       verifyImage: (image, sha) => execFileSync(process.execPath, ['scripts/test-container.mjs', image, sha], { stdio: 'inherit', timeout: 120000 }),
-    })));
+    });
+    if (process.env.GITHUB_OUTPUT) appendFileSync(process.env.GITHUB_OUTPUT, githubOutputs(result));
+    console.log(JSON.stringify(result));
   } catch (error) { console.error(error instanceof assert.AssertionError ? 'Container identity mismatch; publication stopped.' : error.message.startsWith('Command failed') ? 'Container command failed; inspect the release stage and reconcile before retrying.' : error.message); process.exitCode = 1; }
 }


### PR DESCRIPTION
Closes #91

## Summary

- publish the exact remote OCI manifest descriptor digest as a release output instead of confusing it with Docker's config/image ID
- generate signed SLSA build provenance and an SPDX 2.3 SBOM with pinned `actions/attest` and Anchore actions
- verify registry-resident bundles against the immutable digest, exact release source commit, and exact Publish workflow
- prove rejection with a real downloaded bundle that passes unchanged, then fails after its signed DSSE payload is modified; wrong-source and wrong-workflow controls also must fail
- document a conservative 30-day candidate policy while keeping deletion disabled until GHCR tag/version semantics are proven on a staging package

## Release safety

New provenance is minted only when both the workflow commit and the newly built candidate digest match the selected release. Historical recovery may verify existing attestations, but cannot sign a different preserved image. Existing release aliases remain recovery-safe, and no cleanup job or delete permission is introduced.

## Verification

- `npm run check:release`
- `npm run test:release` (44/44)
- `npm run lint`
- `npm test` (779/779)
- `npm run test:package`
- actionlint 1.7.12
- `git diff --check`
- independent Astra adversarial review: no remaining P1/P2/P3 findings

Docker is unavailable in the local workspace, so the real GHCR publication, OCI attachment, and Sigstore verification remain intentionally gated by the release workflow.