### PR TITLE
ci: check documented Node requirement for SSOT drift

### DIFF
--- a/.github/workflows/ssot.yml
+++ b/.github/workflows/ssot.yml
@@ -1,0 +1,31 @@
+name: SSOT
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  ssot:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - name: Get the reviewed checker
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          repository: conorbronsdon/ssot-check
+          ref: f3289c400cd591cdcb6ce4016627a442d0804ce7 # v0.1.3
+          path: .ssot-tool
+          persist-credentials: false
+      - name: Check registered compatibility claims
+        run: python3 .ssot-tool/ssot_check.py check --manifest .ssot.yaml
+      - name: Warn about possible unregistered copies
+        run: python3 .ssot-tool/ssot_check.py discover --manifest .ssot.yaml --untracked-only --github-annotations
+      - name: Exercise drift and advisory controls
+        run: python3 scripts/check-ssot-controls.py .ssot-tool/ssot_check.py

--- a/.ssot.yaml
+++ b/.ssot.yaml
@@ -1,0 +1,15 @@
+# Release manifests already have check:release; this pilot covers prose requirements.
+# History and synthetic examples are not current compatibility promises.
+ignore_paths:
+  - "CHANGELOG.md"
+  - "src/__tests__/**"
+  - ".ssot-tool/**"
+facts:
+  - name: minimum-node-major
+    type: integer
+    canonical:
+      file: package.json
+      pattern: '"node": ">=(\d+)\.0\.0"'
+    copies:
+      - file: README.md
+        pattern: 'Requires \*\*Node\.js (\d+) or newer\*\*'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html). Releases before
 `0.6.0` are recorded in the [GitHub Releases](https://github.com/conorbronsdon/substack-mcp/releases)
 and the git tag history (`v0.1.0`–`v0.5.0`).
 
+## [Unreleased]
+
+### Added
+- SSOT CI checks for the documented Node minimum, advisory discovery, and
+  mutation controls for registered drift and intentional exclusions.
+
 ## [1.0.0] - 2026-09-08
 
 ### Added

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,6 +13,38 @@ Thanks for helping improve substack-mcp. Issues and pull requests are welcome.
   long-form posts. Notes publish immediately by design and their descriptions
   must keep saying so loudly.
 
+## Documentation drift
+
+The `SSOT / ssot` CI job checks the Node minimum in `.ssot.yaml` on every PR.
+`package.json` owns the requirement; the README is a hand-maintained copy.
+Release-version synchronization remains owned by `npm run check:release`.
+
+A mismatched or missing registered copy fails the job. Correct the underlying
+claim, then its copies; do not delete a locator just to make CI pass. Explain
+changes to canonical ownership, locators, or discovery exclusions in the PR.
+
+Discovery scans prose and emits advisory warnings for possible unregistered
+copies. It does not detect every value: the Node floor needs its explicit
+locator. Review each warning before adding a copy or an exclusion. Changelog
+history and synthetic tests are excluded; explicit locators remain checked.
+The initial discovery baseline contains loopback addresses in README/container
+examples, which are intentional and are not release-version drift.
+
+To reproduce CI, check out the checker revision pinned in
+`.github/workflows/ssot.yml` into a sibling `ssot-check` directory, then run:
+
+```bash
+python3 ../ssot-check/ssot_check.py check --manifest .ssot.yaml
+python3 ../ssot-check/ssot_check.py discover --manifest .ssot.yaml --untracked-only --github-annotations
+python3 scripts/check-ssot-controls.py ../ssot-check/ssot_check.py
+```
+
+Controls mutate disposable copies, verify drift and missing-copy failures,
+restore a passing baseline, and prove exclusions do not hide registered drift.
+A synthetic unregistered price must warn while `check` stays green. During the
+pilot, record useful findings, repeated warnings, and maintenance effort in the
+PR or a follow-up issue before expanding the manifest.
+
 ## Working against the unofficial API
 
 This server talks to Substack's unofficial API, so the highest-value

--- a/scripts/check-ssot-controls.py
+++ b/scripts/check-ssot-controls.py
@@ -56,6 +56,8 @@ def main():
                     raise AssertionError(f"Mutation did not report drift: {locator}")
                 # Discovery exclusions must not disable an explicitly registered copy.
                 ignored = manifest_text.replace("ignore_paths:\n", f'ignore_paths:\n  - "{locator["file"]}"\n', 1)
+                if locator["file"] not in checker.parse_manifest(ignored).get("ignore_paths", []):
+                    raise AssertionError("Exclusion control did not add the target path")
                 (scratch / manifest_name).write_text(ignored, encoding="utf-8")
                 run(scratch, "check", 1)
                 (scratch / manifest_name).write_text(manifest_text, encoding="utf-8")
@@ -75,6 +77,7 @@ def main():
         scratch = Path(directory)
         (scratch / manifest_name).write_text(r"""ignore_paths:
   - "CHANGELOG.md"
+  - "history/**"
 facts:
   - name: example-price
     type: currency
@@ -88,14 +91,21 @@ facts:
         for name in ("current.md", "guide.md"):
             (scratch / name).write_text("Price: $100\n", encoding="utf-8")
         (scratch / "CHANGELOG.md").write_text("Historical price: $50\nOld price: $50\n", encoding="utf-8")
+        (scratch / "history/nested").mkdir(parents=True)
+        (scratch / "history/nested/old.md").write_text("Price: $50\n", encoding="utf-8")
+        (scratch / "history/other.md").write_text("Price: $50\n", encoding="utf-8")
         run(scratch)
         clean = run(scratch, "discover", 0, "--untracked-only", "--github-annotations")
         if "::warning" in clean:
             raise AssertionError(f"Tracked or historical values generated warnings: {clean}")
         (scratch / "new-page.md").write_text("Price: $100\n", encoding="utf-8")
+        (scratch / "history-current.md").write_text("Price: $100\n", encoding="utf-8")
         run(scratch)
         warning = run(scratch, "discover", 0, "--untracked-only", "--github-annotations")
-        if "::warning file=new-page.md" not in warning or "::warning file=CHANGELOG.md" in warning:
+        if ("::warning file=new-page.md" not in warning
+                or "::warning file=history-current.md" not in warning
+                or "::warning file=CHANGELOG.md" in warning
+                or "::warning file=history/" in warning):
             raise AssertionError(f"Expected only the unregistered current copy warning: {warning}")
     print(f"SSOT controls passed: {tested} real copy locators; drift, restore, missing copy/manifest, invalid manifest, exclusion, advisory discovery.")
 

--- a/scripts/check-ssot-controls.py
+++ b/scripts/check-ssot-controls.py
@@ -1,0 +1,104 @@
+#!/usr/bin/env python3
+"""Exercise this repository's SSOT locators in disposable copies, without edits."""
+import importlib.util
+import json
+import os
+from pathlib import Path
+import re
+import subprocess
+import sys
+import tempfile
+
+
+def main():
+    cli = Path(sys.argv[1]).resolve()
+    root = Path(__file__).resolve().parents[1]
+    manifest_name = ".ssot-local.yaml" if (root / ".ssot-local.yaml").exists() else ".ssot.yaml"
+    manifest_text = (root / manifest_name).read_text(encoding="utf-8")
+    spec = importlib.util.spec_from_file_location("ssot_check", cli)
+    checker = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(checker)
+    manifest = checker.parse_manifest(manifest_text)
+
+    def run(at, command="check", expected=0, *extra):
+        result = subprocess.run(
+            [sys.executable, "-X", "utf8", str(cli), command, "--manifest", str(at / manifest_name), *extra],
+            text=True, capture_output=True, encoding="utf-8", cwd=at,
+            env={**os.environ, "GITHUB_WORKSPACE": str(at)},
+        )
+        if result.returncode != expected:
+            raise AssertionError(f"{command}: expected {expected}, got {result.returncode}\n{result.stdout}\n{result.stderr}")
+        return result.stdout
+
+    run(root)
+    tested = 0
+    with tempfile.TemporaryDirectory(prefix="ssot-controls-") as directory:
+        scratch = Path(directory)
+        (scratch / manifest_name).write_text(manifest_text, encoding="utf-8")
+        for fact in manifest["facts"]:
+            for locator in [fact["canonical"], *fact["copies"]]:
+                relative = locator["file"]
+                target = scratch / relative
+                target.parent.mkdir(parents=True, exist_ok=True)
+                target.write_bytes((root / relative).read_bytes())
+        run(scratch)
+        for fact in manifest["facts"]:
+            for locator in fact["copies"]:
+                target = scratch / locator["file"]
+                original = target.read_text(encoding="utf-8")
+                match = re.search(locator["pattern"], original, re.MULTILINE)
+                if match is None:
+                    raise AssertionError(f"Unmatched locator: {locator}")
+                changed = original[:match.start(1)] + "987654" + original[match.end(1):]
+                target.write_text(changed, encoding="utf-8")
+                report = json.loads(run(scratch, "check", 1, "--json"))
+                if report["summary"]["drifted"] < 1:
+                    raise AssertionError(f"Mutation did not report drift: {locator}")
+                # Discovery exclusions must not disable an explicitly registered copy.
+                ignored = manifest_text.replace("ignore_paths:\n", f'ignore_paths:\n  - "{locator["file"]}"\n', 1)
+                (scratch / manifest_name).write_text(ignored, encoding="utf-8")
+                run(scratch, "check", 1)
+                (scratch / manifest_name).write_text(manifest_text, encoding="utf-8")
+                target.write_text(original, encoding="utf-8")
+                run(scratch)
+                target.unlink()
+                run(scratch, "check", 1)
+                target.write_text(original, encoding="utf-8")
+                tested += 1
+        (scratch / manifest_name).unlink()
+        run(scratch, "check", 2)
+        (scratch / manifest_name).write_text("facts: invalid\n", encoding="utf-8")
+        run(scratch, "check", 2)
+
+    # Synthetic, supported discovery values. Node/Python floors are not discoverable.
+    with tempfile.TemporaryDirectory(prefix="ssot-discovery-") as directory:
+        scratch = Path(directory)
+        (scratch / manifest_name).write_text(r"""ignore_paths:
+  - "CHANGELOG.md"
+facts:
+  - name: example-price
+    type: currency
+    canonical:
+      file: current.md
+      pattern: 'Price: \$(\d+)'
+    copies:
+      - file: guide.md
+        pattern: 'Price: \$(\d+)'
+""", encoding="utf-8")
+        for name in ("current.md", "guide.md"):
+            (scratch / name).write_text("Price: $100\n", encoding="utf-8")
+        (scratch / "CHANGELOG.md").write_text("Historical price: $50\nOld price: $50\n", encoding="utf-8")
+        run(scratch)
+        clean = run(scratch, "discover", 0, "--untracked-only", "--github-annotations")
+        if "::warning" in clean:
+            raise AssertionError(f"Tracked or historical values generated warnings: {clean}")
+        (scratch / "new-page.md").write_text("Price: $100\n", encoding="utf-8")
+        run(scratch)
+        warning = run(scratch, "discover", 0, "--untracked-only", "--github-annotations")
+        if "::warning file=new-page.md" not in warning or "::warning file=CHANGELOG.md" in warning:
+            raise AssertionError(f"Expected only the unregistered current copy warning: {warning}")
+    print(f"SSOT controls passed: {tested} real copy locators; drift, restore, missing copy/manifest, invalid manifest, exclusion, advisory discovery.")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
A README-only change to the documented Node minimum currently escapes the release-manifest checks. Add a small SSOT manifest owned by package.json and a separate PR job that fails on registered drift, missing copies, or invalid configuration. Discovery remains advisory and the checker is pinned to a reviewed commit with read-only permissions.

Contributor guidance explains repairs, exclusions, and the known baseline: eight loopback-address occurrences in examples. Mutation controls exercise the real README locator plus missing-copy/manifest, restoration, exclusions, and a synthetic unregistered-copy warning. Existing release checks remain in place.

Validation: SSOT baseline and controls passed; actionlint passed; npm lint passed; 778 tests passed and one skipped. All hosted checks passed at final HEAD. Pilot observation and required-check configuration remain follow-up work after merge.


Independent review: authenticated claude-sonnet-5 plus tool-isolated opencode/muse-spark-1.3-contributor-free and opencode/nemotron-3-ultra-free completed full reviews. Claude's nested-glob control finding was fixed, and an ineffective-insertion guard was added. Final affected-control reviews completed; Claude and Muse found no actionable defects. Nemotron findings were checked against the actual source and rejected: SHA checkout is already immutable, downloaded code is not executed before checkout, unmatched locators fail rather than pass silently, exact-file canonical checks survive exclusions, parse_manifest takes text, and the nested-prefix/similarly named sibling assertions are intentional. Free review prices/cost were zero, all resolved tools were disabled, and no tool events occurred. Unchanged-file review coverage carries forward; raw receipts are retained locally.

Full review SHA: ab9b0eeb3da40084e91ae10b73729c97464802e3. Final affected-control review SHA: cc466c6368ed445fdc5356a4095bb0dadc4fc249.
